### PR TITLE
feat: date range filter — Week, Month, Last Month, All Time, Custom

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -32,7 +32,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType } from '../types';
 import { getExpenses, getExpense, createExpense, deleteExpense } from '../services/api';
 import SummaryCards from './dashboard/SummaryCards';
-import MonthPicker from './dashboard/MonthPicker';
+import DateRangeControl, { DatePreset } from './dashboard/DateRangeControl';
 import MobileHero from './dashboard/MobileHero';
 import CategoryChart from './dashboard/CategoryChart';
 import TrendsChart from './dashboard/TrendsChart';
@@ -45,7 +45,6 @@ import EditExpenseModal from './expenses/EditExpenseModal';
 import { useFxRates } from '../hooks/useFxRates';
 import { Currency } from '../hooks/useFxRates';
 import { useRecurring } from '../hooks/useRecurring';
-import CurrencyPicker from './dashboard/CurrencyPicker';
 import ManageItemsPage from './items/ManageItemsPage';
 import SettingsPage from './settings/SettingsPage';
 import { useBudgets } from '../hooks/useBudgets';
@@ -77,7 +76,13 @@ const MainLayout: React.FC = () => {
     return () => { window.removeEventListener('offline', goOffline); window.removeEventListener('online', goOnline); };
   }, []);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [datePreset, setDatePreset] = useState<DatePreset>(() => {
+    const saved = localStorage.getItem('mf_date_preset') as DatePreset | null;
+    return saved ?? 'month';
+  });
   const [selectedMonth, setSelectedMonth] = useState<Dayjs | null>(dayjs());
+  const [customStart, setCustomStart] = useState('');
+  const [customEnd, setCustomEnd] = useState('');
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState<TransactionType | 'all'>('all');
   const [sortBy, setSortBy] = useState<'date' | 'amount'>('date');
@@ -209,22 +214,57 @@ const MainLayout: React.FC = () => {
     return map;
   }, [transactions]);
 
+  const handlePresetChange = (p: DatePreset) => {
+    setDatePreset(p);
+    localStorage.setItem('mf_date_preset', p);
+    if (p === 'month' && !selectedMonth) setSelectedMonth(dayjs());
+  };
+
+  const handleCustomChange = (start: string, end: string) => {
+    setCustomStart(start);
+    setCustomEnd(end);
+  };
+
   const monthFiltered = useMemo(() => {
+    if (datePreset === 'all-time') return transactions;
+    if (datePreset === 'week') {
+      const start = dayjs().startOf('week');
+      return transactions.filter((t) => {
+        const d = dayjs(t.date || t.createdAt);
+        return d.isValid() && !d.isBefore(start);
+      });
+    }
+    if (datePreset === 'last-month') {
+      const lm = dayjs().subtract(1, 'month');
+      return transactions.filter((t) => {
+        const d = dayjs(t.date || t.createdAt);
+        return d.isValid() && d.isSame(lm, 'month');
+      });
+    }
+    if (datePreset === 'custom' && customStart && customEnd) {
+      const start = dayjs(customStart).startOf('day');
+      const end = dayjs(customEnd).endOf('day');
+      return transactions.filter((t) => {
+        const d = dayjs(t.date || t.createdAt);
+        return d.isValid() && !d.isBefore(start) && !d.isAfter(end);
+      });
+    }
+    // 'month' preset (or custom with no dates yet)
     if (!selectedMonth) return transactions;
     return transactions.filter((t) => {
       const d = dayjs(t.date || t.createdAt);
       return d.isValid() && d.isSame(selectedMonth, 'month');
     });
-  }, [transactions, selectedMonth]);
+  }, [transactions, datePreset, selectedMonth, customStart, customEnd]);
 
   const prevMonthFiltered = useMemo(() => {
-    if (!selectedMonth) return [];
+    if (datePreset !== 'month' || !selectedMonth) return [];
     const prev = selectedMonth.subtract(1, 'month');
     return transactions.filter((t) => {
       const d = dayjs(t.date || t.createdAt);
       return d.isValid() && d.isSame(prev, 'month');
     });
-  }, [transactions, selectedMonth]);
+  }, [transactions, datePreset, selectedMonth]);
 
   const streak = useMemo(() => {
     const days = new Set(transactions.map((t) => dayjs(t.date || t.createdAt).format('YYYY-MM-DD')));
@@ -307,11 +347,13 @@ const MainLayout: React.FC = () => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = search
-      ? `money-flow-search.csv`
-      : selectedMonth
-        ? `money-flow-${selectedMonth.format('YYYY-MM')}.csv`
-        : 'money-flow-all.csv';
+    const fileSuffix = datePreset === 'month' && selectedMonth
+      ? selectedMonth.format('YYYY-MM')
+      : datePreset === 'last-month' ? dayjs().subtract(1, 'month').format('YYYY-MM')
+      : datePreset === 'week' ? `week-${dayjs().startOf('week').format('YYYY-MM-DD')}`
+      : datePreset === 'custom' && customStart ? `${customStart}_${customEnd}`
+      : 'all';
+    a.download = search ? 'money-flow-search.csv' : `money-flow-${fileSuffix}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -432,8 +474,21 @@ const MainLayout: React.FC = () => {
                 );
               })()}
 
-              {/* Mobile: hero card with month picker + big balance + breakdown */}
+              {/* Mobile: preset chips + hero card */}
               <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+                <Box sx={{ mb: 1.5 }}>
+                  <DateRangeControl
+                    preset={datePreset}
+                    selectedMonth={selectedMonth}
+                    customStart={customStart}
+                    customEnd={customEnd}
+                    currency={currency}
+                    onPresetChange={handlePresetChange}
+                    onMonthChange={setSelectedMonth}
+                    onCustomChange={handleCustomChange}
+                    onCurrencyChange={setCurrency}
+                  />
+                </Box>
                 <MobileHero
                   transactions={monthFiltered}
                   prevMonthTransactions={prevMonthFiltered}
@@ -483,11 +538,20 @@ const MainLayout: React.FC = () => {
                 )}
               </Box>
 
-              {/* Desktop: separate month picker + summary cards + chart */}
+              {/* Desktop: date range control + summary cards + chart */}
               <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-                  <MonthPicker selectedMonth={selectedMonth} onChange={setSelectedMonth} />
-                  <CurrencyPicker currency={currency} onChange={setCurrency} />
+                <Box sx={{ mb: 2 }}>
+                  <DateRangeControl
+                    preset={datePreset}
+                    selectedMonth={selectedMonth}
+                    customStart={customStart}
+                    customEnd={customEnd}
+                    currency={currency}
+                    onPresetChange={handlePresetChange}
+                    onMonthChange={setSelectedMonth}
+                    onCustomChange={handleCustomChange}
+                    onCurrencyChange={setCurrency}
+                  />
                 </Box>
                 <SummaryCards transactions={monthFiltered} prevMonthTransactions={prevMonthFiltered} convert={convert} symbol={symbol} />
                 {(() => {
@@ -561,9 +625,18 @@ const MainLayout: React.FC = () => {
           {activeTab === 1 && (
             <>
               {search === '' && (
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0 }}>
-                  <MonthPicker selectedMonth={selectedMonth} onChange={setSelectedMonth} />
-                  <CurrencyPicker currency={currency} onChange={setCurrency} />
+                <Box sx={{ mb: 1.5 }}>
+                  <DateRangeControl
+                    preset={datePreset}
+                    selectedMonth={selectedMonth}
+                    customStart={customStart}
+                    customEnd={customEnd}
+                    currency={currency}
+                    onPresetChange={handlePresetChange}
+                    onMonthChange={setSelectedMonth}
+                    onCustomChange={handleCustomChange}
+                    onCurrencyChange={setCurrency}
+                  />
                 </Box>
               )}
               <FilterBar

--- a/src/components/dashboard/DateRangeControl.tsx
+++ b/src/components/dashboard/DateRangeControl.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import { Box, Chip, Popover, TextField, Button, Typography } from '@mui/material';
+import dayjs, { Dayjs } from 'dayjs';
+import MonthPicker from './MonthPicker';
+import CurrencyPicker from './CurrencyPicker';
+import { Currency } from '../../hooks/useFxRates';
+
+export type DatePreset = 'week' | 'month' | 'last-month' | 'all-time' | 'custom';
+
+interface Props {
+  preset: DatePreset;
+  selectedMonth: Dayjs | null;
+  customStart: string;
+  customEnd: string;
+  currency: Currency;
+  onPresetChange: (p: DatePreset) => void;
+  onMonthChange: (m: Dayjs | null) => void;
+  onCustomChange: (start: string, end: string) => void;
+  onCurrencyChange: (c: Currency) => void;
+}
+
+const PRESETS: { value: DatePreset; label: string }[] = [
+  { value: 'week', label: 'Week' },
+  { value: 'month', label: 'Month' },
+  { value: 'last-month', label: 'Last Month' },
+  { value: 'all-time', label: 'All Time' },
+  { value: 'custom', label: 'Custom' },
+];
+
+const DateRangeControl: React.FC<Props> = ({
+  preset,
+  selectedMonth,
+  customStart,
+  customEnd,
+  currency,
+  onPresetChange,
+  onMonthChange,
+  onCustomChange,
+  onCurrencyChange,
+}) => {
+  const [customAnchor, setCustomAnchor] = useState<HTMLElement | null>(null);
+  const [draftStart, setDraftStart] = useState(customStart);
+  const [draftEnd, setDraftEnd] = useState(customEnd);
+
+  const handleChipClick = (p: DatePreset) => {
+    if (p === 'custom') {
+      setDraftStart(customStart || dayjs().startOf('month').format('YYYY-MM-DD'));
+      setDraftEnd(customEnd || dayjs().format('YYYY-MM-DD'));
+    }
+    onPresetChange(p);
+  };
+
+  const openCustom = (e: React.MouseEvent<HTMLElement>) => {
+    setDraftStart(customStart || dayjs().startOf('month').format('YYYY-MM-DD'));
+    setDraftEnd(customEnd || dayjs().format('YYYY-MM-DD'));
+    setCustomAnchor(e.currentTarget);
+  };
+
+  const applyCustom = () => {
+    onCustomChange(draftStart, draftEnd);
+    setCustomAnchor(null);
+  };
+
+  const customLabel = customStart && customEnd
+    ? `${dayjs(customStart).format('MMM D')} – ${dayjs(customEnd).format('MMM D')}`
+    : 'Custom';
+
+  return (
+    <Box>
+      {/* Preset chips row */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+        {PRESETS.map(({ value, label }) => {
+          const isActive = preset === value;
+          const chipLabel = value === 'custom' && isActive ? customLabel : label;
+          return (
+            <Chip
+              key={value}
+              label={chipLabel}
+              size="small"
+              onClick={value === 'custom' && isActive ? openCustom : () => handleChipClick(value)}
+              sx={{
+                height: 26,
+                fontSize: '0.75rem',
+                fontWeight: isActive ? 700 : 400,
+                color: isActive ? '#818cf8' : 'text.secondary',
+                bgcolor: isActive ? 'rgba(129,140,248,0.12)' : 'transparent',
+                border: '1px solid',
+                borderColor: isActive ? 'rgba(129,140,248,0.3)' : 'rgba(148,163,184,0.12)',
+                '&:hover': { bgcolor: isActive ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.06)' },
+              }}
+            />
+          );
+        })}
+        <Box sx={{ ml: 'auto' }}>
+          <CurrencyPicker currency={currency} onChange={onCurrencyChange} />
+        </Box>
+      </Box>
+
+      {/* Month navigation (only when 'month' preset) */}
+      {preset === 'month' && (
+        <Box sx={{ mt: 1.5 }}>
+          <MonthPicker selectedMonth={selectedMonth} onChange={onMonthChange} />
+        </Box>
+      )}
+
+      {/* Custom range popover */}
+      <Popover
+        open={Boolean(customAnchor)}
+        anchorEl={customAnchor}
+        onClose={() => setCustomAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{
+          sx: {
+            mt: 0.5,
+            p: 2,
+            bgcolor: '#1e293b',
+            border: '1px solid rgba(148,163,184,0.12)',
+            borderRadius: 2,
+            minWidth: 260,
+          },
+        }}
+      >
+        <Typography sx={{ fontSize: '0.8rem', fontWeight: 600, mb: 1.5, color: 'text.secondary' }}>
+          Custom date range
+        </Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          <TextField
+            label="From"
+            type="date"
+            size="small"
+            value={draftStart}
+            onChange={(e) => setDraftStart(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            inputProps={{ max: draftEnd || undefined }}
+            sx={{ '& input': { colorScheme: 'dark' } }}
+          />
+          <TextField
+            label="To"
+            type="date"
+            size="small"
+            value={draftEnd}
+            onChange={(e) => setDraftEnd(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            inputProps={{ min: draftStart || undefined, max: dayjs().format('YYYY-MM-DD') }}
+            sx={{ '& input': { colorScheme: 'dark' } }}
+          />
+          <Button
+            variant="contained"
+            size="small"
+            disabled={!draftStart || !draftEnd || draftStart > draftEnd}
+            onClick={applyCustom}
+            sx={{ mt: 0.5 }}
+          >
+            Apply
+          </Button>
+        </Box>
+      </Popover>
+    </Box>
+  );
+};
+
+export default DateRangeControl;


### PR DESCRIPTION
## Summary
- New `DateRangeControl` component with 5 preset chips: **Week · Month · Last Month · All Time · Custom**
- **Month** preset retains existing MonthPicker navigation (prev/next, year grid)
- **Week** filters to current calendar week
- **Last Month** filters to the previous full month
- **All Time** removes the date filter
- **Custom** opens a date range popover with From/To date inputs
- Active preset persists to `localStorage` across refresh (default: Month)
- CurrencyPicker consolidated into DateRangeControl (one row instead of two)
- CSV export filename updates to reflect active period
- Works on both Home tab and Transactions tab

## Test plan
- [ ] All 5 presets filter the transaction list and dashboard summary cards correctly
- [ ] Month preset still allows prev/next month navigation
- [ ] Custom date range applies correctly and shows the date range as the chip label
- [ ] Preset survives page refresh (localStorage)
- [ ] Mobile layout — chips wrap gracefully at 375px
- [ ] CSV filename reflects active period

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)