### PR TITLE
Add transaction notes feature

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -68,6 +68,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
   const [quickDate, setQuickDate] = useState<QuickDate>('today');
   const [customDate, setCustomDate] = useState(today());
   const [participants, setParticipants] = useState<string[]>([]);
+  const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -98,6 +99,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
     setQuickDate('today');
     setCustomDate(today());
     setParticipants([]);
+    setNotes('');
     setError('');
     onClose();
   };
@@ -117,6 +119,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
         item: item || undefined,
         category: category || undefined,
         participants: participants,
+        notes: notes.trim() || undefined,
         date: resolvedDate,
       });
       if (addAnother) {
@@ -318,6 +321,25 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
         </Box>
 
         <ParticipantPicker value={participants} onChange={setParticipants} suggestions={knownParticipants} />
+
+        {/* Notes */}
+        <Box sx={{ mt: 1.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75, fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+            Notes (optional)
+          </Typography>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Add any additional notes..."
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            rows={2}
+            inputProps={{ maxLength: 500 }}
+            helperText={`${notes.length}/500`}
+            sx={{ fontSize: '0.85rem' }}
+          />
+        </Box>
       </DialogContent>
 
       <DialogActions sx={{ p: 2, pt: 1, pb: isMobile ? 'calc(16px + env(safe-area-inset-bottom))' : 2, gap: 1 }}>

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -75,6 +75,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
   const [quickDate, setQuickDate] = useState<QuickDate>('today');
   const [customDate, setCustomDate] = useState(todayStr());
   const [participants, setParticipants] = useState<string[]>([]);
+  const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [deleteConfirm, setDeleteConfirm] = useState(false);
@@ -93,6 +94,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
       setAmount(String(transaction.amount));
       setType(transaction.type);
       setParticipants(transaction.participants ?? []);
+      setNotes(transaction.notes ?? '');
       const raw = transaction.date ? transaction.date.split('T')[0] : todayStr();
       setQuickDate(classifyDate(raw));
       setCustomDate(raw);
@@ -125,6 +127,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         item: item || undefined,
         category: category || undefined,
         participants: participants,
+        notes: notes.trim() || undefined,
         date: resolvedDate,
         owner: transaction.owner,
       };
@@ -328,6 +331,25 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         </Box>
 
         <ParticipantPicker value={participants} onChange={setParticipants} suggestions={knownParticipants} />
+
+        {/* Notes */}
+        <Box sx={{ mt: 1.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75, fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+            Notes (optional)
+          </Typography>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Add any additional notes..."
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            rows={2}
+            inputProps={{ maxLength: 500 }}
+            helperText={`${notes.length}/500`}
+            sx={{ fontSize: '0.85rem' }}
+          />
+        </Box>
       </DialogContent>
 
       <DialogActions sx={{ p: 2, pt: 1, pb: isMobile ? 'calc(16px + env(safe-area-inset-bottom))' : 2, gap: 1 }}>

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -160,6 +160,11 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                                 with {t.participants.join(', ')}
                               </Typography>
                             )}
+                            {t.notes && (
+                              <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled', mt: 0.25, display: 'block', fontStyle: 'italic', maxHeight: '2.4em', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                                {t.notes}
+                              </Typography>
+                            )}
                           </Box>
 
                           {/* Right: amount (tap card to edit/delete) */}
@@ -201,8 +206,15 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
             {transactions.map((t) => (
               <TableRow key={t._id} hover>
                 <TableCell sx={{ whiteSpace: 'nowrap' }}>{formatDate(t.date, t.createdAt)}</TableCell>
-                <TableCell sx={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {t.item ? `${t.item}${t.description && t.description !== t.item ? ` · ${t.description}` : ''}` : t.description}
+                <TableCell sx={{ maxWidth: 200 }}>
+                  <Typography sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {t.item ? `${t.item}${t.description && t.description !== t.item ? ` · ${t.description}` : ''}` : t.description}
+                  </Typography>
+                  {t.notes && (
+                    <Typography sx={{ fontSize: '0.75rem', color: 'text.disabled', fontStyle: 'italic', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', mt: 0.25 }}>
+                      {t.notes}
+                    </Typography>
+                  )}
                 </TableCell>
                 <TableCell sx={{ maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'text.secondary', fontSize: '0.8rem' }}>
                   {t.participants && t.participants.length > 0 ? t.participants.join(', ') : '—'}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface Transaction {
   category?: string;
   item?: string;
   participants?: string[];
+  notes?: string;
   date: string;
   createdAt: string;
   updatedAt: string;
@@ -22,5 +23,6 @@ export interface TransactionRequest {
   category?: string;
   item?: string;
   participants?: string[];
+  notes?: string;
   date?: string;
 }


### PR DESCRIPTION
## Summary
- Add notes field (max 500 chars) to transaction modals (AddExpenseModal, EditExpenseModal)
- Display notes in transaction list view (mobile cards and desktop table)
- Notes are optional and rendered with italic styling for visual distinction

## Implementation
- Added notes state to both modals with 500-char limit via inputProps
- Notes initialized from transaction.notes in EditExpenseModal
- Mobile: notes display below participants in card view
- Desktop: notes display below description in table row
- Build verified and TypeScript compilation successful

## Acceptance Criteria
- [x] Notes field appears in Add transaction modal
- [x] Notes field appears in Edit transaction modal
- [x] Notes display in transaction list (both mobile and desktop)
- [x] 500 character limit enforced with live counter
- [x] Build succeeds without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)