### PR TITLE
feat: add empty state hints on Home tab

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -465,6 +465,48 @@ const MainLayout: React.FC = () => {
         >
           {activeTab === 0 && (
             <>
+              {transactions.length === 0 ? (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: { xs: 'calc(100vh - 200px)', sm: 'auto' },
+                    py: { xs: 0, sm: 8 },
+                  }}
+                >
+                  <Box
+                    sx={{
+                      textAlign: 'center',
+                      maxWidth: 400,
+                      width: '100%',
+                      p: { xs: 3, sm: 4 },
+                      borderRadius: 3,
+                      bgcolor: 'rgba(30,41,59,0.5)',
+                      border: '1px solid rgba(148,163,184,0.1)',
+                      backdropFilter: 'blur(12px)',
+                    }}
+                  >
+                    <Typography sx={{ fontSize: '2.5rem', mb: 1, lineHeight: 1 }}>
+                      {'\uD83D\uDCB8'}
+                    </Typography>
+                    <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5, fontSize: '1.1rem' }}>
+                      Track your first expense
+                    </Typography>
+                    <Typography sx={{ color: 'text.secondary', fontSize: '0.85rem', mb: 3, lineHeight: 1.5 }}>
+                      Track your first expense to see insights
+                    </Typography>
+                    <Button
+                      variant="contained"
+                      startIcon={<AddIcon />}
+                      onClick={() => setAddOpen(true)}
+                      sx={{ px: 3, py: 1, fontWeight: 700, fontSize: '0.9rem', borderRadius: 2 }}
+                    >
+                      Add first expense
+                    </Button>
+                  </Box>
+                </Box>
+              ) : (<>
               {/* Recurring prompt banner */}
               {pendingRecurring.length > 0 && (
                 <Box sx={{ mb: 2, py: 1.5, px: 2, borderRadius: 2, bgcolor: 'rgba(129,140,248,0.08)', border: '1px solid rgba(129,140,248,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
@@ -636,6 +678,7 @@ const MainLayout: React.FC = () => {
                   </Box>
                 )}
               </Box>
+              </>)}
             </>
           )}
 

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MainLayout from '../MainLayout';
+import { Transaction } from '../../types';
+import dayjs from 'dayjs';
+
+const makeTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
+  _id: '1',
+  owner: 'user1',
+  description: 'Coffee',
+  amount: 100,
+  type: 'expense',
+  date: dayjs().format('YYYY-MM-DD'),
+  createdAt: dayjs().format('YYYY-MM-DD'),
+  updatedAt: dayjs().format('YYYY-MM-DD'),
+  ...overrides,
+});
+
+const mockGetExpenses = jest.fn().mockResolvedValue([]);
+const mockCreateExpense = jest.fn().mockResolvedValue(
+  makeTransaction({ _id: 'new1', description: 'New tx' })
+);
+
+jest.mock('../../services/api', () => ({
+  getExpenses: (...args: unknown[]) => mockGetExpenses(...args),
+  getExpense: jest.fn().mockResolvedValue({}),
+  createExpense: (...args: unknown[]) => mockCreateExpense(...args),
+  deleteExpense: jest.fn().mockResolvedValue({}),
+  updateExpense: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('recharts', () => ({
+  ComposedChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: () => null,
+  Area: () => null,
+  Pie: () => null,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => null,
+  ReferenceLine: () => null,
+  Legend: () => null,
+}));
+
+jest.mock('../../hooks/useFxRates', () => ({
+  useFxRates: () => ({
+    currency: 'HKD',
+    setCurrency: jest.fn(),
+    convert: (n: number) => n,
+    symbol: 'HK$',
+    loading: false,
+    rates: { HKD: 1, CAD: 0.18, USD: 0.128, CNY: 0.93 },
+  }),
+  CURRENCIES: ['HKD', 'CAD', 'USD', 'CNY'],
+  CURRENCY_SYMBOLS: { HKD: 'HK$', CAD: 'CA$', USD: 'US$', CNY: '\u00A5' },
+  Currency: {},
+}));
+
+jest.mock('../../hooks/useBudgets', () => ({
+  useBudgets: () => ({ budgets: {}, setBudget: jest.fn() }),
+  BUDGET_CATEGORIES: ['Food & Drink', 'Transport'],
+}));
+
+jest.mock('../../hooks/useRecurring', () => ({
+  useRecurring: () => ({ items: [], addItem: jest.fn(), deleteItem: jest.fn(), markApplied: jest.fn() }),
+}));
+
+jest.mock('../../hooks/useItemPresets', () => ({
+  useItemPresets: () => ({ presets: {}, setPreset: jest.fn(), deletePreset: jest.fn() }),
+}));
+
+jest.mock('../../hooks/useTemplates', () => ({
+  useTemplates: () => ({ templates: [], addTemplate: jest.fn(), deleteTemplate: jest.fn() }),
+}));
+
+const renderMainLayout = () =>
+  render(
+    <MemoryRouter>
+      <MainLayout />
+    </MemoryRouter>
+  );
+
+jest.setTimeout(15000);
+
+describe('Empty state on Home tab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetExpenses.mockResolvedValue([]);
+  });
+
+  it('shows empty state card when no transactions exist', async () => {
+    renderMainLayout();
+    await waitFor(() => {
+      expect(screen.getByText('Track your first expense')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Track your first expense to see insights')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add first expense/i })).toBeInTheDocument();
+  });
+
+  it('empty state button opens AddExpenseModal', async () => {
+    renderMainLayout();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /add first expense/i })).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add first expense/i }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Record Transaction')).toBeInTheDocument();
+    });
+  });
+
+  it('hides empty state when transactions exist', async () => {
+    mockGetExpenses.mockResolvedValue([
+      makeTransaction({ _id: '1', description: 'Coffee', item: 'Coffee Shop' }),
+    ]);
+    renderMainLayout();
+    await waitFor(() => {
+      expect(screen.getAllByText(/See all/).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText('Track your first expense')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What
Empty state card on Home tab when user has no transactions yet, with a one-click CTA to add their first expense.

## Why
Closes #90

## Acceptance Criteria
- [x] Show empty state card on first visit (no expenses yet)
- [x] Hint: 'Track your first expense to see insights'
- [x] One-click to expense form (opens AddExpenseModal)
- [x] Mobile: near full-screen centered empty state, Desktop: centered card
- [x] Dashboard content hidden until first transaction exists

## Test Plan
- Load app with no transactions — verify empty state card appears with title, subtitle, and "Add first expense" button
- Click "Add first expense" — verify AddExpenseModal opens
- Add a transaction — verify empty state disappears and dashboard content shows
- 3 new tests in EmptyState.test.tsx covering all scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)