### PR TITLE
feat: sync recurring transactions with backend API

### DIFF
--- a/src/hooks/__tests__/useRecurring.test.ts
+++ b/src/hooks/__tests__/useRecurring.test.ts
@@ -1,9 +1,30 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useRecurring } from '../useRecurring';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api', () => ({
+  getRecurring: jest.fn(),
+  createRecurring: jest.fn(),
+  deleteRecurringAPI: jest.fn(),
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
 
 describe('useRecurring', () => {
   beforeEach(() => {
     localStorage.clear();
+    jest.clearAllMocks();
+    mockedApi.getRecurring.mockResolvedValue([]);
+    mockedApi.createRecurring.mockImplementation(async (data) => ({
+      _id: String(Date.now()),
+      name: data.name,
+      amount: data.amount,
+      category: data.category,
+      start_date: data.start_date,
+      frequency: data.frequency,
+      description: data.description,
+    }));
+    mockedApi.deleteRecurringAPI.mockResolvedValue(undefined);
   });
 
   it('starts with empty items', () => {
@@ -11,10 +32,23 @@ describe('useRecurring', () => {
     expect(result.current.items).toEqual([]);
   });
 
-  it('addItem adds a new recurring item', () => {
+  it('fetches from API on mount', async () => {
+    mockedApi.getRecurring.mockResolvedValue([
+      { _id: 'abc', name: 'Netflix', amount: 100, category: 'Entertainment', start_date: '2026-01-01', frequency: 'MONTHLY' },
+    ]);
     const { result } = renderHook(() => useRecurring());
-    act(() => {
-      result.current.addItem({
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1);
+    });
+    expect(result.current.items[0].label).toBe('Netflix');
+    expect(result.current.items[0].id).toBe('abc');
+    expect(result.current.items[0].frequency).toBe('monthly');
+  });
+
+  it('addItem creates via API and adds to state', async () => {
+    const { result } = renderHook(() => useRecurring());
+    await act(async () => {
+      await result.current.addItem({
         label: 'Netflix',
         description: 'Streaming',
         amount: 100,
@@ -23,46 +57,78 @@ describe('useRecurring', () => {
     });
     expect(result.current.items).toHaveLength(1);
     expect(result.current.items[0].label).toBe('Netflix');
-    expect(result.current.items[0].id).toBeDefined();
+    expect(mockedApi.createRecurring).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Netflix', amount: 100 })
+    );
   });
 
-  it('deleteItem removes item by id', () => {
+  it('addItem falls back to localStorage when API fails', async () => {
+    mockedApi.createRecurring.mockRejectedValue(new Error('offline'));
     const { result } = renderHook(() => useRecurring());
-    act(() => {
-      result.current.addItem({ label: 'Netflix', description: '', amount: 100, type: 'expense' });
+    await act(async () => {
+      await result.current.addItem({ label: 'Rent', description: '', amount: 5000, type: 'expense' });
     });
-    const id = result.current.items[0].id;
-    act(() => {
-      result.current.deleteItem(id);
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].label).toBe('Rent');
+  });
+
+  it('deleteItem removes from state and calls API', async () => {
+    mockedApi.getRecurring.mockResolvedValue([
+      { _id: 'del1', name: 'Gym', amount: 300, start_date: '2026-01-01', frequency: 'MONTHLY' },
+    ]);
+    const { result } = renderHook(() => useRecurring());
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
+    await act(async () => {
+      await result.current.deleteItem('del1');
     });
     expect(result.current.items).toHaveLength(0);
+    expect(mockedApi.deleteRecurringAPI).toHaveBeenCalledWith('del1');
   });
 
-  it('markApplied sets lastApplied on specified ids', () => {
+  it('markApplied sets lastApplied on specified ids', async () => {
+    mockedApi.getRecurring.mockResolvedValue([
+      { _id: 'r1', name: 'Rent', amount: 5000, start_date: '2026-01-01', frequency: 'MONTHLY' },
+    ]);
     const { result } = renderHook(() => useRecurring());
+    await waitFor(() => expect(result.current.items).toHaveLength(1));
     act(() => {
-      result.current.addItem({ label: 'Rent', description: '', amount: 5000, type: 'expense' });
-    });
-    const id = result.current.items[0].id;
-    act(() => {
-      result.current.markApplied([id], '2026-03');
+      result.current.markApplied(['r1'], '2026-03');
     });
     expect(result.current.items[0].lastApplied).toBe('2026-03');
   });
 
-  it('persists items to localStorage', () => {
+  it('persists items to localStorage', async () => {
     const { result } = renderHook(() => useRecurring());
-    act(() => {
-      result.current.addItem({ label: 'Gym', description: '', amount: 300, type: 'expense' });
+    await act(async () => {
+      await result.current.addItem({ label: 'Gym', description: '', amount: 300, type: 'expense' });
     });
     const stored = JSON.parse(localStorage.getItem('mf_recurring') || '[]');
     expect(stored[0].label).toBe('Gym');
   });
 
-  it('loads from localStorage on mount', () => {
+  it('falls back to localStorage when API fetch fails', async () => {
     const items = [{ id: '1', label: 'Test', description: '', amount: 50, type: 'expense' }];
     localStorage.setItem('mf_recurring', JSON.stringify(items));
+    mockedApi.getRecurring.mockRejectedValue(new Error('offline'));
     const { result } = renderHook(() => useRecurring());
     expect(result.current.items[0].label).toBe('Test');
+  });
+
+  it('migrates localStorage items to API on first load', async () => {
+    const localItems = [{ id: 'local1', label: 'Old item', description: 'test', amount: 50, type: 'expense', frequency: 'monthly' }];
+    localStorage.setItem('mf_recurring', JSON.stringify(localItems));
+    mockedApi.getRecurring.mockResolvedValue([]);
+    mockedApi.createRecurring.mockResolvedValue({
+      _id: 'migrated1', name: 'Old item', amount: 50, start_date: '2026-01-01', frequency: 'MONTHLY', description: 'test',
+    });
+    const { result } = renderHook(() => useRecurring());
+    await waitFor(() => {
+      expect(mockedApi.createRecurring).toHaveBeenCalled();
+    });
+    expect(mockedApi.createRecurring).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Old item', amount: 50 })
+    );
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe('migrated1');
   });
 });

--- a/src/hooks/useRecurring.ts
+++ b/src/hooks/useRecurring.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { TransactionType } from '../types';
+import { getRecurring, createRecurring, deleteRecurringAPI, RecurringExpenseAPI } from '../services/api';
 
 export interface RecurringItem {
   id: string;
@@ -15,8 +16,9 @@ export interface RecurringItem {
 }
 
 const KEY = 'mf_recurring';
+const META_KEY = 'mf_recurring_meta'; // extra frontend fields keyed by API id
 
-function load(): RecurringItem[] {
+function loadLocal(): RecurringItem[] {
   try {
     const raw = localStorage.getItem(KEY);
     return raw ? JSON.parse(raw) : [];
@@ -25,37 +27,144 @@ function load(): RecurringItem[] {
   }
 }
 
-function persist(items: RecurringItem[]) {
+function loadMeta(): Record<string, Partial<RecurringItem>> {
   try {
-    localStorage.setItem(KEY, JSON.stringify(items));
-  } catch {}
+    const raw = localStorage.getItem(META_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistLocal(items: RecurringItem[]) {
+  try { localStorage.setItem(KEY, JSON.stringify(items)); } catch {}
+}
+
+function persistMeta(meta: Record<string, Partial<RecurringItem>>) {
+  try { localStorage.setItem(META_KEY, JSON.stringify(meta)); } catch {}
+}
+
+const FREQ_TO_API: Record<string, string> = { daily: 'DAILY', weekly: 'WEEKLY', monthly: 'MONTHLY' };
+const FREQ_FROM_API: Record<string, 'daily' | 'weekly' | 'monthly'> = {
+  DAILY: 'daily', WEEKLY: 'weekly', MONTHLY: 'monthly', QUARTERLY: 'monthly', YEARLY: 'monthly',
+};
+
+function apiToItem(api: RecurringExpenseAPI, meta: Partial<RecurringItem> = {}): RecurringItem {
+  return {
+    id: api._id,
+    label: api.name,
+    description: api.description || '',
+    amount: api.amount,
+    type: (meta.type as TransactionType) || 'expense',
+    category: api.category,
+    item: meta.item,
+    participants: meta.participants,
+    frequency: FREQ_FROM_API[api.frequency] || 'monthly',
+    lastApplied: meta.lastApplied,
+  };
 }
 
 export function useRecurring() {
-  const [items, setItems] = useState<RecurringItem[]>(load);
+  const [items, setItems] = useState<RecurringItem[]>(loadLocal);
+  const metaRef = useRef<Record<string, Partial<RecurringItem>>>(loadMeta());
+  const migrated = useRef(false);
 
-  const addItem = useCallback((item: Omit<RecurringItem, 'id'>) => {
-    setItems((prev) => {
-      const next = [...prev, { ...item, id: String(Date.now()) }];
-      persist(next);
-      return next;
-    });
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const apiItems = await getRecurring();
+        const meta = metaRef.current;
+
+        // One-time migration: push localStorage items that aren't in API
+        if (!migrated.current) {
+          migrated.current = true;
+          const localItems = loadLocal();
+          const apiIds = new Set(apiItems.map((a) => a._id));
+          const toMigrate = localItems.filter((l) => !apiIds.has(l.id));
+          for (const item of toMigrate) {
+            try {
+              const created = await createRecurring({
+                name: item.label || item.description,
+                amount: item.amount,
+                category: item.category,
+                start_date: new Date().toISOString(),
+                frequency: FREQ_TO_API[item.frequency || 'monthly'] || 'MONTHLY',
+                description: item.description,
+              });
+              meta[created._id] = { type: item.type, item: item.item, participants: item.participants, lastApplied: item.lastApplied };
+              apiItems.push(created);
+            } catch { /* skip failed migrations */ }
+          }
+          persistMeta(meta);
+        }
+
+        if (cancelled) return;
+        const merged = apiItems.map((a) => apiToItem(a, meta[a._id]));
+        setItems(merged);
+        persistLocal(merged);
+      } catch {
+        // Offline — use localStorage fallback (already loaded)
+      }
+    })();
+    return () => { cancelled = true; };
   }, []);
 
-  const deleteItem = useCallback((id: string) => {
+  const addItem = useCallback(async (item: Omit<RecurringItem, 'id'>) => {
+    try {
+      const created = await createRecurring({
+        name: item.label || item.description,
+        amount: item.amount,
+        category: item.category,
+        start_date: new Date().toISOString(),
+        frequency: FREQ_TO_API[item.frequency || 'monthly'] || 'MONTHLY',
+        description: item.description,
+      });
+      const meta = loadMeta();
+      meta[created._id] = { type: item.type, item: item.item, participants: item.participants };
+      persistMeta(meta);
+      metaRef.current = meta;
+      const newItem = apiToItem(created, meta[created._id]);
+      setItems((prev) => {
+        const next = [...prev, newItem];
+        persistLocal(next);
+        return next;
+      });
+    } catch {
+      // Fallback: save locally only
+      setItems((prev) => {
+        const next = [...prev, { ...item, id: String(Date.now()) }];
+        persistLocal(next);
+        return next;
+      });
+    }
+  }, []);
+
+  const deleteItem = useCallback(async (id: string) => {
     setItems((prev) => {
       const next = prev.filter((r) => r.id !== id);
-      persist(next);
+      persistLocal(next);
       return next;
     });
+    try {
+      await deleteRecurringAPI(id);
+      const meta = loadMeta();
+      delete meta[id];
+      persistMeta(meta);
+      metaRef.current = meta;
+    } catch { /* item removed from UI, API delete failed — will be orphaned on server */ }
   }, []);
 
   const markApplied = useCallback((ids: string[], month: string) => {
     setItems((prev) => {
       const next = prev.map((r) => ids.includes(r.id) ? { ...r, lastApplied: month } : r);
-      persist(next);
+      persistLocal(next);
       return next;
     });
+    const meta = loadMeta();
+    ids.forEach((id) => { meta[id] = { ...meta[id], lastApplied: month }; });
+    persistMeta(meta);
+    metaRef.current = meta;
   }, []);
 
   return { items, addItem, deleteItem, markApplied };

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { getExpenses, getExpense, createExpense, updateExpense, deleteExpense, login, register } from '../api';
+import { getExpenses, getExpense, createExpense, updateExpense, deleteExpense, login, register, getRecurring, createRecurring, deleteRecurringAPI } from '../api';
 import axiosInstance from '../../axiosInstance';
 
 jest.mock('../../axiosInstance', () => ({
@@ -73,5 +73,27 @@ describe('api service', () => {
     await register('newuser@test.com', 'newpass');
     expect(mockedAxios.post).toHaveBeenCalledWith('/auth/register', { email: 'newuser@test.com', password: 'newpass' });
     expect(localStorage.getItem('mf_token')).toBe('reg456');
+  });
+
+  it('getRecurring calls GET /api/recurring and returns recurring array', async () => {
+    const recurring = [{ _id: 'r1', name: 'Netflix', amount: 15, frequency: 'MONTHLY', start_date: '2026-01-01' }];
+    (mockedAxios.get as jest.Mock).mockResolvedValue({ data: { recurring } });
+    const result = await getRecurring();
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/recurring');
+    expect(result).toEqual(recurring);
+  });
+
+  it('createRecurring calls POST /api/recurring', async () => {
+    const data = { name: 'Rent', amount: 5000, start_date: '2026-01-01', frequency: 'MONTHLY' };
+    (mockedAxios.post as jest.Mock).mockResolvedValue({ data: { _id: 'r2', ...data } });
+    const result = await createRecurring(data);
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/recurring', data);
+    expect(result._id).toBe('r2');
+  });
+
+  it('deleteRecurringAPI calls DELETE /api/recurring/:id', async () => {
+    (mockedAxios.delete as jest.Mock).mockResolvedValue({});
+    await deleteRecurringAPI('r1');
+    expect(mockedAxios.delete).toHaveBeenCalledWith('/api/recurring/r1');
   });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -53,3 +53,36 @@ export const saveBudgets = async (budgets: Budget[]): Promise<Budget[]> => {
   const res = await axiosInstance.put('/api/budgets', { budgets });
   return res.data.budgets;
 };
+
+// Recurring
+export interface RecurringExpenseAPI {
+  _id: string;
+  name: string;
+  amount: number;
+  category?: string;
+  start_date: string;
+  end_date?: string;
+  frequency: string;
+  description?: string;
+}
+
+export const getRecurring = async (): Promise<RecurringExpenseAPI[]> => {
+  const res = await axiosInstance.get('/api/recurring');
+  return res.data.recurring;
+};
+
+export const createRecurring = async (data: {
+  name: string;
+  amount: number;
+  category?: string;
+  start_date: string;
+  frequency: string;
+  description?: string;
+}): Promise<RecurringExpenseAPI> => {
+  const res = await axiosInstance.post('/api/recurring', data);
+  return res.data;
+};
+
+export const deleteRecurringAPI = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/recurring/${id}`);
+};


### PR DESCRIPTION
## Summary
- Added API functions for recurring CRUD: `getRecurring`, `createRecurring`, `deleteRecurringAPI`
- Rewrote `useRecurring` hook to fetch from `/api/recurring` on mount with localStorage fallback
- One-time migration of existing localStorage recurring items to backend API
- Frontend-specific fields (type, item, participants, lastApplied) stored in localStorage metadata keyed by API `_id`
- 9 hook tests + 3 API tests covering: fetch, create, delete, migration, offline fallback

Closes #100

## Test plan
- [ ] Add recurring item in Settings → verify it appears in API (`GET /api/recurring`)
- [ ] Delete recurring item → verify removed from API
- [ ] Clear browser cache → recurring items still load from API
- [ ] Go offline → recurring items load from localStorage cache
- [ ] Existing localStorage items migrate to API on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)