### PR TITLE
feat: spending insights — month-over-month comparison

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -38,6 +38,7 @@ import MobileHero from './dashboard/MobileHero';
 import CategoryChart from './dashboard/CategoryChart';
 import TrendsChart from './dashboard/TrendsChart';
 import BudgetProgress from './dashboard/BudgetProgress';
+import SpendingInsights from './dashboard/SpendingInsights';
 import SpendingBreakdown from './dashboard/SpendingBreakdown';
 import PeopleBreakdown from './dashboard/PeopleBreakdown';
 import ExpenseList from './expenses/ExpenseList';
@@ -594,6 +595,7 @@ const MainLayout: React.FC = () => {
                   convert={convert}
                   symbol={symbol}
                 />
+                <SpendingInsights transactions={monthFiltered} prevMonthTransactions={prevMonthFiltered} convert={convert} symbol={symbol} />
                 <BudgetProgress budgets={budgets} categorySpend={categorySpend} convert={convert} symbol={symbol} onCategoryClick={(cat) => { setSearch(cat); setActiveTab(1); }} />
                 <SpendingBreakdown transactions={monthFiltered} prevMonthTransactions={prevMonthFiltered} convert={convert} symbol={symbol} onItemClick={(name) => { setSearch(name); setActiveTab(1); }} />
                 <PeopleBreakdown transactions={monthFiltered} convert={convert} symbol={symbol} onPersonClick={(name) => { setSearch(name); setActiveTab(1); }} />
@@ -649,6 +651,7 @@ const MainLayout: React.FC = () => {
                   />
                 </Box>
                 <SummaryCards transactions={monthFiltered} prevMonthTransactions={prevMonthFiltered} convert={convert} symbol={symbol} />
+                <SpendingInsights transactions={monthFiltered} prevMonthTransactions={prevMonthFiltered} convert={convert} symbol={symbol} />
                 {(() => {
                   const weekStart = dayjs().startOf('week');
                   const lastWeekStart = weekStart.subtract(1, 'week');

--- a/src/components/dashboard/SpendingInsights.tsx
+++ b/src/components/dashboard/SpendingInsights.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from 'react';
+import { Box, Typography } from '@mui/material';
+import { Transaction } from '../../types';
+
+interface Props {
+  transactions: Transaction[];
+  prevMonthTransactions: Transaction[];
+  convert: (hkd: number) => number;
+  symbol: string;
+}
+
+function sumByType(txns: Transaction[], type: string): number {
+  return txns.filter((t) => t.type === type).reduce((s, t) => s + t.amount, 0);
+}
+
+function topCategoryChange(current: Transaction[], prev: Transaction[]): { category: string; currentSpend: number; prevSpend: number; delta: number } | null {
+  const curMap: Record<string, number> = {};
+  const prevMap: Record<string, number> = {};
+  current.filter((t) => t.type === 'expense').forEach((t) => { const c = t.category || 'Other'; curMap[c] = (curMap[c] || 0) + t.amount; });
+  prev.filter((t) => t.type === 'expense').forEach((t) => { const c = t.category || 'Other'; prevMap[c] = (prevMap[c] || 0) + t.amount; });
+
+  const allCats = new Set([...Object.keys(curMap), ...Object.keys(prevMap)]);
+  let biggest: { category: string; currentSpend: number; prevSpend: number; delta: number } | null = null;
+  let maxAbsDelta = 0;
+  allCats.forEach((cat) => {
+    const cur = curMap[cat] || 0;
+    const prv = prevMap[cat] || 0;
+    const delta = cur - prv;
+    if (Math.abs(delta) > maxAbsDelta && prv > 0) {
+      maxAbsDelta = Math.abs(delta);
+      biggest = { category: cat, currentSpend: cur, prevSpend: prv, delta };
+    }
+  });
+  return biggest;
+}
+
+const SpendingInsights: React.FC<Props> = ({ transactions, prevMonthTransactions, convert, symbol }) => {
+  const insights = useMemo(() => {
+    if (prevMonthTransactions.length === 0) return null;
+
+    const curExpenses = sumByType(transactions, 'expense');
+    const prevExpenses = sumByType(prevMonthTransactions, 'expense');
+    const curIncome = sumByType(transactions, 'income');
+    const net = curIncome - curExpenses;
+
+    const spendDelta = prevExpenses > 0 ? ((curExpenses - prevExpenses) / prevExpenses) * 100 : null;
+    const topCat = topCategoryChange(transactions, prevMonthTransactions);
+
+    return { curExpenses, prevExpenses, spendDelta, topCat, net };
+  }, [transactions, prevMonthTransactions]);
+
+  if (!insights) return null;
+
+  const { spendDelta, topCat, net } = insights;
+
+  const cards: { text: string; color: string }[] = [];
+
+  if (spendDelta !== null) {
+    const dir = spendDelta <= 0 ? 'less' : 'more';
+    const arrow = spendDelta <= 0 ? '\u2193' : '\u2191';
+    const color = spendDelta <= 0 ? '#34d399' : '#fb7185';
+    cards.push({ text: `${arrow} ${Math.abs(Math.round(spendDelta))}% ${dir} spending than last month`, color });
+  }
+
+  if (topCat && topCat.prevSpend > 0) {
+    const pct = Math.round(((topCat.currentSpend - topCat.prevSpend) / topCat.prevSpend) * 100);
+    if (Math.abs(pct) >= 10) {
+      const arrow = pct <= 0 ? '\u2193' : '\u2191';
+      const color = pct <= 0 ? '#34d399' : '#fb7185';
+      cards.push({ text: `${topCat.category}: ${symbol}${convert(topCat.prevSpend).toLocaleString(undefined, { maximumFractionDigits: 0 })} \u2192 ${symbol}${convert(topCat.currentSpend).toLocaleString(undefined, { maximumFractionDigits: 0 })} (${arrow}${Math.abs(pct)}%)`, color });
+    }
+  }
+
+  if (net > 0) {
+    cards.push({ text: `Saved ${symbol}${convert(net).toLocaleString(undefined, { maximumFractionDigits: 0 })} this month`, color: '#34d399' });
+  }
+
+  if (cards.length === 0) return null;
+
+  return (
+    <Box sx={{ mb: 2, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+      {cards.map((card, i) => (
+        <Box key={i} sx={{ py: 0.75, px: 1.5, borderRadius: 1.5, bgcolor: `${card.color}08`, border: `1px solid ${card.color}20` }}>
+          <Typography sx={{ fontSize: '0.75rem', color: card.color, fontWeight: 600 }}>
+            {card.text}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default SpendingInsights;

--- a/src/components/dashboard/__tests__/SpendingInsights.test.tsx
+++ b/src/components/dashboard/__tests__/SpendingInsights.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SpendingInsights from '../SpendingInsights';
+import { Transaction } from '../../../types';
+
+const convert = (v: number) => v;
+const symbol = '$';
+
+const makeTx = (overrides: Partial<Transaction> = {}): Transaction => ({
+  _id: String(Math.random()),
+  owner: 'u1',
+  description: 'test',
+  amount: 100,
+  type: 'expense',
+  category: 'Food',
+  date: '2026-03-15',
+  createdAt: '2026-03-15',
+  updatedAt: '2026-03-15',
+  ...overrides,
+});
+
+describe('SpendingInsights', () => {
+  it('renders nothing when no previous month data', () => {
+    const { container } = render(
+      <SpendingInsights transactions={[makeTx()]} prevMonthTransactions={[]} convert={convert} symbol={symbol} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows spending decrease insight', () => {
+    const current = [makeTx({ amount: 80 })];
+    const prev = [makeTx({ amount: 100 })];
+    render(<SpendingInsights transactions={current} prevMonthTransactions={prev} convert={convert} symbol={symbol} />);
+    expect(screen.getByText(/20% less spending/)).toBeInTheDocument();
+  });
+
+  it('shows spending increase insight', () => {
+    const current = [makeTx({ amount: 150 })];
+    const prev = [makeTx({ amount: 100 })];
+    render(<SpendingInsights transactions={current} prevMonthTransactions={prev} convert={convert} symbol={symbol} />);
+    expect(screen.getByText(/50% more spending/)).toBeInTheDocument();
+  });
+
+  it('shows savings insight when net positive', () => {
+    const current = [makeTx({ amount: 50 }), makeTx({ amount: 200, type: 'income' })];
+    const prev = [makeTx({ amount: 80 })];
+    render(<SpendingInsights transactions={current} prevMonthTransactions={prev} convert={convert} symbol={symbol} />);
+    expect(screen.getByText(/Saved \$150 this month/)).toBeInTheDocument();
+  });
+
+  it('shows top category change when significant', () => {
+    const current = [makeTx({ amount: 200, category: 'Food' })];
+    const prev = [makeTx({ amount: 100, category: 'Food' })];
+    render(<SpendingInsights transactions={current} prevMonthTransactions={prev} convert={convert} symbol={symbol} />);
+    expect(screen.getByText(/Food.*100.*200/)).toBeInTheDocument();
+  });
+
+  it('hides category insight when change is small', () => {
+    const current = [makeTx({ amount: 105, category: 'Food' })];
+    const prev = [makeTx({ amount: 100, category: 'Food' })];
+    render(<SpendingInsights transactions={current} prevMonthTransactions={prev} convert={convert} symbol={symbol} />);
+    expect(screen.queryByText(/Food.*\u2192/)).toBeNull();
+  });
+
+  it('applies currency conversion', () => {
+    const current = [makeTx({ amount: 50 }), makeTx({ amount: 200, type: 'income' })];
+    const prev = [makeTx({ amount: 80 })];
+    render(<SpendingInsights transactions={current} prevMonthTransactions={prev} convert={(v) => v * 2} symbol="USD " />);
+    expect(screen.getByText(/Saved USD 300 this month/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- New `SpendingInsights` component with compact insight cards
- Compares current vs previous month: total spend %, top category change, net savings
- Color-coded green (improvements) / red (regressions)
- Added to both mobile and desktop dashboard
- 7 tests

Closes #102

## Test plan
- [ ] Have transactions in current and previous month
- [ ] Verify insights appear on dashboard
- [ ] No insights when only one month of data

🤖 Generated with [Claude Code](https://claude.com/claude-code)