### PR TITLE
feat: payment method selector and filter

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -31,7 +31,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import dayjs, { Dayjs } from 'dayjs';
-import { Transaction, TransactionRequest, TransactionType } from '../types';
+import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../types';
 import { getExpenses, getExpense, createExpense, deleteExpense } from '../services/api';
 import SummaryCards from './dashboard/SummaryCards';
 import DateRangeControl, { DatePreset } from './dashboard/DateRangeControl';
@@ -91,6 +91,7 @@ const MainLayout: React.FC = () => {
   const [customEnd, setCustomEnd] = useState('');
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState<TransactionType | 'all'>('all');
+  const [paymentMethodFilter, setPaymentMethodFilter] = useState<PaymentMethod | 'all'>('all');
   const [sortBy, setSortBy] = useState<'date' | 'amount'>('date');
   const [addOpen, setAddOpen] = useState(false);
   const [quickExpenseOpen, setQuickExpenseOpen] = useState(false);
@@ -358,16 +359,17 @@ const MainLayout: React.FC = () => {
         (t.category || '').toLowerCase().includes(searchLow) ||
         (t.participants || []).some((p) => p.toLowerCase().includes(searchLow));
       const matchesType = typeFilter === 'all' || t.type === typeFilter;
-      return matchesSearch && matchesType;
+      const matchesPayment = paymentMethodFilter === 'all' || t.paymentMethod === paymentMethodFilter;
+      return matchesSearch && matchesType && matchesPayment;
     });
     if (sortBy === 'amount') {
       return [...filtered].sort((a, b) => b.amount - a.amount);
     }
     return filtered;
-  }, [transactions, monthFiltered, search, typeFilter, sortBy]);
+  }, [transactions, monthFiltered, search, typeFilter, paymentMethodFilter, sortBy]);
 
   const handleExport = () => {
-    const header = ['Date', 'Item', 'Description', 'Type', 'Category', 'Amount', 'Participants'];
+    const header = ['Date', 'Item', 'Description', 'Type', 'Category', 'Amount', 'Payment Method', 'Participants'];
     const rows = filteredTransactions.map((t) => [
       new Date(t.date || t.createdAt).toISOString().split('T')[0],
       t.item ? `"${t.item.replace(/"/g, '""')}"` : '',
@@ -375,6 +377,7 @@ const MainLayout: React.FC = () => {
       t.type,
       t.category ? `"${t.category.replace(/"/g, '""')}"` : '',
       t.amount,
+      t.paymentMethod || '',
       t.participants?.length ? `"${t.participants.join(', ')}"` : '',
     ]);
     const csv = [header.join(','), ...rows.map((r) => r.join(','))].join('\n');
@@ -745,12 +748,14 @@ const MainLayout: React.FC = () => {
               <FilterBar
                 search={search}
                 typeFilter={typeFilter}
+                paymentMethodFilter={paymentMethodFilter}
                 sortBy={sortBy}
                 total={search !== '' ? transactions.length : monthFiltered.length}
                 filtered={filteredTransactions.length}
                 searchAllTime={search !== ''}
                 onSearchChange={setSearch}
                 onTypeFilterChange={setTypeFilter}
+                onPaymentMethodFilterChange={setPaymentMethodFilter}
                 onSortChange={setSortBy}
                 onExport={handleExport}
               />

--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -22,13 +22,14 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import RepeatIcon from '@mui/icons-material/Repeat';
-import { TransactionRequest, TransactionType } from '../../types';
+import { TransactionRequest, TransactionType, PaymentMethod } from '../../types';
 import NumPad from './NumPad';
 import ItemPicker, { ItemPreset, ITEM_SUGGESTIONS } from './ItemPicker';
 import DescriptionPicker from './DescriptionPicker';
 import TemplateChips from './TemplateChips';
 import ManageTemplatesDrawer from './ManageTemplatesDrawer';
 import ParticipantPicker from './ParticipantPicker';
+import PaymentMethodPicker from './PaymentMethodPicker';
 import { useTemplates, TransactionTemplate } from '../../hooks/useTemplates';
 import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
 import { useItemPresets } from '../../hooks/useItemPresets';
@@ -74,6 +75,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
   const [quickDate, setQuickDate] = useState<QuickDate>('today');
   const [customDate, setCustomDate] = useState(today());
   const [participants, setParticipants] = useState<string[]>([]);
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState<RecurringFrequency>('monthly');
   const [loading, setLoading] = useState(false);
@@ -108,6 +110,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
     setQuickDate('today');
     setCustomDate(today());
     setParticipants([]);
+    setPaymentMethod(null);
     setIsRecurring(false);
     setFrequency('monthly');
     setError('');
@@ -126,6 +129,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
       item: item || undefined,
       category: category || undefined,
       participants: participants,
+      paymentMethod: paymentMethod || undefined,
       date: resolvedDate,
     };
 
@@ -394,6 +398,8 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
         </Box>
 
         <ParticipantPicker value={participants} onChange={setParticipants} suggestions={knownParticipants} />
+
+        <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
 
         {/* Recurring toggle */}
         <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -23,12 +23,13 @@ import HistoryIcon from '@mui/icons-material/History';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
-import { Transaction, TransactionRequest, TransactionType } from '../../types';
+import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../../types';
 import { updateExpense } from '../../services/api';
 import NumPad from './NumPad';
 import ItemPicker, { ItemPreset, ITEM_PRESETS, ITEM_SUGGESTIONS } from './ItemPicker';
 import DescriptionPicker from './DescriptionPicker';
 import ParticipantPicker from './ParticipantPicker';
+import PaymentMethodPicker from './PaymentMethodPicker';
 import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
 import { useItemPresets } from '../../hooks/useItemPresets';
 
@@ -75,6 +76,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
   const [quickDate, setQuickDate] = useState<QuickDate>('today');
   const [customDate, setCustomDate] = useState(todayStr());
   const [participants, setParticipants] = useState<string[]>([]);
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [deleteConfirm, setDeleteConfirm] = useState(false);
@@ -93,6 +95,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
       setAmount(String(transaction.amount));
       setType(transaction.type);
       setParticipants(transaction.participants ?? []);
+      setPaymentMethod((transaction.paymentMethod as PaymentMethod) || null);
       const raw = transaction.date ? transaction.date.split('T')[0] : todayStr();
       setQuickDate(classifyDate(raw));
       setCustomDate(raw);
@@ -125,6 +128,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         item: item || undefined,
         category: category || undefined,
         participants: participants,
+        paymentMethod: paymentMethod || undefined,
         date: resolvedDate,
         owner: transaction.owner,
       };
@@ -155,6 +159,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         item: item || undefined,
         category: category || undefined,
         participants: participants,
+        paymentMethod: paymentMethod || undefined,
         date: todayStr(),
       });
       onClose();
@@ -328,6 +333,8 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         </Box>
 
         <ParticipantPicker value={participants} onChange={setParticipants} suggestions={knownParticipants} />
+
+        <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
       </DialogContent>
 
       <DialogActions sx={{ p: 2, pt: 1, pb: isMobile ? 'calc(16px + env(safe-area-inset-bottom))' : 2, gap: 1 }}>

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -19,6 +19,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import PaymentIcon from '@mui/icons-material/Payment';
 import { Transaction } from '../../types';
 import { ITEM_PRESETS } from './ItemPicker';
 
@@ -171,6 +172,14 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                                 with {t.participants.join(', ')}
                               </Typography>
                             )}
+                            {t.paymentMethod && (
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
+                                <PaymentIcon sx={{ fontSize: 11, color: 'text.disabled' }} />
+                                <Typography sx={{ fontSize: '0.62rem', color: 'text.disabled' }}>
+                                  {t.paymentMethod}
+                                </Typography>
+                              </Box>
+                            )}
                           </Box>
 
                           {/* Right: amount (tap card to edit/delete) */}
@@ -204,6 +213,7 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
               <TableCell>Description</TableCell>
               <TableCell>With</TableCell>
               <TableCell>Type</TableCell>
+              <TableCell>Payment</TableCell>
               <TableCell align="right">Amount</TableCell>
               <TableCell align="right">Actions</TableCell>
             </TableRow>
@@ -228,6 +238,9 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                 </TableCell>
                 <TableCell>
                   <Chip label={t.type === 'income' ? 'Income' : 'Expense'} color={t.type === 'income' ? 'success' : 'error'} size="small" />
+                </TableCell>
+                <TableCell sx={{ color: 'text.secondary', fontSize: '0.8rem', whiteSpace: 'nowrap' }}>
+                  {t.paymentMethod || '\u2014'}
                 </TableCell>
                 <TableCell align="right">
                   <Typography color={t.type === 'income' ? 'success.main' : 'error.main'} fontWeight={600} sx={{ letterSpacing: '-0.01em' }}>

--- a/src/components/expenses/FilterBar.tsx
+++ b/src/components/expenses/FilterBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   TextField,
@@ -8,22 +8,27 @@ import {
   InputAdornment,
   IconButton,
   Tooltip,
+  Chip,
+  Collapse,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ClearIcon from '@mui/icons-material/Clear';
 import DownloadIcon from '@mui/icons-material/Download';
 import SortIcon from '@mui/icons-material/Sort';
-import { TransactionType } from '../../types';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import { TransactionType, PAYMENT_METHODS, PaymentMethod } from '../../types';
 
 interface Props {
   search: string;
   typeFilter: TransactionType | 'all';
+  paymentMethodFilter: PaymentMethod | 'all';
   sortBy: 'date' | 'amount';
   total: number;
   filtered: number;
   searchAllTime?: boolean;
   onSearchChange: (v: string) => void;
   onTypeFilterChange: (v: TransactionType | 'all') => void;
+  onPaymentMethodFilterChange: (v: PaymentMethod | 'all') => void;
   onSortChange: (v: 'date' | 'amount') => void;
   onExport: () => void;
 }
@@ -31,16 +36,19 @@ interface Props {
 const FilterBar: React.FC<Props> = ({
   search,
   typeFilter,
+  paymentMethodFilter,
   sortBy,
   total,
   filtered,
   searchAllTime,
   onSearchChange,
   onTypeFilterChange,
+  onPaymentMethodFilterChange,
   onSortChange,
   onExport,
 }) => {
-  const isActive = search !== '' || typeFilter !== 'all';
+  const [showPaymentFilter, setShowPaymentFilter] = useState(paymentMethodFilter !== 'all');
+  const isActive = search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all';
 
   return (
     <Box sx={{ mb: 2 }}>
@@ -79,6 +87,22 @@ const FilterBar: React.FC<Props> = ({
           <ToggleButton value="income">Income</ToggleButton>
           <ToggleButton value="expense">Expense</ToggleButton>
         </ToggleButtonGroup>
+        <Tooltip title="Filter by payment method">
+          <IconButton
+            size="small"
+            onClick={() => {
+              const next = !showPaymentFilter;
+              setShowPaymentFilter(next);
+              if (!next) onPaymentMethodFilterChange('all');
+            }}
+            sx={{
+              color: paymentMethodFilter !== 'all' ? '#818cf8' : 'text.secondary',
+              '&:hover': { color: 'text.primary' },
+            }}
+          >
+            <FilterListIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
         <Tooltip title={sortBy === 'date' ? 'Sort by amount' : 'Sort by date'}>
           <IconButton
             size="small"
@@ -101,6 +125,43 @@ const FilterBar: React.FC<Props> = ({
           </span>
         </Tooltip>
       </Box>
+      <Collapse in={showPaymentFilter}>
+        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 1.5 }}>
+          <Chip
+            label="All"
+            size="small"
+            clickable
+            onClick={() => onPaymentMethodFilterChange('all')}
+            sx={{
+              fontSize: '0.72rem',
+              height: 26,
+              bgcolor: paymentMethodFilter === 'all' ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.08)',
+              color: paymentMethodFilter === 'all' ? '#818cf8' : 'text.secondary',
+              border: '1px solid',
+              borderColor: paymentMethodFilter === 'all' ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
+              fontWeight: paymentMethodFilter === 'all' ? 700 : 400,
+            }}
+          />
+          {PAYMENT_METHODS.map((m) => (
+            <Chip
+              key={m}
+              label={m}
+              size="small"
+              clickable
+              onClick={() => onPaymentMethodFilterChange(paymentMethodFilter === m ? 'all' : m)}
+              sx={{
+                fontSize: '0.72rem',
+                height: 26,
+                bgcolor: paymentMethodFilter === m ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.08)',
+                color: paymentMethodFilter === m ? '#818cf8' : 'text.secondary',
+                border: '1px solid',
+                borderColor: paymentMethodFilter === m ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
+                fontWeight: paymentMethodFilter === m ? 700 : 400,
+              }}
+            />
+          ))}
+        </Box>
+      </Collapse>
       {isActive && (
         <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
           Showing {filtered} of {total} transactions{searchAllTime ? ' · all time' : ''}

--- a/src/components/expenses/PaymentMethodPicker.tsx
+++ b/src/components/expenses/PaymentMethodPicker.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Box, Chip, Typography } from '@mui/material';
+import LocalAtmIcon from '@mui/icons-material/LocalAtm';
+import CreditCardIcon from '@mui/icons-material/CreditCard';
+import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
+import PaymentIcon from '@mui/icons-material/Payment';
+import { PAYMENT_METHODS, PaymentMethod } from '../../types';
+
+const PAYMENT_METHOD_ICONS: Record<PaymentMethod, React.ReactNode> = {
+  'Cash': <LocalAtmIcon sx={{ fontSize: '14px !important' }} />,
+  'Octopus': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  'PayMe': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  'FPS': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  'Credit Card': <CreditCardIcon sx={{ fontSize: '14px !important' }} />,
+  'Debit Card': <CreditCardIcon sx={{ fontSize: '14px !important' }} />,
+  'Bank Transfer': <AccountBalanceIcon sx={{ fontSize: '14px !important' }} />,
+  'AlipayHK': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  'WeChat Pay': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+};
+
+export function getPaymentMethodIcon(method: PaymentMethod): React.ReactNode {
+  return PAYMENT_METHOD_ICONS[method];
+}
+
+interface Props {
+  value: PaymentMethod | null;
+  onChange: (v: PaymentMethod | null) => void;
+}
+
+const PaymentMethodPicker: React.FC<Props> = ({ value, onChange }) => {
+  return (
+    <Box sx={{ mt: 1.5 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', mb: 1, fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}
+      >
+        Payment Method
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+        {PAYMENT_METHODS.map((m) => (
+          <Chip
+            key={m}
+            icon={PAYMENT_METHOD_ICONS[m] as React.ReactElement}
+            label={m}
+            size="small"
+            clickable
+            onClick={() => onChange(value === m ? null : m)}
+            sx={{
+              fontSize: '0.72rem',
+              height: 28,
+              bgcolor: value === m ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.08)',
+              color: value === m ? '#818cf8' : 'text.secondary',
+              border: '1px solid',
+              borderColor: value === m ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
+              fontWeight: value === m ? 700 : 400,
+            }}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default PaymentMethodPicker;

--- a/src/components/expenses/QuickExpenseInput.tsx
+++ b/src/components/expenses/QuickExpenseInput.tsx
@@ -29,6 +29,7 @@ const QuickExpenseInput: React.FC<Props> = ({ open, onClose, onSubmit }) => {
         description: parsed.description || `Expense ${parsed.amount}`,
         amount: parsed.amount,
         category: parsed.category,
+        paymentMethod: parsed.paymentMethod || undefined,
         type: 'expense',
         date: new Date().toISOString().split('T')[0],
       });
@@ -67,7 +68,7 @@ const QuickExpenseInput: React.FC<Props> = ({ open, onClose, onSubmit }) => {
               <strong>{parsed.description || 'Expense'}</strong> &mdash; ${parsed.amount.toFixed(2)}
             </Typography>
             <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.7rem' }}>
-              Category: {parsed.category}
+              Category: {parsed.category}{parsed.paymentMethod ? ` | ${parsed.paymentMethod}` : ''}
             </Typography>
           </Box>
         )}

--- a/src/components/expenses/__tests__/ExpenseList.test.tsx
+++ b/src/components/expenses/__tests__/ExpenseList.test.tsx
@@ -123,7 +123,27 @@ describe('ExpenseList (desktop)', () => {
   it('shows dash for no participants', () => {
     const transactions = [makeTransaction({ participants: [] })];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
-    expect(screen.getByText('—')).toBeInTheDocument();
+    const dashes = screen.getAllByText('\u2014');
+    expect(dashes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders Payment column header', () => {
+    const transactions = [makeTransaction({})];
+    render(<ExpenseList {...defaultProps} transactions={transactions} />);
+    expect(screen.getByText('Payment')).toBeInTheDocument();
+  });
+
+  it('shows payment method when set', () => {
+    const transactions = [makeTransaction({ paymentMethod: 'Octopus' })];
+    render(<ExpenseList {...defaultProps} transactions={transactions} />);
+    expect(screen.getByText('Octopus')).toBeInTheDocument();
+  });
+
+  it('shows dash when no payment method', () => {
+    const transactions = [makeTransaction({ paymentMethod: undefined })];
+    render(<ExpenseList {...defaultProps} transactions={transactions} />);
+    const dashes = screen.getAllByText('\u2014');
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/src/components/expenses/__tests__/FilterBar.test.tsx
+++ b/src/components/expenses/__tests__/FilterBar.test.tsx
@@ -5,11 +5,13 @@ import FilterBar from '../FilterBar';
 const defaultProps = {
   search: '',
   typeFilter: 'all' as const,
+  paymentMethodFilter: 'all' as const,
   sortBy: 'date' as const,
   total: 10,
   filtered: 10,
   onSearchChange: jest.fn(),
   onTypeFilterChange: jest.fn(),
+  onPaymentMethodFilterChange: jest.fn(),
   onSortChange: jest.fn(),
   onExport: jest.fn(),
 };
@@ -107,5 +109,33 @@ describe('FilterBar', () => {
   it('shows "all time" label when searchAllTime is true', () => {
     render(<FilterBar {...defaultProps} search="test" searchAllTime={true} total={10} filtered={2} />);
     expect(screen.getByText(/all time/i)).toBeInTheDocument();
+  });
+
+  it('renders payment method filter toggle button', () => {
+    render(<FilterBar {...defaultProps} />);
+    expect(document.querySelector('[data-testid="FilterListIcon"]')).toBeTruthy();
+  });
+
+  it('shows payment method chips when filter toggle is clicked', () => {
+    render(<FilterBar {...defaultProps} />);
+    const filterBtn = document.querySelector('[data-testid="FilterListIcon"]')?.parentElement;
+    if (filterBtn) fireEvent.click(filterBtn);
+    expect(screen.getByText('Cash')).toBeInTheDocument();
+    expect(screen.getByText('Octopus')).toBeInTheDocument();
+    expect(screen.getByText('PayMe')).toBeInTheDocument();
+  });
+
+  it('calls onPaymentMethodFilterChange when payment chip clicked', () => {
+    const onPaymentMethodFilterChange = jest.fn();
+    render(<FilterBar {...defaultProps} onPaymentMethodFilterChange={onPaymentMethodFilterChange} />);
+    const filterBtn = document.querySelector('[data-testid="FilterListIcon"]')?.parentElement;
+    if (filterBtn) fireEvent.click(filterBtn);
+    fireEvent.click(screen.getByText('Octopus'));
+    expect(onPaymentMethodFilterChange).toHaveBeenCalledWith('Octopus');
+  });
+
+  it('shows filter count when paymentMethodFilter is active', () => {
+    render(<FilterBar {...defaultProps} paymentMethodFilter="Cash" total={20} filtered={5} />);
+    expect(screen.getByText(/showing 5 of 20/i)).toBeInTheDocument();
   });
 });

--- a/src/components/expenses/__tests__/PaymentMethodPicker.test.tsx
+++ b/src/components/expenses/__tests__/PaymentMethodPicker.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PaymentMethodPicker from '../PaymentMethodPicker';
+import { PAYMENT_METHODS, PaymentMethod } from '../../../types';
+
+describe('PaymentMethodPicker', () => {
+  it('renders all payment method options', () => {
+    render(<PaymentMethodPicker value={null} onChange={jest.fn()} />);
+    PAYMENT_METHODS.forEach((m) => {
+      expect(screen.getByText(m)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the label', () => {
+    render(<PaymentMethodPicker value={null} onChange={jest.fn()} />);
+    expect(screen.getByText('Payment Method')).toBeInTheDocument();
+  });
+
+  it('calls onChange with payment method when clicked', () => {
+    const onChange = jest.fn();
+    render(<PaymentMethodPicker value={null} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Octopus'));
+    expect(onChange).toHaveBeenCalledWith('Octopus');
+  });
+
+  it('calls onChange with null when same method is clicked (deselect)', () => {
+    const onChange = jest.fn();
+    render(<PaymentMethodPicker value={'Octopus' as PaymentMethod} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Octopus'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('calls onChange with new method when different method is clicked', () => {
+    const onChange = jest.fn();
+    render(<PaymentMethodPicker value={'Cash' as PaymentMethod} onChange={onChange} />);
+    fireEvent.click(screen.getByText('PayMe'));
+    expect(onChange).toHaveBeenCalledWith('PayMe');
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,19 @@
 export type TransactionType = 'income' | 'expense';
 
+export const PAYMENT_METHODS = [
+  'Cash',
+  'Octopus',
+  'PayMe',
+  'FPS',
+  'Credit Card',
+  'Debit Card',
+  'Bank Transfer',
+  'AlipayHK',
+  'WeChat Pay',
+] as const;
+
+export type PaymentMethod = typeof PAYMENT_METHODS[number];
+
 export interface Transaction {
   _id: string;
   owner: string;
@@ -9,6 +23,7 @@ export interface Transaction {
   category?: string;
   item?: string;
   participants?: string[];
+  paymentMethod?: PaymentMethod | null;
   date: string;
   createdAt: string;
   updatedAt: string;
@@ -22,5 +37,6 @@ export interface TransactionRequest {
   category?: string;
   item?: string;
   participants?: string[];
+  paymentMethod?: PaymentMethod | null;
   date?: string;
 }

--- a/src/utils/__tests__/parseQuickExpense.test.ts
+++ b/src/utils/__tests__/parseQuickExpense.test.ts
@@ -19,6 +19,56 @@ describe('parseQuickExpense', () => {
   test('shopping', () => { expect(parseQuickExpense('new shirt 300 shopping')).toEqual({ description: 'new shirt', amount: 300, category: 'Shopping' }); });
 });
 
+describe('parseQuickExpense payment method', () => {
+  test('octopus keyword', () => {
+    const result = parseQuickExpense('lunch 85 octopus');
+    expect(result?.paymentMethod).toBe('Octopus');
+    expect(result?.amount).toBe(85);
+  });
+
+  test('payme keyword', () => {
+    const result = parseQuickExpense('dinner 200 payme');
+    expect(result?.paymentMethod).toBe('PayMe');
+  });
+
+  test('cash keyword', () => {
+    const result = parseQuickExpense('coffee 40 cash');
+    expect(result?.paymentMethod).toBe('Cash');
+  });
+
+  test('fps keyword', () => {
+    const result = parseQuickExpense('rent 5000 fps');
+    expect(result?.paymentMethod).toBe('FPS');
+  });
+
+  test('credit keyword', () => {
+    const result = parseQuickExpense('shopping 300 credit');
+    expect(result?.paymentMethod).toBe('Credit Card');
+  });
+
+  test('wechat keyword', () => {
+    const result = parseQuickExpense('milk tea 25 wechat');
+    expect(result?.paymentMethod).toBe('WeChat Pay');
+  });
+
+  test('alipay keyword', () => {
+    const result = parseQuickExpense('snack 15 alipay');
+    expect(result?.paymentMethod).toBe('AlipayHK');
+  });
+
+  test('no payment method by default', () => {
+    const result = parseQuickExpense('lunch 85');
+    expect(result?.paymentMethod).toBeUndefined();
+  });
+
+  test('payment method with category', () => {
+    const result = parseQuickExpense('uber 150 transport octopus');
+    expect(result?.category).toBe('Transport');
+    expect(result?.paymentMethod).toBe('Octopus');
+    expect(result?.description).toBe('uber');
+  });
+});
+
 describe('suggestCategory', () => {
   test('Food for coffee', () => { expect(suggestCategory('coffee')).toBe('Food'); });
   test('Food for grocery', () => { expect(suggestCategory('grocery')).toBe('Food'); });

--- a/src/utils/parseQuickExpense.ts
+++ b/src/utils/parseQuickExpense.ts
@@ -1,7 +1,10 @@
+import { PaymentMethod } from '../types';
+
 export interface ParsedExpense {
   description: string;
   amount: number;
   category: string;
+  paymentMethod?: PaymentMethod;
 }
 
 const KNOWN_CATEGORIES = [
@@ -24,6 +27,27 @@ const CATEGORY_KEYWORDS: Record<string, string[]> = {
   Health: ['health', 'doctor', 'pharmacy', 'medicine', 'gym', 'medical'],
   Education: ['education', 'school', 'course', 'book', 'tuition', 'class'],
 };
+
+const PAYMENT_METHOD_KEYWORDS: Record<string, PaymentMethod> = {
+  'cash': 'Cash',
+  'octopus': 'Octopus',
+  'payme': 'PayMe',
+  'fps': 'FPS',
+  'creditcard': 'Credit Card',
+  'credit': 'Credit Card',
+  'debitcard': 'Debit Card',
+  'debit': 'Debit Card',
+  'banktransfer': 'Bank Transfer',
+  'bank': 'Bank Transfer',
+  'alipayhk': 'AlipayHK',
+  'alipay': 'AlipayHK',
+  'wechatpay': 'WeChat Pay',
+  'wechat': 'WeChat Pay',
+};
+
+function matchPaymentMethod(word: string): PaymentMethod | null {
+  return PAYMENT_METHOD_KEYWORDS[word.toLowerCase()] || null;
+}
 
 function matchCategory(word: string): string | null {
   const lower = word.toLowerCase();
@@ -51,6 +75,7 @@ export function parseQuickExpense(input: string): ParsedExpense | null {
 
   let amount = 0;
   let category = '';
+  let paymentMethod: PaymentMethod | undefined;
   const descParts: string[] = [];
   let foundNumber = false;
 
@@ -59,6 +84,11 @@ export function parseQuickExpense(input: string): ParsedExpense | null {
     if (!isNaN(num) && num >= 0 && !foundNumber) {
       amount = num;
       foundNumber = true;
+      continue;
+    }
+    const pmMatch = matchPaymentMethod(part);
+    if (pmMatch && !paymentMethod) {
+      paymentMethod = pmMatch;
       continue;
     }
     const catMatch = matchCategory(part);
@@ -80,5 +110,5 @@ export function parseQuickExpense(input: string): ParsedExpense | null {
     category = 'Other';
   }
 
-  return { description, amount, category };
+  return { description, amount, category, paymentMethod };
 }


### PR DESCRIPTION
## What
Payment method picker on expense forms, filter in transaction list, badge display, and quick expense parser support.

## Why
Closes #110

## Acceptance Criteria
- [x] Add payment method picker to AddExpense and EditExpense forms (chip-based: Cash, Credit Card, Debit Card, Octopus, PayMe, FPS, AlipayHK, WeChat Pay, Bank Transfer)
- [x] Payment method displayed on transaction list items (small icon/badge on mobile, column on desktop)
- [x] Filter bar supports filtering by payment method (collapsible chip row)
- [x] Default payment method is empty/unset (not required)
- [x] Quick expense parser recognizes "octopus", "payme", "cash", "fps", "credit", "debit", "alipay", "wechat", "bank" and auto-sets payment method
- [x] CSV export includes Payment Method column
- [ ] Payment method breakdown chart on dashboard (optional, deferred)

## Test Plan
1. Open Add Expense modal -- verify Payment Method chips appear below Participant picker
2. Select a payment method (e.g., Octopus), submit -- verify it persists when editing
3. On Transactions tab, click filter icon (funnel) -- verify payment method chip row appears
4. Select "Cash" filter -- verify only Cash transactions show
5. Quick expense: type "lunch 85 octopus" -- verify preview shows "Octopus" payment method
6. Desktop: verify Payment column in transaction table
7. Mobile: verify small payment method badge under transaction cards
8. Export CSV -- verify Payment Method column present