### PR TITLE
fix: wait for async data in empty state test

### DIFF
--- a/src/components/__tests__/MainLayout.test.tsx
+++ b/src/components/__tests__/MainLayout.test.tsx
@@ -505,8 +505,10 @@ describe('MainLayout', () => {
     ]);
     renderMainLayout();
     await waitFor(() => {
-      expect(screen.getAllByText('Home').length).toBeGreaterThan(0);
+      expect(mockGetExpenses).toHaveBeenCalled();
     });
-    expect(screen.queryByText('Track your first expense')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Track your first expense')).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## What
Fixed the failing MainLayout test "hides empty state when transactions exist" by properly awaiting async transaction fetching before asserting.

## Why
Closes the test failure. The test was asserting synchronously that the empty state text was absent, but `fetchTransactions` is async -- the component still had `transactions = []` at assertion time.

## Acceptance Criteria
- [x] Test "hides empty state when transactions exist" passes
- [x] All 498 tests pass
- [x] Build succeeds
- [x] npm audit fix attempted (fails due to pre-existing peer dependency conflicts, not forceable)

## Test Plan
1. Run `CI=true yarn test --watchAll=false` -- all 498 tests pass
2. Run `yarn build` -- compiles successfully

Generated with [Claude Code](https://claude.com/claude-code)