### PR TITLE
fix: remove duplicate currency bar in modals (#120)

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -31,7 +31,7 @@ import ManageTemplatesDrawer from './ManageTemplatesDrawer';
 import ParticipantPicker from './ParticipantPicker';
 import PaymentMethodPicker from './PaymentMethodPicker';
 import { useTemplates, TransactionTemplate } from '../../hooks/useTemplates';
-import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
+import { useFxRates, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
 import { useItemPresets } from '../../hooks/useItemPresets';
 import { useRecurring } from '../../hooks/useRecurring';
 
@@ -338,33 +338,6 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
             </Box>
           );
         })()}
-
-        {/* Transaction currency selector */}
-        <Box sx={{ mt: 1.5, mb: 0.5 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1, fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-            Currency
-          </Typography>
-          <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-            {CURRENCIES.map((c) => (
-              <Chip
-                key={c}
-                label={`${CURRENCY_SYMBOLS[c]} ${c}`}
-                size="small"
-                clickable
-                onClick={() => setTxCurrency(c)}
-                sx={{
-                  fontSize: '0.72rem',
-                  height: 28,
-                  bgcolor: txCurrency === c ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.08)',
-                  color: txCurrency === c ? '#818cf8' : 'text.secondary',
-                  border: '1px solid',
-                  borderColor: txCurrency === c ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
-                  fontWeight: txCurrency === c ? 700 : 400,
-                }}
-              />
-            ))}
-          </Box>
-        </Box>
 
         {/* Amount — calculator keypad with FX support */}
         <NumPad

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -30,7 +30,7 @@ import ItemPicker, { ItemPreset, ITEM_PRESETS, ITEM_SUGGESTIONS } from './ItemPi
 import DescriptionPicker from './DescriptionPicker';
 import ParticipantPicker from './ParticipantPicker';
 import PaymentMethodPicker from './PaymentMethodPicker';
-import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
+import { useFxRates, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
 import { useItemPresets } from '../../hooks/useItemPresets';
 
 interface Props {
@@ -282,33 +282,6 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
           const suggestions = Array.from(new Set([...(preset ? [preset] : []), ...history, ...builtIn])).slice(0, 10);
           return <DescriptionPicker value={description} onChange={setDescription} suggestions={suggestions} />;
         })()}
-
-        {/* Transaction currency selector */}
-        <Box sx={{ mt: 1.5, mb: 0.5 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1, fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-            Currency
-          </Typography>
-          <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-            {CURRENCIES.map((c) => (
-              <Chip
-                key={c}
-                label={`${CURRENCY_SYMBOLS[c]} ${c}`}
-                size="small"
-                clickable
-                onClick={() => setTxCurrency(c)}
-                sx={{
-                  fontSize: '0.72rem',
-                  height: 28,
-                  bgcolor: txCurrency === c ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.08)',
-                  color: txCurrency === c ? '#818cf8' : 'text.secondary',
-                  border: '1px solid',
-                  borderColor: txCurrency === c ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
-                  fontWeight: txCurrency === c ? 700 : 400,
-                }}
-              />
-            ))}
-          </Box>
-        </Box>
 
         {/* Amount — calculator keypad with FX support */}
         <NumPad

--- a/src/components/expenses/__tests__/AddExpenseModal.test.tsx
+++ b/src/components/expenses/__tests__/AddExpenseModal.test.tsx
@@ -120,10 +120,9 @@ describe('AddExpenseModal', () => {
     expect(screen.getAllByText(/HK\$/).length).toBeGreaterThan(0);
   });
 
-  it('shows currency chips for all currencies', () => {
+  it('shows HK$ in NumPad amount display when currency is HKD', () => {
     render(<AddExpenseModal {...defaultProps} />);
-    expect(screen.getByText('HK$ HKD')).toBeInTheDocument();
-    expect(screen.getByText('CA$ CAD')).toBeInTheDocument();
+    expect(screen.getAllByText(/HK\$/).length).toBeGreaterThan(0);
   });
 
   it('shows error when Save is clicked without description or item', async () => {
@@ -145,9 +144,9 @@ describe('AddExpenseModal', () => {
     expect(screen.getByText('Record Transaction')).toBeInTheDocument();
   });
 
-  it('shows Currency section label', () => {
+  it('shows Amount label in NumPad', () => {
     render(<AddExpenseModal {...defaultProps} />);
-    expect(screen.getByText('Currency')).toBeInTheDocument();
+    expect(screen.getByText('Amount')).toBeInTheDocument();
   });
 
   it('shows Date section label', () => {

--- a/src/components/expenses/__tests__/EditExpenseModal.test.tsx
+++ b/src/components/expenses/__tests__/EditExpenseModal.test.tsx
@@ -89,9 +89,9 @@ describe('EditExpenseModal', () => {
     expect(deleteBtn).toBeTruthy();
   });
 
-  it('shows currency chips', () => {
+  it('shows HK$ in NumPad amount display when currency is HKD', () => {
     render(<EditExpenseModal {...defaultProps} />);
-    expect(screen.getByText('HK$ HKD')).toBeInTheDocument();
+    expect(screen.getAllByText(/HK\$/).length).toBeGreaterThan(0);
   });
 
   it('shows today/yesterday date shortcuts', () => {


### PR DESCRIPTION
## What
Removes the standalone currency chips Box from AddExpenseModal and EditExpenseModal. Also removes the now-unused CURRENCIES import from both files.

## Why
Closes #120

NumPad already renders currency context via its fxSymbol/fxRate props — it shows the active currency symbol inline in the amount display and provides a swap row when a foreign currency is selected. The modal-level chips Box was redundant and caused a duplicate currency UI row on mobile (fullScreen={isMobile}).

## Acceptance Criteria
- [x] Currency selection appears exactly once (inside NumPad)
- [x] No standalone currency chips row in AddExpenseModal
- [x] No standalone currency chips row in EditExpenseModal
- [x] NumPad still receives fxSymbol/fxRate props and renders currency correctly
- [x] Unused CURRENCIES import removed from both modals
- [x] Tests updated to reflect the new single-location currency display

## Test Plan
1. Open the app on mobile viewport (< 600px)
2. Tap + to open AddExpenseModal — verify currency indicator appears only once (inside the NumPad amount display)
3. Tap an existing expense to open EditExpenseModal — same check
4. On desktop, confirm no visible regression
5. CI=true yarn test --testPathPattern="(AddExpenseModal|EditExpenseModal|NumPad)" — 98 pass, 6 skipped