### PR TITLE
feat: category filter in transaction list (#131)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -96,6 +96,7 @@ const MainLayout: React.FC = () => {
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState<TransactionType | 'all'>('all');
   const [paymentMethodFilter, setPaymentMethodFilter] = useState<PaymentMethod | 'all'>('all');
+  const [categoryFilter, setCategoryFilter] = useState<string | 'all'>('all');
   const [sortBy, setSortBy] = useState<'date' | 'amount'>('date');
   const [exportMenuAnchor, setExportMenuAnchor] = useState<null | HTMLElement>(null);
   const [addOpen, setAddOpen] = useState(false);
@@ -366,13 +367,14 @@ const MainLayout: React.FC = () => {
         (t.notes || '').toLowerCase().includes(searchLow);
       const matchesType = typeFilter === 'all' || t.type === typeFilter;
       const matchesPayment = paymentMethodFilter === 'all' || t.paymentMethod === paymentMethodFilter;
-      return matchesSearch && matchesType && matchesPayment;
+      const matchesCategory = categoryFilter === 'all' || t.category === categoryFilter;
+      return matchesSearch && matchesType && matchesPayment && matchesCategory;
     });
     if (sortBy === 'amount') {
       return [...filtered].sort((a, b) => b.amount - a.amount);
     }
     return filtered;
-  }, [transactions, monthFiltered, search, typeFilter, paymentMethodFilter, sortBy]);
+  }, [transactions, monthFiltered, search, typeFilter, paymentMethodFilter, categoryFilter, sortBy]);
 
   const handleExport = () => {
     const header = ['Date', 'Item', 'Description', 'Type', 'Category', 'Amount', 'Payment Method', 'Participants'];
@@ -816,6 +818,8 @@ const MainLayout: React.FC = () => {
                 search={search}
                 typeFilter={typeFilter}
                 paymentMethodFilter={paymentMethodFilter}
+                categoryFilter={categoryFilter}
+                categories={existingCategories}
                 sortBy={sortBy}
                 total={search !== '' ? transactions.length : monthFiltered.length}
                 filtered={filteredTransactions.length}
@@ -823,6 +827,7 @@ const MainLayout: React.FC = () => {
                 onSearchChange={setSearch}
                 onTypeFilterChange={setTypeFilter}
                 onPaymentMethodFilterChange={setPaymentMethodFilter}
+                onCategoryFilterChange={setCategoryFilter}
                 onSortChange={setSortBy}
                 onExport={handleExport}
                 onExportJson={handleExportJson}

--- a/src/components/__tests__/MainLayout.test.tsx
+++ b/src/components/__tests__/MainLayout.test.tsx
@@ -562,6 +562,33 @@ describe('MainLayout', () => {
     });
   });
 
+  it('category filter shows only matching transactions', async () => {
+    mockGetExpenses.mockResolvedValue([
+      makeTransaction({ _id: '1', description: 'Coffee', category: 'Food & Drink' }),
+      makeTransaction({ _id: '2', description: 'Bus fare', category: 'Transport' }),
+    ]);
+    renderMainLayout();
+    await waitFor(() => screen.getAllByText('Home').length > 0);
+    const transLabels = screen.getAllByText('Transactions');
+    await act(async () => { fireEvent.click(transLabels[transLabels.length - 1]); });
+    await waitFor(() => screen.getByText('Coffee'));
+    // Both transactions visible initially
+    expect(screen.getByText('Coffee')).toBeInTheDocument();
+    expect(screen.getByText('Bus fare')).toBeInTheDocument();
+    // Open category filter panel
+    const labelIcon = document.querySelector('[data-testid="LabelIcon"]');
+    if (labelIcon?.parentElement) {
+      await act(async () => { fireEvent.click(labelIcon.parentElement!); });
+    }
+    // Click the Food & Drink category chip
+    await waitFor(() => screen.getByText('Food & Drink'));
+    await act(async () => { fireEvent.click(screen.getByText('Food & Drink')); });
+    await waitFor(() => {
+      expect(screen.getByText('Coffee')).toBeInTheDocument();
+      expect(screen.queryByText('Bus fare')).not.toBeInTheDocument();
+    });
+  });
+
   it('search by notes content filters transactions', async () => {
     mockGetExpenses.mockResolvedValue([
       makeTransaction({ _id: '1', description: 'Lunch', notes: 'client meeting' }),

--- a/src/components/expenses/FilterBar.tsx
+++ b/src/components/expenses/FilterBar.tsx
@@ -22,12 +22,15 @@ import TableChartIcon from '@mui/icons-material/TableChart';
 import DataObjectIcon from '@mui/icons-material/DataObject';
 import SortIcon from '@mui/icons-material/Sort';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import LabelIcon from '@mui/icons-material/Label';
 import { TransactionType, PAYMENT_METHODS, PaymentMethod } from '../../types';
 
 interface Props {
   search: string;
   typeFilter: TransactionType | 'all';
   paymentMethodFilter: PaymentMethod | 'all';
+  categoryFilter: string | 'all';
+  categories: string[];
   sortBy: 'date' | 'amount';
   total: number;
   filtered: number;
@@ -35,6 +38,7 @@ interface Props {
   onSearchChange: (v: string) => void;
   onTypeFilterChange: (v: TransactionType | 'all') => void;
   onPaymentMethodFilterChange: (v: PaymentMethod | 'all') => void;
+  onCategoryFilterChange: (v: string | 'all') => void;
   onSortChange: (v: 'date' | 'amount') => void;
   onExport: () => void;
   onExportJson: () => void;
@@ -44,6 +48,8 @@ const FilterBar: React.FC<Props> = ({
   search,
   typeFilter,
   paymentMethodFilter,
+  categoryFilter,
+  categories,
   sortBy,
   total,
   filtered,
@@ -51,13 +57,15 @@ const FilterBar: React.FC<Props> = ({
   onSearchChange,
   onTypeFilterChange,
   onPaymentMethodFilterChange,
+  onCategoryFilterChange,
   onSortChange,
   onExport,
   onExportJson,
 }) => {
   const [showPaymentFilter, setShowPaymentFilter] = useState(paymentMethodFilter !== 'all');
+  const [showCategoryFilter, setShowCategoryFilter] = useState(categoryFilter !== 'all');
   const [exportMenuAnchor, setExportMenuAnchor] = useState<null | HTMLElement>(null);
-  const isActive = search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all';
+  const isActive = search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all' || categoryFilter !== 'all';
 
   return (
     <Box sx={{ mb: 2 }}>
@@ -112,6 +120,25 @@ const FilterBar: React.FC<Props> = ({
             <FilterListIcon fontSize="small" />
           </IconButton>
         </Tooltip>
+        {categories.length > 0 && (
+          <Tooltip title="Filter by category">
+            <IconButton
+              size="small"
+              aria-label="Filter by category"
+              onClick={() => {
+                const next = !showCategoryFilter;
+                setShowCategoryFilter(next);
+                if (!next) onCategoryFilterChange('all');
+              }}
+              sx={{
+                color: categoryFilter !== 'all' ? '#818cf8' : 'text.secondary',
+                '&:hover': { color: 'text.primary' },
+              }}
+            >
+              <LabelIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
         <Tooltip title={sortBy === 'date' ? 'Sort by amount' : 'Sort by date'}>
           <IconButton
             size="small"
@@ -201,6 +228,43 @@ const FilterBar: React.FC<Props> = ({
                 border: '1px solid',
                 borderColor: paymentMethodFilter === m ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
                 fontWeight: paymentMethodFilter === m ? 700 : 400,
+              }}
+            />
+          ))}
+        </Box>
+      </Collapse>
+      <Collapse in={showCategoryFilter && categories.length > 0}>
+        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 1.5 }}>
+          <Chip
+            label="All"
+            size="small"
+            clickable
+            onClick={() => onCategoryFilterChange('all')}
+            sx={{
+              fontSize: '0.72rem',
+              height: 26,
+              bgcolor: categoryFilter === 'all' ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.08)',
+              color: categoryFilter === 'all' ? '#818cf8' : 'text.secondary',
+              border: '1px solid',
+              borderColor: categoryFilter === 'all' ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
+              fontWeight: categoryFilter === 'all' ? 700 : 400,
+            }}
+          />
+          {categories.map((cat) => (
+            <Chip
+              key={cat}
+              label={cat}
+              size="small"
+              clickable
+              onClick={() => onCategoryFilterChange(categoryFilter === cat ? 'all' : cat)}
+              sx={{
+                fontSize: '0.72rem',
+                height: 26,
+                bgcolor: categoryFilter === cat ? 'rgba(129,140,248,0.18)' : 'rgba(148,163,184,0.08)',
+                color: categoryFilter === cat ? '#818cf8' : 'text.secondary',
+                border: '1px solid',
+                borderColor: categoryFilter === cat ? 'rgba(129,140,248,0.4)' : 'rgba(148,163,184,0.12)',
+                fontWeight: categoryFilter === cat ? 700 : 400,
               }}
             />
           ))}

--- a/src/components/expenses/__tests__/FilterBar.test.tsx
+++ b/src/components/expenses/__tests__/FilterBar.test.tsx
@@ -6,12 +6,15 @@ const defaultProps = {
   search: '',
   typeFilter: 'all' as const,
   paymentMethodFilter: 'all' as const,
+  categoryFilter: 'all' as const,
+  categories: [],
   sortBy: 'date' as const,
   total: 10,
   filtered: 10,
   onSearchChange: jest.fn(),
   onTypeFilterChange: jest.fn(),
   onPaymentMethodFilterChange: jest.fn(),
+  onCategoryFilterChange: jest.fn(),
   onSortChange: jest.fn(),
   onExport: jest.fn(),
   onExportJson: jest.fn(),
@@ -166,5 +169,85 @@ describe('FilterBar', () => {
     const allChip = document.querySelector('.MuiChip-root');
     if (allChip) fireEvent.click(allChip);
     expect(onPaymentMethodFilterChange).toHaveBeenCalledWith('all');
+  });
+
+  it('does not render category filter icon when categories list is empty', () => {
+    render(<FilterBar {...defaultProps} categories={[]} />);
+    expect(document.querySelector('[data-testid="LabelIcon"]')).toBeNull();
+  });
+
+  it('renders category filter icon when categories are provided', () => {
+    render(<FilterBar {...defaultProps} categories={['Food', 'Transport']} />);
+    expect(document.querySelector('[data-testid="LabelIcon"]')).toBeTruthy();
+  });
+
+  it('shows category chips when filter icon is clicked', () => {
+    render(<FilterBar {...defaultProps} categories={['Food', 'Transport']} />);
+    const labelBtn = document.querySelector('[data-testid="LabelIcon"]')?.parentElement;
+    if (labelBtn) fireEvent.click(labelBtn);
+    expect(screen.getByText('Food')).toBeInTheDocument();
+    expect(screen.getByText('Transport')).toBeInTheDocument();
+  });
+
+  it('calls onCategoryFilterChange when category chip is clicked', () => {
+    const onCategoryFilterChange = jest.fn();
+    render(<FilterBar {...defaultProps} categories={['Food', 'Transport']} onCategoryFilterChange={onCategoryFilterChange} />);
+    const labelBtn = document.querySelector('[data-testid="LabelIcon"]')?.parentElement;
+    if (labelBtn) fireEvent.click(labelBtn);
+    fireEvent.click(screen.getByText('Food'));
+    expect(onCategoryFilterChange).toHaveBeenCalledWith('Food');
+  });
+
+  it('calls onCategoryFilterChange with "all" when clicking active category chip again', () => {
+    const onCategoryFilterChange = jest.fn();
+    render(
+      <FilterBar
+        {...defaultProps}
+        categories={['Food', 'Transport']}
+        categoryFilter="Food"
+        onCategoryFilterChange={onCategoryFilterChange}
+      />
+    );
+    // Panel is open since categoryFilter !== 'all'
+    fireEvent.click(screen.getByText('Food'));
+    expect(onCategoryFilterChange).toHaveBeenCalledWith('all');
+  });
+
+  it('clicking All chip in category panel resets category filter', () => {
+    const onCategoryFilterChange = jest.fn();
+    render(
+      <FilterBar
+        {...defaultProps}
+        categories={['Food', 'Transport']}
+        categoryFilter="Food"
+        onCategoryFilterChange={onCategoryFilterChange}
+      />
+    );
+    // Category panel is open since categoryFilter !== 'all'
+    // The category Collapse renders: All, Food, Transport chips
+    // Payment method Collapse also renders an "All" chip but it comes first in DOM
+    // Last "All" chip in the DOM belongs to the category section
+    const allChips = screen.getAllByText('All');
+    fireEvent.click(allChips[allChips.length - 1]);
+    expect(onCategoryFilterChange).toHaveBeenCalledWith('all');
+  });
+
+  it('shows filter count when categoryFilter is active', () => {
+    render(
+      <FilterBar
+        {...defaultProps}
+        categories={['Food']}
+        categoryFilter="Food"
+        total={20}
+        filtered={4}
+      />
+    );
+    expect(screen.getByText(/showing 4 of 20/i)).toBeInTheDocument();
+  });
+
+  it('category filter icon is highlighted when a category is selected', () => {
+    render(<FilterBar {...defaultProps} categories={['Food']} categoryFilter="Food" />);
+    const labelIcon = document.querySelector('[data-testid="LabelIcon"]');
+    expect(labelIcon?.parentElement).toBeTruthy();
   });
 });


### PR DESCRIPTION
## What
Adds a category filter to the transaction list FilterBar. Users can now tap a label icon to expand a chip row and filter transactions by category. The active filter is visually indicated (icon and chip turn indigo), and clicking a selected category again or tapping the chip resets to all. The filtered count caption reflects the active category filter.

## Why
Closes #131

## Acceptance Criteria
- [x] A filter control is accessible from the transaction list (label icon in filter bar)
- [x] User can select a category to filter by
- [x] Active filters are visually indicated (icon and chip highlight in indigo when active)
- [x] Filtered results update the transaction list in real time
- [x] A clear action resets to show all transactions (re-click active chip, or re-click the icon)
- [x] Filter state is not persisted across sessions (resets on page reload)

**Note on date range filtering:** The date range quick-filters (This Week, Last Month, Custom) requested in the issue are already fully implemented via `DateRangeControl` / `MonthPicker`. A separate custom date range picker is not added in this PR to keep scope focused. If additional date filtering is needed beyond what exists, that should be a separate follow-up issue.

## Test Plan
1. Navigate to the Transactions tab
2. Verify the label (tag) icon only appears when there are transactions with categories
3. Click the icon — category chips expand below the filter bar
4. Click a category chip — only transactions matching that category are shown; count caption updates
5. Click the same chip again — filter clears back to all
6. Click the icon again — chips collapse and filter resets
7. Verify the icon highlights indigo when a category is active
8. Reload the page — filter is reset (no persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)