### PR TITLE
feat: swipe-to-delete on mobile transaction list (#133)

### DIFF
--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import {
   Table,
   TableHead,
@@ -75,10 +75,59 @@ function fmtOriginal(t: Transaction): string | null {
   return `${sym}${t.originalAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 }
 
+const SWIPE_REVEAL_PX = 80;
+const SWIPE_THRESHOLD_PX = 60;
+
 const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert, symbol, recurringLabels }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [expandedNote, setExpandedNote] = useState<string | null>(null);
+  const [swipedId, setSwipedId] = useState<string | null>(null);
+  const [swipeOffset, setSwipeOffset] = useState<Record<string, number>>({});
+  const touchStartX = useRef<Record<string, number>>({});
+  const isSwiping = useRef<Record<string, boolean>>({});
+
+  const handleTouchStart = useCallback((id: string, e: React.TouchEvent) => {
+    if (!('ontouchstart' in window)) return;
+    touchStartX.current[id] = e.touches[0].clientX;
+    isSwiping.current[id] = false;
+  }, []);
+
+  const handleTouchMove = useCallback((id: string, e: React.TouchEvent) => {
+    if (!('ontouchstart' in window)) return;
+    const startX = touchStartX.current[id];
+    if (startX === undefined) return;
+    const deltaX = e.touches[0].clientX - startX;
+    if (deltaX > 0) {
+      // Swiping right — reset
+      setSwipeOffset((prev) => ({ ...prev, [id]: 0 }));
+      setSwipedId(null);
+      isSwiping.current[id] = false;
+      return;
+    }
+    isSwiping.current[id] = true;
+    const clamped = Math.max(deltaX, -SWIPE_REVEAL_PX);
+    setSwipeOffset((prev) => ({ ...prev, [id]: clamped }));
+  }, []);
+
+  const handleTouchEnd = useCallback((id: string) => {
+    if (!('ontouchstart' in window)) return;
+    const offset = swipeOffset[id] ?? 0;
+    if (Math.abs(offset) >= SWIPE_THRESHOLD_PX) {
+      setSwipeOffset((prev) => ({ ...prev, [id]: -SWIPE_REVEAL_PX }));
+      setSwipedId(id);
+    } else {
+      setSwipeOffset((prev) => ({ ...prev, [id]: 0 }));
+      setSwipedId(null);
+    }
+    isSwiping.current[id] = false;
+  }, [swipeOffset]);
+
+  const handleDeleteTap = useCallback((id: string) => {
+    setSwipeOffset((prev) => ({ ...prev, [id]: 0 }));
+    setSwipedId(null);
+    onDelete(id);
+  }, [onDelete]);
 
   if (transactions.length === 0) {
     return (
@@ -147,17 +196,64 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                     (t.item && recurringLabels.has(t.item)) ||
                     recurringLabels.has(t.description)
                   );
+                  const offset = swipeOffset[t._id] ?? 0;
                   return (
-                  <Card
+                  <Box
                     key={t._id}
-                    sx={{
-                      border: '1px solid rgba(148,163,184,0.08)',
-                      background: theme.palette.mode === 'dark' ? 'rgba(30,41,59,0.5)' : 'rgba(255,255,255,0.85)',
-                      backdropFilter: 'blur(8px)',
-                      borderLeft: `3px solid ${accentColor}44`,
-                    }}
+                    data-testid="swipeable-row"
+                    sx={{ position: 'relative', overflow: 'hidden', borderRadius: 1 }}
+                    onTouchStart={(e) => handleTouchStart(t._id, e)}
+                    onTouchMove={(e) => handleTouchMove(t._id, e)}
+                    onTouchEnd={() => handleTouchEnd(t._id)}
                   >
-                    <CardActionArea onClick={() => onEdit(t)} sx={{ p: 0 }}>
+                    {/* Red delete background revealed on swipe */}
+                    <Box
+                      sx={{
+                        position: 'absolute',
+                        right: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: SWIPE_REVEAL_PX,
+                        bgcolor: 'error.main',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderRadius: '0 4px 4px 0',
+                      }}
+                    >
+                      <IconButton
+                        aria-label={`Delete ${t.item || t.description}`}
+                        data-testid={`delete-btn-${t._id}`}
+                        onClick={() => handleDeleteTap(t._id)}
+                        sx={{ color: '#fff', p: 1 }}
+                        size="small"
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </Box>
+                    <Card
+                      sx={{
+                        border: '1px solid rgba(148,163,184,0.08)',
+                        background: theme.palette.mode === 'dark' ? 'rgba(30,41,59,0.5)' : 'rgba(255,255,255,0.85)',
+                        backdropFilter: 'blur(8px)',
+                        borderLeft: `3px solid ${accentColor}44`,
+                        transform: `translateX(${offset}px)`,
+                        transition: isSwiping.current[t._id] ? 'none' : 'transform 0.2s ease',
+                        position: 'relative',
+                        zIndex: 1,
+                      }}
+                    >
+                    <CardActionArea
+                      onClick={() => {
+                        if (swipedId === t._id) {
+                          setSwipedId(null);
+                          setSwipeOffset((prev) => ({ ...prev, [t._id]: 0 }));
+                          return;
+                        }
+                        onEdit(t);
+                      }}
+                      sx={{ p: 0 }}
+                    >
                       <CardContent sx={{ p: '14px 16px', '&:last-child': { pb: t.notes ? '8px' : '14px' } }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
                           {/* Left: title + participants */}
@@ -235,6 +331,7 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                       </CardContent>
                     </CardActionArea>
                   </Card>
+                  </Box>
                   );
                 })}
               </Box>

--- a/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
+++ b/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
@@ -146,3 +146,62 @@ describe('ExpenseList (mobile layout)', () => {
     expect(screen.queryByText('tap to expand note')).not.toBeInTheDocument();
   });
 });
+
+describe('ExpenseList (mobile swipe-to-delete)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Simulate touch device
+    Object.defineProperty(window, 'ontouchstart', { value: () => {}, writable: true, configurable: true });
+  });
+
+  afterEach(() => {
+    // Clean up touch simulation
+    // @ts-expect-error resetting touch simulation
+    delete window.ontouchstart;
+  });
+
+  it('calls onDelete after swiping left past threshold', () => {
+    const onDelete = jest.fn();
+    const t = makeTransaction({ _id: 'swipe1', description: 'Swipe me' });
+    const { container } = render(<ExpenseList {...defaultProps} transactions={[t]} onDelete={onDelete} />);
+    const swipeEl = container.querySelector('[data-testid="swipeable-row"]') as HTMLElement;
+    expect(swipeEl).not.toBeNull();
+
+    fireEvent.touchStart(swipeEl, { touches: [{ clientX: 200 }] });
+    fireEvent.touchMove(swipeEl, { touches: [{ clientX: 130 }] }); // -70px, past 60px threshold
+    fireEvent.touchEnd(swipeEl);
+
+    // Reveal state set — now click the delete button
+    const deleteBtn = container.querySelector('[data-testid="delete-btn-swipe1"]') as HTMLElement;
+    expect(deleteBtn).not.toBeNull();
+    fireEvent.click(deleteBtn);
+    expect(onDelete).toHaveBeenCalledWith('swipe1');
+  });
+
+  it('does not call onDelete after partial swipe below threshold', () => {
+    const onDelete = jest.fn();
+    const t = makeTransaction({ _id: 'partial1', description: 'Partial swipe' });
+    const { container } = render(<ExpenseList {...defaultProps} transactions={[t]} onDelete={onDelete} />);
+    const swipeEl = container.querySelector('[data-testid="swipeable-row"]') as HTMLElement;
+
+    fireEvent.touchStart(swipeEl, { touches: [{ clientX: 200 }] });
+    fireEvent.touchMove(swipeEl, { touches: [{ clientX: 160 }] }); // -40px, below 60px threshold
+    fireEvent.touchEnd(swipeEl);
+
+    // onDelete should not have been called — delete button is not activated
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('swiping right resets position without calling onDelete', () => {
+    const onDelete = jest.fn();
+    const t = makeTransaction({ _id: 'right1', description: 'Right swipe' });
+    const { container } = render(<ExpenseList {...defaultProps} transactions={[t]} onDelete={onDelete} />);
+    const swipeEl = container.querySelector('[data-testid="swipeable-row"]') as HTMLElement;
+
+    fireEvent.touchStart(swipeEl, { touches: [{ clientX: 100 }] });
+    fireEvent.touchMove(swipeEl, { touches: [{ clientX: 150 }] }); // positive delta → right swipe
+    fireEvent.touchEnd(swipeEl);
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
Add left-swipe gesture on mobile transaction cards to reveal a red Delete button. Implemented with CSS transforms and native touch event handlers — no external library.

Key details:
- Swipe threshold: 60px left to snap open, otherwise snaps back with `transition: transform 0.2s ease`
- Reveal distance capped at 80px, showing a red `DeleteIcon` button behind the card
- Touch-only guard: `if ('ontouchstart' in window)` — mouse drag on desktop does nothing
- Tapping the revealed Delete button calls the existing `onDelete` handler, which fires the pre-existing undo snackbar (5s restore window)
- Tapping a swiped-open card body resets it without navigating to edit
- Swiping right on an open card resets it with no action

## Why
Closes #133

## Acceptance Criteria
- [x] Swiping left on a transaction row reveals a red Delete action button
- [x] Tapping the revealed Delete button triggers deletion (with undo snackbar from existing logic)
- [x] Swiping right before tapping Delete returns row to original position with no action taken
- [x] Swipe gesture only activates on touch devices; mouse drag does not trigger it on desktop
- [x] Deleting via swipe produces the same result as deleting via the detail view
- [x] Animation is smooth — CSS transform with 0.2s ease transition
- [x] Works in both dark and light mode (delete background uses `error.main` from MUI theme)

## Test Plan
1. Open the app on a mobile device or Chrome DevTools mobile emulation
2. Navigate to the transaction list
3. Swipe left on any transaction card — red Delete button should appear
4. Tap the Delete button — transaction removed, undo snackbar appears
5. Swipe left partially (less than ~60px) and release — card snaps back, no deletion
6. Swipe left fully, then swipe right — card resets to original position
7. On desktop: verify mouse drag does not trigger swipe behavior
8. Run tests: `CI=true yarn test --testPathPattern="ExpenseListMobile"`