### PR TITLE
feat: pull-to-refresh on mobile transaction list (#151)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -877,6 +877,7 @@ const MainLayout: React.FC = () => {
                 recurringLabels={recurringLabels}
                 filtersActive={search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all' || categoryFilter !== 'all'}
                 onAddClick={() => setAddOpen(true)}
+                onRefresh={fetchTransactions}
               />
             </>
           )}

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -14,6 +14,7 @@ import {
   CardContent,
   Collapse,
   Tooltip,
+  CircularProgress,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -39,6 +40,7 @@ interface Props {
   recurringLabels?: Set<string>;
   filtersActive?: boolean;
   onAddClick?: () => void;
+  onRefresh?: () => Promise<void>;
 }
 
 function getDateKey(dateStr: string | undefined, fallback?: string): string {
@@ -80,7 +82,11 @@ function fmtOriginal(t: Transaction): string | null {
 const SWIPE_REVEAL_PX = 80;
 const SWIPE_THRESHOLD_PX = 60;
 
-const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert, symbol, recurringLabels, filtersActive, onAddClick }) => {
+const PULL_THRESHOLD_PX = 65;
+const PULL_MAX_PX = 80;
+const PULL_DEBOUNCE_MS = 2000;
+
+const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert, symbol, recurringLabels, filtersActive, onAddClick, onRefresh }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [expandedNote, setExpandedNote] = useState<string | null>(null);
@@ -88,6 +94,62 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
   const [swipeOffset, setSwipeOffset] = useState<Record<string, number>>({});
   const touchStartX = useRef<Record<string, number>>({});
   const isSwiping = useRef<Record<string, boolean>>({});
+
+  // Pull-to-refresh state
+  const [pullY, setPullY] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const pullStartY = useRef(0);
+  const isPullingRef = useRef(false);
+  const pullYRef = useRef(0);
+  const lastRefreshAt = useRef(0);
+
+  const handlePullStart = useCallback((e: React.TouchEvent) => {
+    if (!onRefresh || isRefreshing) return;
+    pullStartY.current = e.touches[0].clientY;
+    isPullingRef.current = false;
+  }, [onRefresh, isRefreshing]);
+
+  const handlePullMove = useCallback((e: React.TouchEvent) => {
+    if (!onRefresh || isRefreshing) return;
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    if (scrollTop > 4) { isPullingRef.current = false; return; }
+    const deltaY = e.touches[0].clientY - pullStartY.current;
+    if (deltaY <= 0) {
+      if (isPullingRef.current) {
+        isPullingRef.current = false;
+        setPullY(0);
+        pullYRef.current = 0;
+      }
+      return;
+    }
+    isPullingRef.current = true;
+    const clamped = Math.min(deltaY * 0.5, PULL_MAX_PX);
+    pullYRef.current = clamped;
+    setPullY(clamped);
+  }, [onRefresh, isRefreshing]);
+
+  const handlePullEnd = useCallback(async () => {
+    if (!onRefresh || !isPullingRef.current) {
+      setPullY(0);
+      pullYRef.current = 0;
+      return;
+    }
+    isPullingRef.current = false;
+    const dist = pullYRef.current;
+    setPullY(0);
+    pullYRef.current = 0;
+    if (dist >= PULL_THRESHOLD_PX) {
+      const now = Date.now();
+      if (now - lastRefreshAt.current < PULL_DEBOUNCE_MS) return;
+      lastRefreshAt.current = now;
+      setIsRefreshing(true);
+      try {
+        await onRefresh();
+      } finally {
+        setIsRefreshing(false);
+      }
+    }
+  }, [onRefresh]);
 
   const handleTouchStart = useCallback((id: string, e: React.TouchEvent) => {
     if (!('ontouchstart' in window)) return;
@@ -168,8 +230,37 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
   return (
     <>
       {isMobile ? (
-        /* ── Mobile: date-grouped card list ── */
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+        /* ── Mobile: date-grouped card list with pull-to-refresh ── */
+        <Box
+          data-testid="pull-refresh-container"
+          onTouchStart={handlePullStart}
+          onTouchMove={handlePullMove}
+          onTouchEnd={handlePullEnd}
+          sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}
+        >
+          {(pullY > 0 || isRefreshing) && (
+            <Box
+              data-testid="pull-refresh-indicator"
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: isRefreshing ? 48 : pullY,
+                opacity: isRefreshing ? 1 : Math.min(pullY / PULL_THRESHOLD_PX, 1),
+                transition: pullY > 0 ? 'none' : 'height 0.2s ease, opacity 0.2s ease',
+              }}
+            >
+              {isRefreshing ? (
+                <CircularProgress size={22} />
+              ) : (
+                <CircularProgress
+                  size={22}
+                  variant="determinate"
+                  value={Math.min((pullY / PULL_THRESHOLD_PX) * 100, 100)}
+                />
+              )}
+            </Box>
+          )}
           {grouped.map((group) => (
             <Box key={group.key} sx={{ mb: 2 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1, px: 0.5 }}>

--- a/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
+++ b/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import ExpenseList from '../ExpenseList';
 import { Transaction } from '../../../types';
 import dayjs from 'dayjs';
@@ -144,6 +144,99 @@ describe('ExpenseList (mobile layout)', () => {
     fireEvent.click(screen.getByText('tap to expand note'));
     // After click: expandedNote === t._id, so tap-to-expand hint is hidden
     expect(screen.queryByText('tap to expand note')).not.toBeInTheDocument();
+  });
+});
+
+describe('ExpenseList (mobile pull-to-refresh)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window, 'ontouchstart', { value: () => {}, writable: true, configurable: true });
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true });
+  });
+
+  afterEach(() => {
+    // @ts-expect-error resetting touch simulation
+    delete window.ontouchstart;
+  });
+
+  it('calls onRefresh after pull past threshold', async () => {
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+    render(<ExpenseList {...defaultProps} transactions={[makeTransaction()]} onRefresh={onRefresh} />);
+    const container = screen.getByTestId('pull-refresh-container');
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 140 }] }); // 140 * 0.5 = 70 >= 65 threshold
+    await act(async () => { fireEvent.touchEnd(container); });
+
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not call onRefresh for pull below threshold', async () => {
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+    render(<ExpenseList {...defaultProps} transactions={[makeTransaction()]} onRefresh={onRefresh} />);
+    const container = screen.getByTestId('pull-refresh-container');
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 100 }] }); // 100 * 0.5 = 50 < 65 threshold
+    await act(async () => { fireEvent.touchEnd(container); });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('shows determinate spinner while pulling', () => {
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+    render(<ExpenseList {...defaultProps} transactions={[makeTransaction()]} onRefresh={onRefresh} />);
+    const container = screen.getByTestId('pull-refresh-container');
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 80 }] }); // pulling but not released
+
+    expect(screen.getByTestId('pull-refresh-indicator')).toBeInTheDocument();
+  });
+
+  it('shows indeterminate spinner while refreshing after pull', async () => {
+    let resolveRefresh!: () => void;
+    const onRefresh = jest.fn().mockImplementation(
+      () => new Promise<void>((r) => { resolveRefresh = r; }),
+    );
+    render(<ExpenseList {...defaultProps} transactions={[makeTransaction()]} onRefresh={onRefresh} />);
+    const container = screen.getByTestId('pull-refresh-container');
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 140 }] });
+    fireEvent.touchEnd(container);
+
+    await waitFor(() => expect(screen.getByTestId('pull-refresh-indicator')).toBeInTheDocument());
+
+    await act(async () => { resolveRefresh(); });
+    await waitFor(() => expect(screen.queryByTestId('pull-refresh-indicator')).not.toBeInTheDocument());
+  });
+
+  it('debounces rapid successive pulls', async () => {
+    const mockNow = jest.spyOn(Date, 'now');
+    mockNow.mockReturnValueOnce(1000).mockReturnValueOnce(1500); // 500ms apart < 2000ms debounce
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+    render(<ExpenseList {...defaultProps} transactions={[makeTransaction()]} onRefresh={onRefresh} />);
+    const container = screen.getByTestId('pull-refresh-container');
+
+    // First pull — succeeds
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 140 }] });
+    await act(async () => { fireEvent.touchEnd(container); });
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+
+    // Second pull within debounce window — should be ignored
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 140 }] });
+    await act(async () => { fireEvent.touchEnd(container); });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    mockNow.mockRestore();
+  });
+
+  it('does not show pull indicator on desktop (no onRefresh)', () => {
+    render(<ExpenseList {...defaultProps} transactions={[makeTransaction()]} />);
+    expect(screen.queryByTestId('pull-refresh-indicator')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds pull-to-refresh gesture to the mobile transaction list using native touch events (`touchstart`/`touchmove`/`touchend`) — no external library
- Shows a determinate `CircularProgress` while the user is pulling (fills as they pull), switches to indeterminate spinner during the fetch
- Debounces rapid successive refreshes (2 s cooldown)
- Desktop table is completely unaffected
- Filters and sort order are preserved after refresh (fetch replaces `transactions` state; `filteredTransactions` is derived from the same filter state)

## Implementation notes
- `onRefresh?: () => Promise<void>` prop added to `ExpenseList`
- Pull is only triggered when `window.scrollY ≤ 4` (top of page) and the vertical delta reaches 65 px (with 0.5× resistance, so 130 px of finger travel)
- Touch handlers co-exist with the existing horizontal swipe-to-delete handlers without conflict (different axes)
- `MainLayout` passes `fetchTransactions` directly as `onRefresh`

## Test plan
- [x] `calls onRefresh after pull past threshold`
- [x] `does not call onRefresh for pull below threshold`
- [x] `shows determinate spinner while pulling`
- [x] `shows indeterminate spinner while refreshing after pull`
- [x] `debounces rapid successive pulls`
- [x] `does not show pull indicator on desktop (no onRefresh)`
- [x] Build passes (`yarn build`)
- [ ] Manual: pull down on mobile transaction list → spinner appears → data reloads → filters intact

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)