### PR TITLE
Show item name and description on transaction list

### DIFF
--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -280,7 +280,7 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                               )}
                             </Box>
                             {t.item && t.description && t.description !== t.item && (
-                              <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', lineHeight: 1.2 }}>
+                              <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                                 {t.description}
                               </Typography>
                             )}
@@ -368,9 +368,36 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
               return (
               <TableRow key={t._id} hover>
                 <TableCell sx={{ whiteSpace: 'nowrap' }}>{formatDate(t.date, t.createdAt)}</TableCell>
-                <TableCell sx={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    <span>{t.item ? `${t.item}${t.description && t.description !== t.item ? ` · ${t.description}` : ''}` : t.description}</span>
+                <TableCell sx={{ maxWidth: 280 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                    <Box sx={{ minWidth: 0, flex: 1 }}>
+                      {t.item ? (
+                        <>
+                          <Typography
+                            variant="body2"
+                            fontWeight={600}
+                            sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                          >
+                            {t.item}
+                          </Typography>
+                          {t.description && t.description !== t.item && (
+                            <Typography
+                              variant="caption"
+                              sx={{ color: 'text.secondary', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'block' }}
+                            >
+                              {t.description}
+                            </Typography>
+                          )}
+                        </>
+                      ) : (
+                        <Typography
+                          variant="body2"
+                          sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                        >
+                          {t.description}
+                        </Typography>
+                      )}
+                    </Box>
                     {isRecurring && <RepeatIcon sx={{ fontSize: 13, color: 'text.disabled', flexShrink: 0 }} />}
                     {t.notes && (
                       <Tooltip title={t.notes} placement="top" arrow>


### PR DESCRIPTION
## What
Enhanced the transaction list view to prominently display item names and descriptions on both desktop and mobile layouts.

## Why
Closes #157

## Acceptance Criteria
- [x] Transaction list rows show the item name prominently (desktop: bold, mobile: primary line)
- [x] Transaction list rows show the description (truncated with ellipsis if needed)
- [x] Layout remains clean and readable with the additional fields
- [x] All existing tests pass
- [x] Build succeeds without errors

## Changes
### Desktop View
- Item name displayed as bold body2 typography
- Description shown below item as smaller caption text (when different from item)
- Increased maxWidth from 200px to 280px to accommodate two-line layout
- Proper flex layout ensures responsive truncation

### Mobile View
- Description now truncated with ellipsis for better readability with long descriptions
- Maintains existing card-based layout
- Item name remains primary, description as secondary text

## Test Plan
1. View transactions on desktop with both item and description
2. View transactions on desktop with only description (no item)
3. View transactions on mobile with various item/description combinations
4. Verify long descriptions truncate properly
5. Verify edit/delete functionality still works
6. Run test suite: `yarn test --testPathPattern="ExpenseList"`