### PR TITLE
feat: distinct icons for split vs treat transactions

### DIFF
--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -20,6 +20,8 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import CallSplitIcon from '@mui/icons-material/CallSplit';
+import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
 import EmptyState from '../EmptyState';
 import PaymentIcon from '@mui/icons-material/Payment';
 import NoteIcon from '@mui/icons-material/Notes';
@@ -285,9 +287,15 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                               </Typography>
                             )}
                             {t.participants && t.participants.length > 0 && (
-                              <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled', mt: 0.25, display: 'block' }}>
-                                with {t.participants.join(', ')}
-                              </Typography>
+                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.375, mt: 0.25 }}>
+                                {t.splitBill
+                                  ? <CallSplitIcon sx={{ fontSize: 12, color: '#818cf8' }} />
+                                  : <CardGiftcardIcon sx={{ fontSize: 12, color: '#f472b6' }} />
+                                }
+                                <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled' }}>
+                                  {t.splitBill ? 'split' : 'treat'} · {t.participants.join(', ')}
+                                </Typography>
+                              </Box>
                             )}
                             {t.paymentMethod && (
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
@@ -380,7 +388,15 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                   </Box>
                 </TableCell>
                 <TableCell sx={{ maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'text.secondary', fontSize: '0.8rem' }}>
-                  {t.participants && t.participants.length > 0 ? t.participants.join(', ') : '—'}
+                  {t.participants && t.participants.length > 0 ? (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      {t.splitBill
+                        ? <CallSplitIcon sx={{ fontSize: 14, color: '#818cf8', flexShrink: 0 }} />
+                        : <CardGiftcardIcon sx={{ fontSize: 14, color: '#f472b6', flexShrink: 0 }} />
+                      }
+                      {t.participants.join(', ')}
+                    </Box>
+                  ) : '—'}
                 </TableCell>
                 <TableCell>
                   <Chip label={t.type === 'income' ? 'Income' : 'Expense'} color={t.type === 'income' ? 'success' : 'error'} size="small" />

--- a/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
+++ b/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
@@ -74,10 +74,16 @@ describe('ExpenseList (mobile layout)', () => {
     expect(screen.getAllByText('+HK$200').length).toBeGreaterThan(0);
   });
 
-  it('shows participants in mobile card', () => {
+  it('shows participants with treat icon in mobile card', () => {
     const transactions = [makeTransaction({ participants: ['Alice', 'Bob'] })];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
-    expect(screen.getByText(/with Alice, Bob/)).toBeInTheDocument();
+    expect(screen.getByText(/treat · Alice, Bob/)).toBeInTheDocument();
+  });
+
+  it('shows participants with split icon in mobile card', () => {
+    const transactions = [makeTransaction({ participants: ['Alice', 'Bob'], splitBill: true })];
+    render(<ExpenseList {...defaultProps} transactions={transactions} />);
+    expect(screen.getByText(/split · Alice, Bob/)).toBeInTheDocument();
   });
 
   it('shows daily expense total in group header', () => {


### PR DESCRIPTION
## Summary
- Split transactions show a CallSplit icon (indigo) with "split" label
- Treat transactions show a CardGiftcard icon (pink) with "treat" label
- Applied to both mobile card layout and desktop table "With" column

Closes #156

## Test plan
- [x] All 41 ExpenseList tests pass (1 updated + 1 new test)
- [x] Build succeeds
- [ ] Verify split icon appears for splitBill=true transactions
- [ ] Verify treat/gift icon appears for splitBill=false transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)