### PR TITLE
feat: 3-step onboarding flow for first-time users (#152)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -60,6 +60,7 @@ import ManageItemsPage from './items/ManageItemsPage';
 import NetWorthPage from './networth/NetWorthPage';
 import SettingsPage from './settings/SettingsPage';
 import { useBudgets } from '../hooks/useBudgets';
+import OnboardingFlow, { isOnboardingComplete, markOnboardingComplete } from './onboarding/OnboardingFlow';
 
 function getOwnerFromToken(): string {
   try {
@@ -114,6 +115,18 @@ const MainLayout: React.FC = () => {
   const [scanLoading, setScanLoading] = useState(false);
   const [receiptPrefill, setReceiptPrefill] = useState<ReceiptPrefill | undefined>(undefined);
   const receiptImageUrlRef = useRef<string | null>(null);
+  const [onboardingOpen, setOnboardingOpen] = useState(() => !isOnboardingComplete());
+
+  const handleOnboardingDismiss = useCallback(() => {
+    markOnboardingComplete();
+    setOnboardingOpen(false);
+  }, []);
+
+  const handleOnboardingFab = useCallback(() => {
+    markOnboardingComplete();
+    setOnboardingOpen(false);
+    setAddOpen(true);
+  }, []);
 
   const showSnackbar = (message: string, severity: 'success' | 'error' = 'success') => {
     setSnackbar({ open: true, message, severity });
@@ -940,7 +953,13 @@ const MainLayout: React.FC = () => {
         <ReceiptScanButton onFileSelected={handleScanReceipt} loading={scanLoading} />
         <Fab
           color="primary"
-          onClick={() => setAddOpen(true)}
+          onClick={() => {
+            if (onboardingOpen) {
+              handleOnboardingFab();
+            } else {
+              setAddOpen(true);
+            }
+          }}
           variant={isDesktop ? 'extended' : 'circular'}
           sx={{
             px: isDesktop ? 3 : undefined,
@@ -1024,6 +1043,12 @@ const MainLayout: React.FC = () => {
           {snackbar.message}
         </Alert>
       </Snackbar>
+
+      <OnboardingFlow
+        open={onboardingOpen}
+        onDismiss={handleOnboardingDismiss}
+        onFabClick={handleOnboardingFab}
+      />
 
       <Snackbar
         open={undoSnackbar}

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,258 @@
+import React, { useCallback } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  MobileStepper,
+  Typography,
+  useMediaQuery,
+  useTheme,
+  Drawer,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DocumentScannerIcon from '@mui/icons-material/DocumentScanner';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+
+const ONBOARDING_KEY = 'mf_onboarding_complete';
+
+export const isOnboardingComplete = (): boolean =>
+  localStorage.getItem(ONBOARDING_KEY) === 'true';
+
+export const markOnboardingComplete = (): void =>
+  localStorage.setItem(ONBOARDING_KEY, 'true');
+
+interface Step {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+  highlight?: 'fab' | 'scan';
+}
+
+const STEPS: Step[] = [
+  {
+    icon: <TrendingUpIcon sx={{ fontSize: 48, color: 'primary.main' }} />,
+    title: 'Welcome to Money Flow',
+    body: 'The simplest way to track your spending. Log expenses in seconds, spot patterns instantly, and stay in control of your money.',
+    highlight: undefined,
+  },
+  {
+    icon: (
+      <Box
+        sx={{
+          width: 56,
+          height: 56,
+          borderRadius: '50%',
+          bgcolor: 'primary.main',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          '@media (prefers-reduced-motion: no-preference)': {
+            animation: 'onboarding-fab-pulse 1.6s ease-in-out infinite',
+          },
+          '@keyframes onboarding-fab-pulse': {
+            '0%': { boxShadow: '0 0 0 0 rgba(129,140,248,0.55)' },
+            '60%': { boxShadow: '0 0 0 16px rgba(129,140,248,0)' },
+            '100%': { boxShadow: '0 0 0 0 rgba(129,140,248,0)' },
+          },
+        }}
+      >
+        <AddIcon sx={{ color: '#fff', fontSize: 28 }} />
+      </Box>
+    ),
+    title: 'Record your first expense',
+    body: 'Tap the + button (bottom-right) anytime to log an expense or income. Takes less than 10 seconds.',
+    highlight: 'fab',
+  },
+  {
+    icon: <DocumentScannerIcon sx={{ fontSize: 48, color: 'primary.main' }} />,
+    title: 'Scan a receipt',
+    body: 'Tap the scan button next to +, point your camera at any receipt, and Money Flow auto-fills the amount, merchant, and category for you.',
+    highlight: 'scan',
+  },
+];
+
+interface Props {
+  open: boolean;
+  onDismiss: () => void;
+  onFabClick: () => void;
+}
+
+const StepContent: React.FC<{
+  step: Step;
+  stepIndex: number;
+  totalSteps: number;
+  onNext: () => void;
+  onSkip: () => void;
+  onFabClick: () => void;
+}> = ({ step, stepIndex, totalSteps, onNext, onSkip, onFabClick }) => {
+  const isLast = stepIndex === totalSteps - 1;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        pt: 2,
+        pb: 1,
+        px: 1,
+        gap: 2,
+      }}
+    >
+      {/* Icon */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 64 }}>
+        {step.icon}
+      </Box>
+
+      {/* Title */}
+      <Typography
+        variant="h6"
+        sx={{ fontWeight: 700, fontSize: { xs: '1.1rem', sm: '1.2rem' }, lineHeight: 1.25 }}
+      >
+        {step.title}
+      </Typography>
+
+      {/* Body */}
+      <Typography
+        variant="body2"
+        sx={{ color: 'text.secondary', fontSize: '0.9rem', lineHeight: 1.6, maxWidth: 340 }}
+      >
+        {step.body}
+      </Typography>
+
+      {/* Step 2 CTA: tap the FAB directly */}
+      {step.highlight === 'fab' && (
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={onFabClick}
+          sx={{ mt: 0.5, fontSize: '0.82rem', borderRadius: 2 }}
+          aria-label="Open add expense form"
+        >
+          Try it now
+        </Button>
+      )}
+
+      {/* Stepper dots */}
+      <MobileStepper
+        variant="dots"
+        steps={totalSteps}
+        position="static"
+        activeStep={stepIndex}
+        sx={{
+          bgcolor: 'transparent',
+          justifyContent: 'center',
+          py: 0,
+          '& .MuiMobileStepper-dot': { bgcolor: 'action.disabled' },
+          '& .MuiMobileStepper-dotActive': { bgcolor: 'primary.main' },
+        }}
+        nextButton={null}
+        backButton={null}
+      />
+
+      {/* Actions */}
+      <Box sx={{ display: 'flex', gap: 1.5, width: '100%', maxWidth: 320, mt: 0.5 }}>
+        <Button
+          variant="text"
+          size="small"
+          onClick={onSkip}
+          sx={{ color: 'text.disabled', fontSize: '0.82rem', flexShrink: 0 }}
+          aria-label="Skip onboarding"
+        >
+          Skip
+        </Button>
+        <Button
+          variant="contained"
+          fullWidth
+          onClick={onNext}
+          sx={{ fontSize: '0.9rem', fontWeight: 600, borderRadius: 2 }}
+          aria-label={isLast ? 'Finish onboarding' : 'Next step'}
+        >
+          {isLast ? "Let's go" : 'Next'}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+const OnboardingFlow: React.FC<Props> = ({ open, onDismiss, onFabClick }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [stepIndex, setStepIndex] = React.useState(0);
+
+  const handleNext = useCallback(() => {
+    if (stepIndex < STEPS.length - 1) {
+      setStepIndex((i) => i + 1);
+    } else {
+      onDismiss();
+    }
+  }, [stepIndex, onDismiss]);
+
+  const handleSkip = useCallback(() => {
+    onDismiss();
+  }, [onDismiss]);
+
+  const handleFabClick = useCallback(() => {
+    onFabClick();
+  }, [onFabClick]);
+
+  const content = (
+    <StepContent
+      step={STEPS[stepIndex]}
+      stepIndex={stepIndex}
+      totalSteps={STEPS.length}
+      onNext={handleNext}
+      onSkip={handleSkip}
+      onFabClick={handleFabClick}
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer
+        anchor="bottom"
+        open={open}
+        onClose={handleSkip}
+        PaperProps={{
+          sx: {
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            bgcolor: 'background.paper',
+            pb: 'env(safe-area-inset-bottom)',
+            px: 2,
+            pt: 2,
+          },
+        }}
+        aria-label="Onboarding walkthrough"
+      >
+        {content}
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleSkip}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          bgcolor: 'background.paper',
+          px: 2,
+          pt: 1,
+          pb: 2,
+        },
+      }}
+      aria-label="Onboarding walkthrough"
+    >
+      <DialogContent sx={{ p: 0 }}>{content}</DialogContent>
+    </Dialog>
+  );
+};
+
+export default OnboardingFlow;

--- a/src/components/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OnboardingFlow, { isOnboardingComplete, markOnboardingComplete } from '../OnboardingFlow';
+
+const renderOnboarding = (
+  open = true,
+  onDismiss = jest.fn(),
+  onFabClick = jest.fn()
+) =>
+  render(
+    <OnboardingFlow open={open} onDismiss={onDismiss} onFabClick={onFabClick} />
+  );
+
+describe('OnboardingFlow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('isOnboardingComplete / markOnboardingComplete', () => {
+    it('returns false when key is not set', () => {
+      expect(isOnboardingComplete()).toBe(false);
+    });
+
+    it('returns true after markOnboardingComplete is called', () => {
+      markOnboardingComplete();
+      expect(isOnboardingComplete()).toBe(true);
+    });
+  });
+
+  describe('Step 1 — Welcome', () => {
+    it('renders the welcome title on first open', () => {
+      renderOnboarding();
+      expect(screen.getByText('Welcome to Money Flow')).toBeInTheDocument();
+    });
+
+    it('renders Skip button', () => {
+      renderOnboarding();
+      expect(screen.getByRole('button', { name: /skip/i })).toBeInTheDocument();
+    });
+
+    it('renders Next button', () => {
+      renderOnboarding();
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    });
+
+    it('calls onDismiss when Skip is clicked', () => {
+      const onDismiss = jest.fn();
+      renderOnboarding(true, onDismiss);
+      fireEvent.click(screen.getByRole('button', { name: /skip/i }));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Step 2 — Record expense', () => {
+    it('advances to step 2 after clicking Next', () => {
+      renderOnboarding();
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      expect(screen.getByText('Record your first expense')).toBeInTheDocument();
+    });
+
+    it('shows "Try it now" CTA on step 2', () => {
+      renderOnboarding();
+      fireEvent.click(screen.getByRole('button', { name: /next step/i }));
+      expect(screen.getByRole('button', { name: /open add expense form/i })).toBeInTheDocument();
+    });
+
+    it('calls onFabClick when "Try it now" is clicked', () => {
+      const onFabClick = jest.fn();
+      renderOnboarding(true, jest.fn(), onFabClick);
+      fireEvent.click(screen.getByRole('button', { name: /next step/i }));
+      fireEvent.click(screen.getByRole('button', { name: /open add expense form/i }));
+      expect(onFabClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Step 3 — Scan receipt', () => {
+    const advanceToStep3 = () => {
+      renderOnboarding();
+      fireEvent.click(screen.getByRole('button', { name: /next step/i }));
+      fireEvent.click(screen.getByRole('button', { name: /next step/i }));
+    };
+
+    it('shows scan receipt title on step 3', () => {
+      advanceToStep3();
+      expect(screen.getByText('Scan a receipt')).toBeInTheDocument();
+    });
+
+    it('shows finish button on last step', () => {
+      advanceToStep3();
+      expect(screen.getByRole('button', { name: /finish onboarding/i })).toBeInTheDocument();
+    });
+
+    it('calls onDismiss when finish button is clicked', () => {
+      const onDismiss = jest.fn();
+      renderOnboarding(true, onDismiss);
+      fireEvent.click(screen.getByRole('button', { name: /next step/i }));
+      fireEvent.click(screen.getByRole('button', { name: /next step/i }));
+      fireEvent.click(screen.getByRole('button', { name: /finish onboarding/i }));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Closed state', () => {
+    it('does not render content when open is false', () => {
+      renderOnboarding(false);
+      expect(screen.queryByText('Welcome to Money Flow')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds a 3-step onboarding overlay for first-time users after SSO sign-up.

- **OnboardingFlow** component (`src/components/onboarding/OnboardingFlow.tsx`) renders as a bottom Drawer on mobile and a centered Dialog on desktop.
- **Step 1** — "Welcome to Money Flow": brief value prop with TrendingUp icon.
- **Step 2** — "Record your first expense": animated pulsing FAB icon + "Try it now" button that dismisses the overlay and opens AddExpenseModal.
- **Step 3** — "Scan a receipt": DocumentScanner icon + explanation of auto-fill.
- Every step has a **Skip** button and a **Next / Let's go** button.
- Gated by `localStorage` key `mf_onboarding_complete` — shows only once per browser.
- If the user taps the real FAB while onboarding is open, the overlay is dismissed and AddExpenseModal opens.

## Why
Closes #152

## Acceptance Criteria
- [x] After first sign-in (new account), show a 3-step welcome overlay/bottom sheet
- [x] Step 1: "Welcome to Money Flow" — brief value prop
- [x] Step 2: "Record your first expense" — highlight the FAB with a pulse animation
- [x] Step 3: "Scan a receipt" — point to scan button, explain auto-fill
- [x] "Skip" button on every step
- [x] Onboarding marked complete in localStorage so it only shows once
- [x] If user taps FAB during onboarding, dismiss overlay and open AddExpenseModal
- [x] MUI components (Dialog/Drawer, MobileStepper, Button)
- [x] Dark theme consistent styling

## Test Plan
1. Clear localStorage (`localStorage.removeItem('mf_onboarding_complete')`) in DevTools.
2. Navigate to `/` while logged in — bottom sheet (mobile) or dialog (desktop) should appear.
3. Click Next through all 3 steps — verify titles and content.
4. Click Skip on any step — overlay closes and doesn't reappear on refresh.
5. Repeat step 1, then click "Try it now" on step 2 — AddExpenseModal should open.
6. Repeat step 1, then tap the real FAB (+) — overlay should close and AddExpenseModal should open.
7. Refresh after completing — overlay should NOT reappear.

13 unit tests: `yarn test --testPathPattern=OnboardingFlow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)