### PR TITLE
feat: compact add/edit form — collapsible numpad + more options

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -16,6 +16,7 @@ import {
   Chip,
   ToggleButtonGroup,
   ToggleButton,
+  Collapse,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import TodayIcon from '@mui/icons-material/Today';
@@ -24,6 +25,7 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { TransactionRequest, TransactionType, PaymentMethod } from '../../types';
 import { ReceiptConfidence } from '../../services/api';
@@ -99,6 +101,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
   const [error, setError] = useState('');
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
   const [pendingSubmit, setPendingSubmit] = useState<{ data: Omit<TransactionRequest, 'owner'>; addAnother: boolean } | null>(null);
+  const [showMore, setShowMore] = useState(false);
 
   // Apply receipt OCR prefill when the modal opens with data
   useEffect(() => {
@@ -406,12 +409,13 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
           );
         })()}
 
-        {/* Amount — calculator keypad with FX support */}
+        {/* Amount — compact calculator with expandable grid */}
         <NumPad
           value={amount}
           onChange={setAmount}
           fxSymbol={txCurrency !== 'HKD' ? CURRENCY_SYMBOLS[txCurrency] : undefined}
           fxRate={fxRate}
+          compact
         />
 
         {/* Date — quick chips */}
@@ -452,90 +456,109 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
           )}
         </Box>
 
-        <ParticipantPicker value={participants} onChange={setParticipants} suggestions={knownParticipants} />
-
-        {participants.length > 0 && (
-          <Box sx={{ mt: 1, mb: 0.5 }}>
-            <ToggleButtonGroup
-              value={splitBillMode}
-              exclusive
-              onChange={(_, v) => { if (v) setSplitBillMode(v); }}
-              size="small"
-              sx={{ height: 30 }}
-            >
-              <ToggleButton value="split" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
-                Split bill
-              </ToggleButton>
-              <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
-                My treat
-              </ToggleButton>
-            </ToggleButtonGroup>
-          </Box>
-        )}
-
-        <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
-
-        {/* Notes */}
-        <Box sx={{ mt: 1.5 }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.75 }}>
-            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-              Notes (optional)
-            </Typography>
-            <Typography variant="caption" sx={{ fontSize: '0.68rem', color: notes.length > 450 ? (notes.length >= 500 ? 'error.main' : 'warning.main') : 'text.disabled' }}>
-              {notes.length}/500
-            </Typography>
-          </Box>
-          <TextField
-            multiline
-            minRows={2}
-            maxRows={4}
-            fullWidth
-            size="small"
-            placeholder="Add a note..."
-            value={notes}
-            onChange={(e) => setNotes(e.target.value.slice(0, 500))}
-            inputProps={{ maxLength: 500 }}
-            sx={{ '& .MuiInputBase-root': { fontSize: '0.85rem' } }}
-          />
+        {/* Collapsible secondary fields */}
+        <Box
+          onClick={() => setShowMore((v) => !v)}
+          sx={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5,
+            mt: 1, py: 0.75, cursor: 'pointer', borderRadius: 2,
+            bgcolor: 'rgba(148,163,184,0.04)', border: '1px solid rgba(148,163,184,0.1)',
+            userSelect: 'none', '&:hover': { bgcolor: 'rgba(148,163,184,0.08)' },
+          }}
+        >
+          <Typography variant="caption" sx={{ fontSize: '0.72rem', color: 'text.secondary', letterSpacing: '0.04em' }}>
+            {showMore ? 'Less options' : 'More options'}
+            {!showMore && (participants.length > 0 || paymentMethod || notes || isRecurring) && ' \u00b7'}
+          </Typography>
+          <ExpandMoreIcon sx={{ fontSize: 18, color: 'text.secondary', transition: 'transform 0.2s', transform: showMore ? 'rotate(180deg)' : 'rotate(0)' }} />
         </Box>
 
-        {/* Recurring toggle */}
-        <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-          <Chip
-            icon={<RepeatIcon sx={{ fontSize: '14px !important' }} />}
-            label="Repeat"
-            size="small"
-            clickable
-            onClick={() => setIsRecurring((v) => !v)}
-            sx={{
-              fontSize: '0.75rem',
-              height: 30,
-              bgcolor: isRecurring ? (isDark ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.22)') : 'rgba(148,163,184,0.08)',
-              color: isRecurring ? theme.palette.primary.main : 'text.secondary',
-              border: '1px solid',
-              borderColor: isRecurring ? (isDark ? 'rgba(129,140,248,0.4)' : 'rgba(99,102,241,0.5)') : 'rgba(148,163,184,0.12)',
-              fontWeight: isRecurring ? 600 : 400,
-            }}
-          />
-          {isRecurring && (['monthly', 'weekly', 'daily'] as RecurringFrequency[]).map((f) => (
+        <Collapse in={showMore}>
+          <ParticipantPicker value={participants} onChange={setParticipants} suggestions={knownParticipants} />
+
+          {participants.length > 0 && (
+            <Box sx={{ mt: 1, mb: 0.5 }}>
+              <ToggleButtonGroup
+                value={splitBillMode}
+                exclusive
+                onChange={(_, v) => { if (v) setSplitBillMode(v); }}
+                size="small"
+                sx={{ height: 30 }}
+              >
+                <ToggleButton value="split" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  Split bill
+                </ToggleButton>
+                <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  My treat
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Box>
+          )}
+
+          <PaymentMethodPicker value={paymentMethod} onChange={setPaymentMethod} />
+
+          {/* Notes */}
+          <Box sx={{ mt: 1 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.75 }}>
+              <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+                Notes (optional)
+              </Typography>
+              <Typography variant="caption" sx={{ fontSize: '0.68rem', color: notes.length > 450 ? (notes.length >= 500 ? 'error.main' : 'warning.main') : 'text.disabled' }}>
+                {notes.length}/500
+              </Typography>
+            </Box>
+            <TextField
+              multiline
+              minRows={2}
+              maxRows={4}
+              fullWidth
+              size="small"
+              placeholder="Add a note..."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value.slice(0, 500))}
+              inputProps={{ maxLength: 500 }}
+              sx={{ '& .MuiInputBase-root': { fontSize: '0.85rem' } }}
+            />
+          </Box>
+
+          {/* Recurring toggle */}
+          <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
             <Chip
-              key={f}
-              label={f.charAt(0).toUpperCase() + f.slice(1)}
+              icon={<RepeatIcon sx={{ fontSize: '14px !important' }} />}
+              label="Repeat"
               size="small"
               clickable
-              onClick={() => setFrequency(f)}
+              onClick={() => setIsRecurring((v) => !v)}
               sx={{
-                fontSize: '0.72rem',
-                height: 28,
-                bgcolor: frequency === f ? (isDark ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.22)') : 'rgba(148,163,184,0.06)',
-                color: frequency === f ? theme.palette.primary.main : 'text.disabled',
+                fontSize: '0.75rem',
+                height: 30,
+                bgcolor: isRecurring ? (isDark ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.22)') : 'rgba(148,163,184,0.08)',
+                color: isRecurring ? theme.palette.primary.main : 'text.secondary',
                 border: '1px solid',
-                borderColor: frequency === f ? (isDark ? 'rgba(129,140,248,0.4)' : 'rgba(99,102,241,0.5)') : 'rgba(148,163,184,0.1)',
-                fontWeight: frequency === f ? 700 : 400,
+                borderColor: isRecurring ? (isDark ? 'rgba(129,140,248,0.4)' : 'rgba(99,102,241,0.5)') : 'rgba(148,163,184,0.12)',
+                fontWeight: isRecurring ? 600 : 400,
               }}
             />
-          ))}
-        </Box>
+            {isRecurring && (['monthly', 'weekly', 'daily'] as RecurringFrequency[]).map((f) => (
+              <Chip
+                key={f}
+                label={f.charAt(0).toUpperCase() + f.slice(1)}
+                size="small"
+                clickable
+                onClick={() => setFrequency(f)}
+                sx={{
+                  fontSize: '0.72rem',
+                  height: 28,
+                  bgcolor: frequency === f ? (isDark ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.22)') : 'rgba(148,163,184,0.06)',
+                  color: frequency === f ? theme.palette.primary.main : 'text.disabled',
+                  border: '1px solid',
+                  borderColor: frequency === f ? (isDark ? 'rgba(129,140,248,0.4)' : 'rgba(99,102,241,0.5)') : 'rgba(148,163,184,0.1)',
+                  fontWeight: frequency === f ? 700 : 400,
+                }}
+              />
+            ))}
+          </Box>
+        </Collapse>
       </DialogContent>
 
       <DialogActions sx={{ p: 2, pt: 1, pb: isMobile ? 'calc(16px + env(safe-area-inset-bottom))' : 2, gap: 1 }}>

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -297,12 +297,13 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
           return <DescriptionPicker value={description} onChange={setDescription} suggestions={suggestions} />;
         })()}
 
-        {/* Amount — calculator keypad with FX support */}
+        {/* Amount — compact calculator with expandable grid */}
         <NumPad
           value={amount}
           onChange={setAmount}
           fxSymbol={txCurrency !== 'HKD' ? CURRENCY_SYMBOLS[txCurrency] : undefined}
           fxRate={fxRate}
+          compact
         />
 
         {/* Date — quick chips */}

--- a/src/components/expenses/NumPad.tsx
+++ b/src/components/expenses/NumPad.tsx
@@ -1,14 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography, ButtonBase } from '@mui/material';
+import { Box, Typography, ButtonBase, Collapse, TextField, InputAdornment } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import BackspaceOutlinedIcon from '@mui/icons-material/BackspaceOutlined';
 import SwapVertIcon from '@mui/icons-material/SwapVert';
+import CalculateOutlinedIcon from '@mui/icons-material/CalculateOutlined';
 
 interface Props {
   value: string;           // Always HKD — parent stores HKD
   onChange: (hkdValue: string) => void;
   fxSymbol?: string;       // e.g. 'CA$' — if set, FX swap available
   fxRate?: number;         // HKD per 1 foreign unit
+  compact?: boolean;       // Hide calculator grid by default, show text input
 }
 
 function compute(a: number, b: number, op: string): number {
@@ -25,7 +27,7 @@ function fmt(n: number): string {
   return String(Math.round(n * 100) / 100);
 }
 
-const NumPad: React.FC<Props> = ({ value, onChange, fxSymbol, fxRate }) => {
+const NumPad: React.FC<Props> = ({ value, onChange, fxSymbol, fxRate, compact }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const isFxAvailable = !!fxSymbol && !!fxRate;
@@ -35,6 +37,7 @@ const NumPad: React.FC<Props> = ({ value, onChange, fxSymbol, fxRate }) => {
   const [storedValue, setStoredValue] = useState<number | null>(null);
   const [pendingOp, setPendingOp] = useState<string | null>(null);
   const [waitForNext, setWaitForNext] = useState(false);
+  const [showGrid, setShowGrid] = useState(false);
 
   // On currency switch, default to FX mode when FX available, re-init fxInput
   useEffect(() => {
@@ -149,53 +152,94 @@ const NumPad: React.FC<Props> = ({ value, onChange, fxSymbol, fxRate }) => {
     '&:active': { transform: 'scale(0.95)' },
   };
 
-  return (
-    <Box>
-      {/* Display */}
-      <Box sx={{ mb: 1, borderRadius: 2, bgcolor: 'rgba(148,163,184,0.05)', border: '1px solid rgba(148,163,184,0.1)', overflow: 'hidden' }}>
-        {pendingOp && (
-          <Typography sx={{ fontSize: '0.65rem', color: theme.palette.primary.main, px: 2, pt: 1, letterSpacing: '0.04em', textAlign: 'center' }}>
-            {storedValue} {pendingOp}
+  // Compact mode: text input + calc toggle instead of large display
+  const compactAmountInput = compact ? (
+    <Box sx={{ mb: 1 }}>
+      <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.72rem', letterSpacing: '0.08em', textTransform: 'uppercase', display: 'block', mb: 0.5 }}>
+        Amount
+      </Typography>
+      <TextField
+        value={displayStr || ''}
+        onChange={(e) => {
+          const v = e.target.value.replace(/[^0-9.]/g, '');
+          if (inputInFx) { setFxInput(v); emitHkd(v); } else onChange(v);
+        }}
+        placeholder="0"
+        size="small"
+        fullWidth
+        inputProps={{ inputMode: 'decimal', style: { fontSize: '1.3rem', fontWeight: 700, letterSpacing: '-0.02em' } }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Typography sx={{ fontSize: '0.85rem', color: 'text.secondary', fontWeight: 500 }}>{displaySymbol}</Typography>
+            </InputAdornment>
+          ),
+          endAdornment: (
+            <InputAdornment position="end">
+              <ButtonBase
+                onClick={() => setShowGrid((v) => !v)}
+                sx={{ p: 0.5, borderRadius: 1, bgcolor: showGrid ? (isDark ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.22)') : 'transparent' }}
+              >
+                <CalculateOutlinedIcon sx={{ fontSize: 20, color: showGrid ? theme.palette.primary.main : 'text.disabled' }} />
+              </ButtonBase>
+            </InputAdornment>
+          ),
+        }}
+        sx={{ '& .MuiOutlinedInput-root': { borderRadius: 2 } }}
+      />
+      {isFxAvailable && (
+        <Box
+          onClick={handleSwap}
+          sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5, cursor: 'pointer' }}
+        >
+          <Typography sx={{ fontSize: '0.68rem', color: 'text.disabled' }}>
+            {hintSymbol}{hintVal ?? '0'}
           </Typography>
-        )}
+          <SwapVertIcon sx={{ fontSize: 14, color: inputInFx ? theme.palette.primary.main : 'text.disabled' }} />
+        </Box>
+      )}
+    </Box>
+  ) : null;
 
-        {/* Primary — what user is entering */}
-        <Box sx={{ px: 2, pt: pendingOp ? 0.5 : 1.5, pb: isFxAvailable ? 0.5 : 1.5, textAlign: 'center' }}>
-          <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.72rem', letterSpacing: '0.08em', textTransform: 'uppercase', display: 'block', mb: 0.25 }}>
-            Amount
-          </Typography>
-          <Typography variant="h3" fontWeight={700} sx={{ letterSpacing: '-0.03em', lineHeight: 1.1, color: displayStr ? 'text.primary' : 'text.disabled' }}>
-            <span style={{ fontSize: '1rem', fontWeight: 500, opacity: 0.6 }}>{displaySymbol}</span>
-            {displayNum}
+  const fullDisplay = !compact ? (
+    <Box sx={{ mb: 1, borderRadius: 2, bgcolor: 'rgba(148,163,184,0.05)', border: '1px solid rgba(148,163,184,0.1)', overflow: 'hidden' }}>
+      {pendingOp && (
+        <Typography sx={{ fontSize: '0.65rem', color: theme.palette.primary.main, px: 2, pt: 1, letterSpacing: '0.04em', textAlign: 'center' }}>
+          {storedValue} {pendingOp}
+        </Typography>
+      )}
+      <Box sx={{ px: 2, pt: pendingOp ? 0.5 : 1.5, pb: isFxAvailable ? 0.5 : 1.5, textAlign: 'center' }}>
+        <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.72rem', letterSpacing: '0.08em', textTransform: 'uppercase', display: 'block', mb: 0.25 }}>
+          Amount
+        </Typography>
+        <Typography variant="h3" fontWeight={700} sx={{ letterSpacing: '-0.03em', lineHeight: 1.1, color: displayStr ? 'text.primary' : 'text.disabled' }}>
+          <span style={{ fontSize: '1rem', fontWeight: 500, opacity: 0.6 }}>{displaySymbol}</span>
+          {displayNum}
+        </Typography>
+      </Box>
+      {isFxAvailable && (
+        <Box
+          sx={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1, py: 0.75,
+            borderTop: '1px solid rgba(148,163,184,0.08)', cursor: 'pointer', bgcolor: 'rgba(148,163,184,0.03)',
+            '&:active': { bgcolor: isDark ? 'rgba(129,140,248,0.08)' : 'rgba(99,102,241,0.1)' },
+          }}
+          onClick={handleSwap}
+        >
+          <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled' }}>{hintSymbol}{hintVal ?? '0'}</Typography>
+          <SwapVertIcon sx={{ fontSize: 16, color: inputInFx ? theme.palette.primary.main : 'text.disabled' }} />
+          <Typography sx={{ fontSize: '0.65rem', color: inputInFx ? theme.palette.primary.main : 'text.disabled', fontWeight: 600 }}>
+            {inputInFx ? `Enter in ${fxSymbol}` : 'Enter in HK$'}
           </Typography>
         </Box>
+      )}
+    </Box>
+  ) : null;
 
-        {/* Swap row — only when FX available */}
-        {isFxAvailable && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 1,
-              py: 0.75,
-              borderTop: '1px solid rgba(148,163,184,0.08)',
-              cursor: 'pointer',
-              bgcolor: 'rgba(148,163,184,0.03)',
-              '&:active': { bgcolor: isDark ? 'rgba(129,140,248,0.08)' : 'rgba(99,102,241,0.1)' },
-            }}
-            onClick={handleSwap}
-          >
-            <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled' }}>
-              {hintSymbol}{hintVal ?? '0'}
-            </Typography>
-            <SwapVertIcon sx={{ fontSize: 16, color: inputInFx ? theme.palette.primary.main : 'text.disabled' }} />
-            <Typography sx={{ fontSize: '0.65rem', color: inputInFx ? theme.palette.primary.main : 'text.disabled', fontWeight: 600 }}>
-              {inputInFx ? `Enter in ${fxSymbol}` : 'Enter in HK$'}
-            </Typography>
-          </Box>
-        )}
-      </Box>
+  return (
+    <Box>
+      {compactAmountInput}
+      {fullDisplay}
 
       {/* Quick amount presets */}
       <Box sx={{ display: 'flex', gap: 0.75, mb: 0.75 }}>
@@ -231,7 +275,8 @@ const NumPad: React.FC<Props> = ({ value, onChange, fxSymbol, fxRate }) => {
         ))}
       </Box>
 
-      {/* Grid */}
+      {/* Grid — collapsible in compact mode */}
+      <Collapse in={compact ? showGrid : true}>
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 0.75 }}>
         {['7','8','9'].map(k => (
           <ButtonBase key={k} onClick={() => handleDigit(k)} sx={{ ...btnBase, bgcolor: 'rgba(148,163,184,0.06)', border: '1px solid rgba(148,163,184,0.1)', '&:active': { bgcolor: isDark ? 'rgba(129,140,248,0.15)' : 'rgba(99,102,241,0.18)', transform: 'scale(0.95)' } }}>
@@ -280,6 +325,7 @@ const NumPad: React.FC<Props> = ({ value, onChange, fxSymbol, fxRate }) => {
           <Typography fontWeight={700} sx={{ fontSize: '1.1rem', color: '#fff' }}>=</Typography>
         </ButtonBase>
       </Box>
+      </Collapse>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- **Compact NumPad**: New `compact` prop replaces the always-visible calculator grid with a text input (`inputMode="decimal"`) + calculator icon toggle. Quick presets (50/100/200/500) stay always visible. Full calc grid available via expand.
- **Add modal "More options"**: Participants, Payment Method, Notes, and Recurring wrapped in a collapsible section (same pattern as edit modal)
- **Edit modal**: Also uses compact NumPad now

Saves ~450px vertical space. Common case (item + amount + date) fits in one mobile viewport.

Closes #166

## Test plan
- [x] 109 tests pass (AddExpenseModal + EditExpenseModal + NumPad)
- [x] Build succeeds
- [ ] Add form fits on mobile without scrolling for common case
- [ ] Calculator grid expands on calc icon tap
- [ ] "More options" expands to show participants, payment, notes, recurring
- [ ] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)