### PR TITLE
feat: move Item Presets into Settings page

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -28,7 +28,6 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
-import CategoryIcon from '@mui/icons-material/Category';
 import SettingsIcon from '@mui/icons-material/Settings';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
@@ -56,7 +55,6 @@ import QuickExpenseInput from './expenses/QuickExpenseInput';
 import { useFxRates } from '../hooks/useFxRates';
 import { Currency } from '../hooks/useFxRates';
 import { useRecurring } from '../hooks/useRecurring';
-import ManageItemsPage from './items/ManageItemsPage';
 import NetWorthPage from './networth/NetWorthPage';
 import SettingsPage from './settings/SettingsPage';
 import { useBudgets } from '../hooks/useBudgets';
@@ -485,7 +483,6 @@ const MainLayout: React.FC = () => {
   const navItems = [
     { label: 'Home', icon: <DashboardIcon /> },
     { label: 'Transactions', icon: <ReceiptLongIcon /> },
-    { label: 'Items', icon: <CategoryIcon /> },
     { label: 'Net Worth', icon: <AccountBalanceIcon /> },
     { label: 'Settings', icon: <SettingsIcon /> },
   ];
@@ -895,13 +892,11 @@ const MainLayout: React.FC = () => {
             </>
           )}
 
-          {activeTab === 2 && <ManageItemsPage />}
-
-          {activeTab === 3 && (
+          {activeTab === 2 && (
             <NetWorthPage convert={convert} symbol={symbol} />
           )}
 
-          {activeTab === 4 && (
+          {activeTab === 3 && (
             <SettingsPage
               currency={currency}
               onCurrencyChange={(c: Currency) => setCurrency(c)}
@@ -931,7 +926,6 @@ const MainLayout: React.FC = () => {
         >
           <BottomNavigationAction label="Home" icon={<DashboardIcon />} />
           <BottomNavigationAction label="Txns" icon={<ReceiptLongIcon />} />
-          <BottomNavigationAction label="Items" icon={<CategoryIcon />} />
           <BottomNavigationAction label="Worth" icon={<AccountBalanceIcon />} />
           <BottomNavigationAction label="Settings" icon={<SettingsIcon />} />
         </BottomNavigation>

--- a/src/components/__tests__/MainLayout.test.tsx
+++ b/src/components/__tests__/MainLayout.test.tsx
@@ -152,12 +152,12 @@ describe('MainLayout', () => {
     });
   });
 
-  it('navigates to Items tab when clicked', async () => {
+  it('shows Item Presets in Settings tab', async () => {
     renderMainLayout();
     await waitFor(() => screen.getAllByText('Home').length > 0);
-    const itemsLabels = screen.getAllByText('Items');
+    const settingsLabels = screen.getAllByText('Settings');
     await act(async () => {
-      fireEvent.click(itemsLabels[itemsLabels.length - 1]);
+      fireEvent.click(settingsLabels[settingsLabels.length - 1]);
     });
     await waitFor(() => {
       expect(screen.getByText('Item Presets')).toBeInTheDocument();

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -29,7 +29,9 @@ import { useCurrencyPreferences } from '../../hooks/useCurrencyPreferences';
 import { useBudgets, BUDGET_CATEGORIES } from '../../hooks/useBudgets';
 import { useRecurring, RecurringItem } from '../../hooks/useRecurring';
 import { ITEM_PRESETS } from '../expenses/ItemPicker';
+import { useItemPresets } from '../../hooks/useItemPresets';
 import { TransactionType } from '../../types';
+import ManageItemsPage from '../items/ManageItemsPage';
 import { useThemePreference } from '../../ThemeContext';
 import { ThemePreference } from '../../theme';
 
@@ -306,6 +308,13 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
               </Box>
             </Box>
           )}
+        </Box>
+      </Box>
+
+      {/* Item Presets */}
+      <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>
+        <Box sx={{ px: 2, py: 1.5 }}>
+          <ManageItemsPage />
         </Box>
       </Box>
 


### PR DESCRIPTION
## Summary
- Moved Item Presets from dedicated "Items" tab into the Settings page
- Removed Items tab from bottom navigation (5 → 4 tabs: Home, Txns, Worth, Settings)
- All existing Item Presets CRUD functionality preserved
- Cleaner mobile navigation

Closes #165

## Test plan
- [x] Build succeeds
- [x] Updated test to find Item Presets in Settings tab
- [ ] Verify 4-tab bottom nav on mobile
- [ ] Verify Item Presets section appears in Settings
- [ ] Verify edit/delete presets still works from Settings
- [ ] Verify add transaction form still auto-fills from presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)