### PR TITLE
fix: unskip duplicate detection tests

### DIFF
--- a/src/components/expenses/__tests__/AddExpenseModal.test.tsx
+++ b/src/components/expenses/__tests__/AddExpenseModal.test.tsx
@@ -380,7 +380,7 @@ describe('AddExpenseModal', () => {
     });
   });
 
-  describe.skip('duplicate detection (409 response)', () => {
+  describe('duplicate detection (409 response)', () => {
     const fillAndSubmit = async (onSubmit: jest.Mock, saveButton = /^save$/i) => {
       render(<AddExpenseModal {...defaultProps} onSubmit={onSubmit} />);
       const descInput = screen.getByPlaceholderText(/McDonald/i) as HTMLInputElement;


### PR DESCRIPTION
## Summary
- Removed `describe.skip` from duplicate detection (409 response) test suite
- All 6 tests pass reliably (3s each)

The original hang was likely caused by a race condition in a prior code version. Current code resolves the async flow correctly.

Closes #116

## Test plan
- [x] All 6 duplicate detection tests pass
- [x] No timeout issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)