### PR TITLE
fix: remove debug console.log that leaks expense data

### DIFF
--- a/src/axiosInstance.ts
+++ b/src/axiosInstance.ts
@@ -16,21 +16,11 @@ axiosInstance.interceptors.request.use((config) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
-  // Log expense requests with participants for debugging
-  if (config.url?.includes('/expenses') && config.data) {
-    console.log('[DEBUG] Expense request:', { url: config.url, method: config.method, data: config.data });
-  }
   return config;
 });
 
 axiosInstance.interceptors.response.use(
-  (res) => {
-    // Log expense responses for debugging
-    if (res.config.url?.includes('/expenses') && res.data) {
-      console.log('[DEBUG] Expense response:', { url: res.config.url, status: res.status, data: res.data });
-    }
-    return res;
-  },
+  (res) => res,
   (err) => {
     if (err.response?.status === 401) {
       clearToken();

--- a/src/components/expenses/ParticipantPicker.tsx
+++ b/src/components/expenses/ParticipantPicker.tsx
@@ -18,7 +18,6 @@ const ParticipantPicker: React.FC<Props> = ({ value, onChange, suggestions = [] 
     const name = input.trim();
     if (!name) return;
     if (value.some((n) => n.toLowerCase() === name.toLowerCase())) { setInput(''); return; }
-    console.log('[DEBUG] ParticipantPicker: Adding participant', { current: value, adding: name, newArray: [...value, name] });
     onChange([...value, name]);
     setInput('');
   };


### PR DESCRIPTION
## Summary
- Removed debug `console.log` from `axiosInstance.ts` interceptors (request + response)
- Removed debug `console.log` from `ParticipantPicker.tsx`
- These logged sensitive expense data (amounts, descriptions, participants) unconditionally in production

Closes #178

## Test plan
- [x] No console.log statements remain in non-test source files
- [ ] Verify no expense data appears in browser console during normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)