### PR TITLE
Fix: fetch all transactions with pagination

### DIFF
--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -28,11 +28,25 @@ beforeEach(() => {
 });
 
 describe('api service', () => {
-  it('getExpenses calls GET /api/expenses and returns data', async () => {
-    (mockedAxios.get as jest.Mock).mockResolvedValue({ data: { data: [sampleExpense] } });
+  it('getExpenses calls GET /api/expenses with pagination and returns all data', async () => {
+    (mockedAxios.get as jest.Mock).mockResolvedValue({ data: { data: [sampleExpense], page: 1, pages: 1 } });
     const result = await getExpenses();
-    expect(mockedAxios.get).toHaveBeenCalledWith('/api/expenses');
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/expenses', { params: { limit: 100, page: 1 } });
     expect(result).toEqual([sampleExpense]);
+  });
+
+  it('getExpenses fetches all pages when pages > 1', async () => {
+    const expense1 = { ...sampleExpense, _id: '1' };
+    const expense2 = { ...sampleExpense, _id: '2' };
+    const expense3 = { ...sampleExpense, _id: '3' };
+    (mockedAxios.get as jest.Mock)
+      .mockResolvedValueOnce({ data: { data: [expense1, expense2], page: 1, pages: 2 } })
+      .mockResolvedValueOnce({ data: { data: [expense3], page: 2, pages: 2 } });
+    const result = await getExpenses();
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(1, '/api/expenses', { params: { limit: 100, page: 1 } });
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(2, '/api/expenses', { params: { limit: 100, page: 2 } });
+    expect(result).toEqual([expense1, expense2, expense3]);
   });
 
   it('getExpense calls GET /api/expenses/:id', async () => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '../axiosInstance';
-import { TransactionRequest } from '../types';
+import { Transaction, TransactionRequest } from '../types';
 import { setToken } from './auth';
 import { ThemePreference } from '../theme';
 
@@ -42,8 +42,21 @@ export const patchUserPreferences = async (prefs: { themePreference: ThemePrefer
 
 // Expenses
 export const getExpenses = async () => {
-  const res = await axiosInstance.get('/api/expenses');
-  return res.data.data; // API returns { data, total, page, pages }
+  const allExpenses: Transaction[] = [];
+  let page = 1;
+  let hasMorePages = true;
+
+  while (hasMorePages) {
+    const res = await axiosInstance.get('/api/expenses', {
+      params: { limit: 100, page },
+    });
+    allExpenses.push(...res.data.data);
+    const { pages } = res.data;
+    hasMorePages = page < pages;
+    page++;
+  }
+
+  return allExpenses;
 };
 
 export const getExpense = async (id: string) => {


### PR DESCRIPTION
## What
The `getExpenses()` function now automatically fetches all pages of transactions instead of only returning page 1. With a limit of 100 per page, users with more than 100 transactions will no longer lose access to historical data.

## Why
Closes #177

## Acceptance Criteria
- [x] API request includes `limit=100` query parameter
- [x] Pagination loop handles multiple pages (`pages > 1`)
- [x] All transaction pages are concatenated and returned
- [x] Tests cover single-page and multi-page scenarios
- [x] Build succeeds with no TypeScript errors

## Test Plan
1. Review the test cases in `src/services/__tests__/api.test.ts`:
   - Single page scenario (pages=1)
   - Multi-page scenario (pages=2, with 2 requests)
2. Manual: With a test user who has >100 transactions, verify the app loads all of them
3. Run: `yarn test -- api.test.ts` to verify tests pass