### PR TITLE
fix: remove broken Vercel deploy step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,6 @@ jobs:
           REACT_APP_API_URL: https://money-flow-backend-production.up.railway.app
           REACT_APP_VERSION: 1.0.0
           CI: false
-      - name: Deploy to Vercel
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: npx vercel --prod --yes --token ${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Notify Telegram on success
         if: success()
         run: |


### PR DESCRIPTION
## Summary
Removes the Vercel deploy step added in #142 that has been **failing every CI run on main** since it was merged. The required secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) were never added.

## Root cause
PR #142 added a CI-based Vercel deploy step and also disabled the Vercel Git integration (`live: false`). The secrets were never configured, so:
- CI deploy step crashes → entire job marked failed
- Vercel Git integration disabled → no auto-deploy
- **Result: nothing has been deployed since PR #140**

## Fix
- Remove the broken deploy step from CI
- Re-enable Vercel Git integration from dashboard (manual step — Settings > Git > Connected Git Repository)

## After merge
Once this is merged and Vercel Git integration is re-enabled, all the accumulated changes (~15 PRs) will deploy automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)