### PR TITLE
fix: make Telegram notify non-blocking + fix release notes escaping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,19 @@ jobs:
           REACT_APP_VERSION: 1.0.0
           CI: false
       - name: Notify Telegram on success
-        if: success()
+        if: success() && secrets.TELEGRAM_BOT_TOKEN != ''
+        continue-on-error: true
         run: |
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="CI passed: money-flow-frontend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+            -d text="CI passed: money-flow-frontend (${{ github.ref_name }})"
       - name: Notify Telegram on failure
-        if: failure()
+        if: failure() && secrets.TELEGRAM_BOT_TOKEN != ''
+        continue-on-error: true
         run: |
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="CI failed: money-flow-frontend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+            -d text="CI failed: money-flow-frontend (${{ github.ref_name }})"
 
   release:
     needs: build
@@ -125,14 +127,12 @@ jobs:
           [ -n "$CHORES" ] && NOTES+=$'\n'"### 🧹 Chores"$'\n'"$CHORES"$'\n'
           [ -n "$DIFF_LINE" ] && NOTES+=$'\n'"---"$'\n'"$DIFF_LINE"
 
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" > /tmp/release-notes.md
       - name: Create GitHub release
         if: steps.version.outputs.skip != 'true'
         run: |
           gh release create "v${{ steps.version.outputs.version }}" \
             --title "v${{ steps.version.outputs.version }} — money-flow-frontend" \
-            --notes "${{ steps.changelog.outputs.notes }}"
+            --notes-file /tmp/release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Telegram notify steps: added `continue-on-error: true` so a missing/expired token doesn't fail the entire CI run
- Telegram notify steps: skip entirely if `TELEGRAM_BOT_TOKEN` secret is empty
- Telegram notify steps: removed commit message from text (shell escaping issues with parentheses)
- Release job: write changelog to a file and use `--notes-file` instead of inline `--notes` which broke on special chars like `(#142)`

Closes #127

## Test plan
- [ ] CI passes on main even without valid Telegram token
- [ ] Release job creates GitHub release with proper changelog formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)