### PR TITLE
fix: CI workflow syntax error in Telegram notify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,19 +45,19 @@ jobs:
           REACT_APP_VERSION: 1.0.0
           CI: false
       - name: Notify Telegram on success
-        if: success() && secrets.TELEGRAM_BOT_TOKEN != ''
+        if: success()
         continue-on-error: true
         run: |
-          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="CI passed: money-flow-frontend (${{ github.ref_name }})"
+            -d text="CI passed: money-flow-frontend (${{ github.ref_name }})" || true
       - name: Notify Telegram on failure
-        if: failure() && secrets.TELEGRAM_BOT_TOKEN != ''
+        if: failure()
         continue-on-error: true
         run: |
-          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="CI failed: money-flow-frontend (${{ github.ref_name }})"
+            -d text="CI failed: money-flow-frontend (${{ github.ref_name }})" || true
 
   release:
     needs: build


### PR DESCRIPTION
Fixes workflow file parse error from `secrets.TELEGRAM_BOT_TOKEN != ''` — can't reference secrets directly in `if:` without `${{ }}`. Simplified to always attempt with `continue-on-error` + `|| true`.