### PR TITLE
feat: server-side price hints from full transaction history

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -37,7 +37,7 @@ import TableChartIcon from '@mui/icons-material/TableChart';
 import DataObjectIcon from '@mui/icons-material/DataObject';
 import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../types';
-import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, ReceiptScanResult } from '../services/api';
+import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult } from '../services/api';
 import SummaryCards from './dashboard/SummaryCards';
 import DateRangeControl, { DatePreset } from './dashboard/DateRangeControl';
 import MobileHero from './dashboard/MobileHero';
@@ -282,17 +282,11 @@ const MainLayout: React.FC = () => {
     return map;
   }, [transactions]);
 
-  // description → most recent amount used for that description (for autocomplete)
-  const amountsByDescription = useMemo(() => {
-    const map: Record<string, number> = {};
-    // Sort newest first so first hit is most recent
-    [...transactions].sort((a, b) => new Date(b.date || b.createdAt).getTime() - new Date(a.date || a.createdAt).getTime())
-      .forEach((t) => {
-        const key = (t.description?.trim() || t.item || '').toLowerCase();
-        if (key && !map[key]) map[key] = t.amount;
-      });
-    return map;
-  }, [transactions]);
+  // description/item → most recent amount (fetched from API for full history coverage)
+  const [amountsByDescription, setAmountsByDescription] = useState<Record<string, number>>({});
+  useEffect(() => {
+    getLastAmounts().then(setAmountsByDescription).catch(() => {});
+  }, [transactions.length]);
 
   // description → most recent category used for that description (for smart categorization)
   const categoriesByDescription = useMemo(() => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -78,6 +78,12 @@ export const deleteExpense = async (id: string): Promise<void> => {
   await axiosInstance.delete(`/api/expenses/${id}`);
 };
 
+// Price hints
+export const getLastAmounts = async (): Promise<Record<string, number>> => {
+  const res = await axiosInstance.get('/api/expenses/last-amounts');
+  return res.data;
+};
+
 // Exchange rates
 export interface ExchangeRates {
   [currency: string]: number;


### PR DESCRIPTION
## Summary
- Added `getLastAmounts()` API call to `api.ts`
- Replaced client-side `useMemo` computation of `amountsByDescription` with server-side `GET /api/expenses/last-amounts`
- Price hints now cover ALL transactions, not just the currently loaded page

Depends on: wkliwk/money-flow-backend#102

Closes #31

## Test plan
- [x] Build succeeds
- [ ] "Last time: HK$X" chip appears when entering a known item/description
- [ ] Hint reflects full history, not just recent transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)