### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+build
+coverage
+.env
+.env.*
+.git
+*.md
+.github
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# ---- Base ----
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package.json yarn.lock ./
+
+# ---- Dev (hot-reload with react-scripts) ----
+FROM base AS dev
+RUN yarn install --frozen-lockfile
+COPY tsconfig.json ./
+# src/ and public/ are volume-mounted in docker-compose for hot-reload
+EXPOSE 3000
+CMD ["yarn", "start"]
+
+# ---- Build ----
+FROM base AS build
+RUN yarn install --frozen-lockfile
+COPY tsconfig.json ./
+COPY public ./public
+COPY src ./src
+ARG REACT_APP_API_URL
+ARG REACT_APP_VERSION
+RUN yarn build
+
+# ---- Production ----
+FROM nginx:alpine AS prod
+COPY --from=build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  frontend:
+    build:
+      context: .
+      target: dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./src:/app/src
+      - ./public:/app/public
+      - ./tsconfig.json:/app/tsconfig.json
+    environment:
+      - REACT_APP_API_URL=${REACT_APP_API_URL:-http://localhost:3001}
+      - WATCHPACK_POLLING=true
+    profiles:
+      - dev
+
+  frontend-prod:
+    build:
+      context: .
+      target: prod
+      args:
+        - REACT_APP_API_URL=${REACT_APP_API_URL:-http://localhost:3001}
+    ports:
+      - "80:80"
+    profiles:
+      - prod

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /static/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (dev with hot reload, prod with nginx)
- docker-compose.yml with dev and prod profiles
- .dockerignore and nginx.conf for SPA routing

Closes #196

## Test plan
- [ ] `docker compose --profile dev up` starts dev server on port 3000
- [ ] Hot reload works when editing src/ files
- [ ] `docker compose --profile prod up` serves production build via nginx

🤖 Generated with [Claude Code](https://claude.com/claude-code)