### PR TITLE
feat: sync templates to backend API with localStorage fallback

### DIFF
--- a/src/hooks/useTemplates.ts
+++ b/src/hooks/useTemplates.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { TransactionType } from '../types';
+import { getTemplates, createTemplate, deleteTemplate as deleteTemplateAPI, APITemplate } from '../services/api';
 
 export interface TransactionTemplate {
   id: string;
@@ -13,7 +14,7 @@ export interface TransactionTemplate {
 
 const KEY = 'money_flow_templates';
 
-function load(): TransactionTemplate[] {
+function loadLocal(): TransactionTemplate[] {
   try {
     const raw = localStorage.getItem(KEY);
     return raw ? JSON.parse(raw) : [];
@@ -22,28 +23,116 @@ function load(): TransactionTemplate[] {
   }
 }
 
-function save(templates: TransactionTemplate[]) {
+function saveLocal(templates: TransactionTemplate[]) {
   try {
     localStorage.setItem(KEY, JSON.stringify(templates));
-  } catch {
-    // storage unavailable — silently ignore
-  }
+  } catch {}
+}
+
+function apiToLocal(t: APITemplate): TransactionTemplate {
+  return {
+    id: t._id,
+    label: t.name,
+    item: t.item,
+    description: t.description || '',
+    type: (t.type as TransactionType) || 'expense',
+    category: t.category || '',
+    defaultAmount: t.amount > 0 ? t.amount : undefined,
+  };
 }
 
 export function useTemplates() {
-  const [templates, setTemplates] = useState<TransactionTemplate[]>(load);
+  const [templates, setTemplates] = useState<TransactionTemplate[]>(loadLocal);
+  const migrated = useRef(false);
 
-  const addTemplate = useCallback((t: Omit<TransactionTemplate, 'id'>) => {
-    const next = [...templates, { ...t, id: String(Date.now()) }];
-    setTemplates(next);
-    save(next);
-  }, [templates]);
+  // Fetch from API on mount, migrate localStorage if needed
+  useEffect(() => {
+    getTemplates()
+      .then(async (apiTemplates) => {
+        const fromApi = apiTemplates.map(apiToLocal);
+        setTemplates(fromApi);
+        saveLocal(fromApi);
 
-  const deleteTemplate = useCallback((id: string) => {
-    const next = templates.filter((t) => t.id !== id);
-    setTemplates(next);
-    save(next);
-  }, [templates]);
+        // Migrate localStorage templates to API (one-time)
+        if (!migrated.current) {
+          migrated.current = true;
+          const local = loadLocal();
+          const apiIds = new Set(fromApi.map((t) => t.id));
+          const toMigrate = local.filter((t) => !apiIds.has(t.id));
+          for (const t of toMigrate) {
+            try {
+              await createTemplate({
+                name: t.label,
+                amount: t.defaultAmount || 0,
+                category: t.category,
+                description: t.description,
+                type: t.type,
+                item: t.item,
+                frequency: 'monthly',
+              });
+            } catch {
+              // Migration failed for this template — skip
+            }
+          }
+          if (toMigrate.length > 0) {
+            // Re-fetch to get migrated templates with proper IDs
+            const updated = await getTemplates();
+            const refreshed = updated.map(apiToLocal);
+            setTemplates(refreshed);
+            saveLocal(refreshed);
+          }
+        }
+      })
+      .catch(() => {
+        // API unavailable — use localStorage fallback
+      });
+  }, []);
 
-  return { templates, addTemplate, deleteTemplate };
+  const addTemplate = useCallback(async (t: Omit<TransactionTemplate, 'id'>) => {
+    // Optimistic local update
+    const tempId = String(Date.now());
+    const optimistic = { ...t, id: tempId };
+    setTemplates((prev) => {
+      const next = [...prev, optimistic];
+      saveLocal(next);
+      return next;
+    });
+
+    try {
+      const created = await createTemplate({
+        name: t.label,
+        amount: t.defaultAmount || 0,
+        category: t.category,
+        description: t.description,
+        type: t.type,
+        item: t.item,
+        frequency: 'monthly',
+      });
+      // Replace temp ID with real ID
+      setTemplates((prev) => {
+        const next = prev.map((tmpl) => tmpl.id === tempId ? apiToLocal(created) : tmpl);
+        saveLocal(next);
+        return next;
+      });
+    } catch {
+      // API failed — keep local version with temp ID
+    }
+  }, []);
+
+  const removeTemplate = useCallback(async (id: string) => {
+    // Optimistic local update
+    setTemplates((prev) => {
+      const next = prev.filter((t) => t.id !== id);
+      saveLocal(next);
+      return next;
+    });
+
+    try {
+      await deleteTemplateAPI(id);
+    } catch {
+      // API failed — item already removed from UI
+    }
+  }, []);
+
+  return { templates, addTemplate, deleteTemplate: removeTemplate };
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -221,6 +221,32 @@ export interface ReceiptScanResult {
   confidence: ReceiptConfidence;
 }
 
+// Templates
+export interface APITemplate {
+  _id: string;
+  name: string;
+  amount: number;
+  category?: string;
+  description?: string;
+  type?: string;
+  item?: string;
+  frequency?: string;
+}
+
+export const getTemplates = async (): Promise<APITemplate[]> => {
+  const res = await axiosInstance.get('/api/templates');
+  return res.data.templates;
+};
+
+export const createTemplate = async (data: Omit<APITemplate, '_id'>): Promise<APITemplate> => {
+  const res = await axiosInstance.post('/api/templates', data);
+  return res.data;
+};
+
+export const deleteTemplate = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/templates/${id}`);
+};
+
 // Friends
 export interface Friend {
   id: string;


### PR DESCRIPTION
## Summary
- Rewrites `useTemplates` hook to use backend API (GET/POST/DELETE /api/templates)
- One-time migration: existing localStorage templates auto-pushed to API on first load
- Optimistic updates: UI updates instantly, API syncs in background
- Graceful fallback: if API unavailable, uses localStorage (offline-compatible)

Closes #199

## Test plan
- [x] Build succeeds
- [ ] New templates saved to API (check Network tab)
- [ ] Templates persist across devices (log in on different browser)
- [ ] Existing localStorage templates migrated to API
- [ ] Offline: templates still work from localStorage cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)