### PR TITLE
Add keyboard accessibility to transaction type selector

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -343,13 +343,24 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
         />
 
         {/* Type selector — icon cards */}
-        <Box sx={{ display: 'flex', gap: 1, mb: 1.5, mt: 0.5 }}>
+        <Box role="radiogroup" aria-label="Transaction type" sx={{ display: 'flex', gap: 1, mb: 1.5, mt: 0.5 }}>
           {typeCards.map((card) => {
             const selected = type === card.value;
             return (
               <Box
                 key={card.value}
+                role="radio"
+                aria-checked={selected}
+                tabIndex={0}
                 onClick={() => { setType(card.value); setItem(''); setCategory(''); }}
+                onKeyDown={(e) => {
+                  if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    setType(card.value);
+                    setItem('');
+                    setCategory('');
+                  }
+                }}
                 sx={{
                   flex: 1,
                   display: 'flex',
@@ -366,6 +377,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
                   transition: 'all 0.15s ease',
                   userSelect: 'none',
                   '&:hover': { bgcolor: card.activeBg },
+                  '&:focus': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: 2 },
                 }}
               >
                 <Box sx={{ color: card.color }}>{card.icon}</Box>

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -250,13 +250,24 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         {error && <Alert severity="error" sx={{ mb: 2, mt: 1 }}>{error}</Alert>}
 
         {/* Type selector — icon cards */}
-        <Box sx={{ display: 'flex', gap: 1, mb: 1.5, mt: 0.5 }}>
+        <Box role="radiogroup" aria-label="Transaction type" sx={{ display: 'flex', gap: 1, mb: 1.5, mt: 0.5 }}>
           {typeCards.map((card) => {
             const selected = type === card.value;
             return (
               <Box
                 key={card.value}
+                role="radio"
+                aria-checked={selected}
+                tabIndex={0}
                 onClick={() => { setType(card.value); setItem(''); setCategory(''); }}
+                onKeyDown={(e) => {
+                  if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    setType(card.value);
+                    setItem('');
+                    setCategory('');
+                  }
+                }}
                 sx={{
                   flex: 1,
                   display: 'flex',
@@ -273,6 +284,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
                   transition: 'all 0.15s ease',
                   userSelect: 'none',
                   '&:hover': { bgcolor: card.activeBg },
+                  '&:focus': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: 2 },
                 }}
               >
                 <Box sx={{ color: card.color }}>{card.icon}</Box>


### PR DESCRIPTION
## What
Added keyboard accessibility to the Expense/Income type selector in both AddExpenseModal and EditExpenseModal components.

## Why
Closes #200

## Acceptance Criteria
- [x] Type cards have role="radio" and aria-checked
- [x] Wrapper has role="radiogroup" with aria-label
- [x] Tab navigates to type cards (tabIndex={0})
- [x] Space/Enter activates selection (onKeyDown handler)
- [x] Works in both Add and Edit modals
- [x] Build succeeds with no errors
- [x] Focus styles added for keyboard navigation visibility

## Changes
- AddExpenseModal.tsx: Added accessibility attributes and keyboard handlers to type selector
- EditExpenseModal.tsx: Added accessibility attributes and keyboard handlers to type selector
- Added focus outline styles for visible keyboard navigation

## Test Plan
1. Open Add Transaction modal
2. Use Tab key to navigate to the type selector cards
3. Verify focus outline appears around cards when focused
4. Press Space or Enter to toggle between Expense and Income
5. Repeat steps 1-4 in Edit Transaction modal
6. Verify screen reader announces "Transaction type" radiogroup and card state (checked/unchecked)

Generated with Claude Code