### PR TITLE
Add confirmation dialog before sign out

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -14,6 +14,10 @@ import {
   ToggleButtonGroup,
   ToggleButton,
   SvgIcon,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
 import LogoutIcon from '@mui/icons-material/Logout';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -110,6 +114,7 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const [recurringDraft, setRecurringDraft] = useState(emptyRecurring());
   const [editingItem, setEditingItem] = useState<string | null>(null);
   const [itemDraft, setItemDraft] = useState('');
+  const [signOutConfirm, setSignOutConfirm] = useState(false);
 
   const handleBudgetBlur = (category: string) => {
     const val = parseFloat(drafts[category]);
@@ -132,6 +137,11 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const handleLogout = () => {
     clearToken();
     window.location.href = '/login';
+  };
+
+  const confirmLogout = () => {
+    setSignOutConfirm(false);
+    handleLogout();
   };
 
   const renderItemSection = (label: string, items: typeof ITEM_PRESETS) => (
@@ -432,11 +442,24 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
         variant="outlined"
         color="error"
         startIcon={<LogoutIcon />}
-        onClick={handleLogout}
+        onClick={() => setSignOutConfirm(true)}
         fullWidth
       >
         Sign Out
       </Button>
+
+      <Dialog open={signOutConfirm} onClose={() => setSignOutConfirm(false)}>
+        <DialogTitle>Sign Out</DialogTitle>
+        <DialogContent>
+          <Typography>Are you sure you want to sign out?</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSignOutConfirm(false)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={confirmLogout}>
+            Sign Out
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };


### PR DESCRIPTION
## What
Added a confirmation dialog to the Sign Out button in Settings. Users must now confirm their intention to sign out to prevent accidental logout, especially on mobile devices.

## Why
Closes #201

## Acceptance Criteria
- [x] Clicking Sign Out shows confirmation dialog
- [x] Cancel dismisses dialog, no logout
- [x] Confirm signs out and redirects to /login

## Changes
- Added `signOutConfirm` state to manage dialog visibility
- Changed Sign Out button to open dialog instead of logging out immediately
- Added confirmation dialog using MUI Dialog, DialogTitle, DialogContent, and DialogActions components
- Dialog shows "Are you sure you want to sign out?" message
- Cancel button closes the dialog
- Confirm button executes the logout flow

## Test Plan
1. Navigate to Settings page
2. Click the "Sign Out" button
3. Verify that a confirmation dialog appears with title "Sign Out" and message "Are you sure you want to sign out?"
4. Click "Cancel" - verify dialog closes and user remains logged in
5. Click "Sign Out" button again
6. Click "Sign Out" in the confirmation dialog - verify user is logged out and redirected to /login

Build completed successfully with no TypeScript or build errors.