### PR TITLE
fix: align payment method enum with backend values

### DIFF
--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -26,7 +26,7 @@ import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
 import EmptyState from '../EmptyState';
 import PaymentIcon from '@mui/icons-material/Payment';
 import NoteIcon from '@mui/icons-material/Notes';
-import { Transaction } from '../../types';
+import { Transaction, PAYMENT_METHOD_LABELS, PaymentMethod } from '../../types';
 import { CURRENCY_SYMBOLS, Currency } from '../../constants/currencies';
 
 interface Props {
@@ -402,7 +402,7 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
                                 <PaymentIcon sx={{ fontSize: 11, color: 'text.disabled' }} />
                                 <Typography sx={{ fontSize: '0.62rem', color: 'text.disabled' }}>
-                                  {t.paymentMethod}
+                                  {PAYMENT_METHOD_LABELS[t.paymentMethod as PaymentMethod] || t.paymentMethod}
                                 </Typography>
                               </Box>
                             )}
@@ -533,7 +533,7 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                   <Chip label={t.type === 'income' ? 'Income' : 'Expense'} color={t.type === 'income' ? 'success' : 'error'} size="small" />
                 </TableCell>
                 <TableCell sx={{ color: 'text.secondary', fontSize: '0.8rem', whiteSpace: 'nowrap' }}>
-                  {t.paymentMethod || '\u2014'}
+                  {t.paymentMethod ? (PAYMENT_METHOD_LABELS[t.paymentMethod as PaymentMethod] || t.paymentMethod) : '\u2014'}
                 </TableCell>
                 <TableCell align="right">
                   <Typography fontWeight={600} sx={{ letterSpacing: '-0.01em', color: t.type === 'income' ? '#81c784' : '#e57373' }}>

--- a/src/components/expenses/PaymentMethodPicker.tsx
+++ b/src/components/expenses/PaymentMethodPicker.tsx
@@ -5,18 +5,20 @@ import LocalAtmIcon from '@mui/icons-material/LocalAtm';
 import CreditCardIcon from '@mui/icons-material/CreditCard';
 import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import PaymentIcon from '@mui/icons-material/Payment';
-import { PAYMENT_METHODS, PaymentMethod } from '../../types';
+import CategoryIcon from '@mui/icons-material/Category';
+import { PAYMENT_METHODS, PAYMENT_METHOD_LABELS, PaymentMethod } from '../../types';
 
 const PAYMENT_METHOD_ICONS: Record<PaymentMethod, React.ReactNode> = {
-  'Cash': <LocalAtmIcon sx={{ fontSize: '14px !important' }} />,
-  'Octopus': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
-  'PayMe': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
-  'FPS': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
-  'Credit Card': <CreditCardIcon sx={{ fontSize: '14px !important' }} />,
-  'Debit Card': <CreditCardIcon sx={{ fontSize: '14px !important' }} />,
-  'Bank Transfer': <AccountBalanceIcon sx={{ fontSize: '14px !important' }} />,
-  'AlipayHK': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
-  'WeChat Pay': <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  cash: <LocalAtmIcon sx={{ fontSize: '14px !important' }} />,
+  octopus: <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  payme: <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  fps: <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  credit_card: <CreditCardIcon sx={{ fontSize: '14px !important' }} />,
+  debit_card: <CreditCardIcon sx={{ fontSize: '14px !important' }} />,
+  bank_transfer: <AccountBalanceIcon sx={{ fontSize: '14px !important' }} />,
+  alipay_hk: <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  wechat_pay: <PaymentIcon sx={{ fontSize: '14px !important' }} />,
+  other: <CategoryIcon sx={{ fontSize: '14px !important' }} />,
 };
 
 export function getPaymentMethodIcon(method: PaymentMethod): React.ReactNode {
@@ -45,7 +47,7 @@ const PaymentMethodPicker: React.FC<Props> = ({ value, onChange }) => {
           <Chip
             key={m}
             icon={PAYMENT_METHOD_ICONS[m] as React.ReactElement}
-            label={m}
+            label={PAYMENT_METHOD_LABELS[m]}
             size="small"
             clickable
             onClick={() => onChange(value === m ? null : m)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,34 @@
 export type TransactionType = 'income' | 'expense';
 
+// Backend enum values — these are sent to the API
 export const PAYMENT_METHODS = [
-  'Cash',
-  'Octopus',
-  'PayMe',
-  'FPS',
-  'Credit Card',
-  'Debit Card',
-  'Bank Transfer',
-  'AlipayHK',
-  'WeChat Pay',
+  'cash',
+  'octopus',
+  'payme',
+  'fps',
+  'credit_card',
+  'debit_card',
+  'bank_transfer',
+  'alipay_hk',
+  'wechat_pay',
+  'other',
 ] as const;
 
 export type PaymentMethod = typeof PAYMENT_METHODS[number];
+
+// Display names for the UI
+export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
+  cash: 'Cash',
+  octopus: 'Octopus',
+  payme: 'PayMe',
+  fps: 'FPS',
+  credit_card: 'Credit Card',
+  debit_card: 'Debit Card',
+  bank_transfer: 'Bank Transfer',
+  alipay_hk: 'AlipayHK',
+  wechat_pay: 'WeChat Pay',
+  other: 'Other',
+};
 
 export interface Transaction {
   _id: string;

--- a/src/utils/parseQuickExpense.ts
+++ b/src/utils/parseQuickExpense.ts
@@ -30,20 +30,21 @@ const CATEGORY_KEYWORDS: Record<string, string[]> = {
 };
 
 const PAYMENT_METHOD_KEYWORDS: Record<string, PaymentMethod> = {
-  'cash': 'Cash',
-  'octopus': 'Octopus',
-  'payme': 'PayMe',
-  'fps': 'FPS',
-  'creditcard': 'Credit Card',
-  'credit': 'Credit Card',
-  'debitcard': 'Debit Card',
-  'debit': 'Debit Card',
-  'banktransfer': 'Bank Transfer',
-  'bank': 'Bank Transfer',
-  'alipayhk': 'AlipayHK',
-  'alipay': 'AlipayHK',
-  'wechatpay': 'WeChat Pay',
-  'wechat': 'WeChat Pay',
+  'cash': 'cash',
+  'octopus': 'octopus',
+  'payme': 'payme',
+  'fps': 'fps',
+  'creditcard': 'credit_card',
+  'credit': 'credit_card',
+  'debitcard': 'debit_card',
+  'debit': 'debit_card',
+  'banktransfer': 'bank_transfer',
+  'bank': 'bank_transfer',
+  'alipayhk': 'alipay_hk',
+  'alipay': 'alipay_hk',
+  'wechatpay': 'wechat_pay',
+  'wechat': 'wechat_pay',
+  'other': 'other',
 };
 
 const CURRENCY_CODES: Record<string, string> = {


### PR DESCRIPTION
## Summary
Frontend was sending display names ("Cash", "Credit Card") but backend expects snake_case enum ("cash", "credit_card"). This caused 400 errors when saving payment methods.

- `types.ts`: PAYMENT_METHODS now uses backend enum values + new PAYMENT_METHOD_LABELS map for display
- `PaymentMethodPicker.tsx`: uses labels for display, sends enum values
- `ExpenseList.tsx`: uses labels for display
- `parseQuickExpense.ts`: updated keyword map

Closes #207

## Test plan
- [x] Build succeeds
- [ ] Select payment method in Add modal → saves without error
- [ ] Select payment method in Edit modal → saves without error
- [ ] Payment methods display correctly in transaction list

🤖 Generated with [Claude Code](https://claude.com/claude-code)