### PR TITLE
feat: extract Monthly Recurring into dedicated tab

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -35,6 +35,7 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import DataObjectIcon from '@mui/icons-material/DataObject';
+import RepeatIcon from '@mui/icons-material/Repeat';
 import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../types';
 import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult } from '../services/api';
@@ -59,6 +60,7 @@ import { Currency } from '../hooks/useFxRates';
 import { useRecurring } from '../hooks/useRecurring';
 import NetWorthPage from './networth/NetWorthPage';
 import SettingsPage from './settings/SettingsPage';
+import RecurringPage from './recurring/RecurringPage';
 import { useBudgets } from '../hooks/useBudgets';
 import OnboardingFlow, { isOnboardingComplete, markOnboardingComplete } from './onboarding/OnboardingFlow';
 import SpendingInsightsPage from './insights/SpendingInsightsPage';
@@ -79,7 +81,7 @@ const MainLayout: React.FC = () => {
   const { currency, setCurrency, convert, symbol } = useFxRates();
   const { items: recurringItems, markApplied } = useRecurring();
   const { budgets } = useBudgets();
-  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4>(0);
+  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4 | 5>(0);
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
 
   useEffect(() => {
@@ -492,6 +494,7 @@ const MainLayout: React.FC = () => {
     { label: 'Transactions', icon: <ReceiptLongIcon /> },
     { label: 'Net Worth', icon: <AccountBalanceIcon /> },
     { label: 'Insights', icon: <BarChartIcon /> },
+    { label: 'Recurring', icon: <RepeatIcon /> },
     { label: 'Settings', icon: <SettingsIcon /> },
   ];
 
@@ -592,7 +595,7 @@ const MainLayout: React.FC = () => {
               <ListItemButton
                 key={item.label}
                 selected={activeTab === index}
-                onClick={() => setActiveTab(index as 0 | 1 | 2 | 3 | 4)}
+                onClick={() => setActiveTab(index as 0 | 1 | 2 | 3 | 4 | 5)}
                 sx={{
                   '&.Mui-selected': { bgcolor: theme.palette.mode === 'dark' ? 'rgba(129,140,248,0.1)' : 'rgba(99,102,241,0.12)', color: 'primary.main' },
                   '&.Mui-selected .MuiListItemIcon-root': { color: 'primary.main' },
@@ -913,6 +916,10 @@ const MainLayout: React.FC = () => {
           )}
 
           {activeTab === 4 && (
+            <RecurringPage />
+          )}
+
+          {activeTab === 5 && (
             <SettingsPage
               currency={currency}
               onCurrencyChange={(c: Currency) => setCurrency(c)}
@@ -944,6 +951,7 @@ const MainLayout: React.FC = () => {
           <BottomNavigationAction label="Txns" icon={<ReceiptLongIcon />} />
           <BottomNavigationAction label="Worth" icon={<AccountBalanceIcon />} />
           <BottomNavigationAction label="Insights" icon={<BarChartIcon />} />
+          <BottomNavigationAction label="Repeat" icon={<RepeatIcon />} />
           <BottomNavigationAction label="Settings" icon={<SettingsIcon />} />
         </BottomNavigation>
       </Box>

--- a/src/components/recurring/RecurringPage.tsx
+++ b/src/components/recurring/RecurringPage.tsx
@@ -1,0 +1,327 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Chip,
+  TextField,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import RepeatIcon from '@mui/icons-material/Repeat';
+import { useTheme } from '@mui/material/styles';
+import dayjs from 'dayjs';
+import { useRecurring, RecurringItem } from '../../hooks/useRecurring';
+import { useFxRates } from '../../hooks/useFxRates';
+import { ITEM_PRESETS } from '../expenses/ItemPicker';
+import { TransactionType } from '../../types';
+
+const emptyRecurring = (): Omit<RecurringItem, 'id'> => ({
+  label: '',
+  item: '',
+  description: '',
+  amount: 0,
+  type: 'expense' as TransactionType,
+  category: '',
+  startDate: dayjs().format('YYYY-MM-DD'),
+});
+
+const RecurringPage: React.FC = () => {
+  const theme = useTheme();
+  const { items: recurring, addItem: addRecurring, deleteItem: deleteRecurring } = useRecurring();
+  const { symbol, convert } = useFxRates();
+  const [showForm, setShowForm] = useState(false);
+  const [draft, setDraft] = useState(emptyRecurring());
+
+  const expenses = recurring.filter((r) => r.type === 'expense');
+  const incomes = recurring.filter((r) => r.type === 'income');
+  const totalExpense = expenses.reduce((s, r) => s + r.amount, 0);
+  const totalIncome = incomes.reduce((s, r) => s + r.amount, 0);
+
+  const renderItem = (r: RecurringItem) => (
+    <ListItem key={r.id} disableGutters sx={{ py: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
+      <ListItemText
+        primary={
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography sx={{ fontSize: '0.88rem', fontWeight: 600, flex: 1 }}>
+              {r.label || r.description}
+            </Typography>
+            <Typography sx={{
+              fontSize: '0.88rem',
+              fontWeight: 700,
+              color: r.type === 'expense' ? 'error.light' : 'success.light',
+            }}>
+              {r.type === 'expense' ? '-' : '+'}{symbol}{convert(r.amount).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+            </Typography>
+          </Box>
+        }
+        secondary={
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.25 }}>
+            {r.item && (
+              <Chip label={r.item} size="small" sx={{ fontSize: '0.65rem', height: 18, bgcolor: 'action.hover' }} />
+            )}
+            {r.frequency && r.frequency !== 'monthly' && (
+              <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.68rem' }}>
+                {r.frequency}
+              </Typography>
+            )}
+            {r.startDate && (
+              <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.68rem' }}>
+                from {dayjs(r.startDate).format('MMM D, YYYY')}
+              </Typography>
+            )}
+          </Box>
+        }
+      />
+      <IconButton size="small" onClick={() => deleteRecurring(r.id)} sx={{ color: 'error.light', '&:hover': { color: 'error.main' }, ml: 0.5 }}>
+        <DeleteIcon sx={{ fontSize: 16 }} />
+      </IconButton>
+    </ListItem>
+  );
+
+  return (
+    <Box sx={{ maxWidth: 500, mx: 'auto' }}>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <RepeatIcon sx={{ color: 'primary.main', fontSize: 22 }} />
+        <Typography variant="h6" fontWeight={700}>Monthly Recurring</Typography>
+      </Box>
+
+      {/* Summary cards */}
+      {recurring.length > 0 && (
+        <Box sx={{ display: 'flex', gap: 1.5, mb: 2.5 }}>
+          <Box sx={{ flex: 1, borderRadius: 2, border: '1px solid', borderColor: 'divider', p: 1.5, textAlign: 'center' }}>
+            <Typography sx={{ fontSize: '0.68rem', color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.04em', mb: 0.25 }}>
+              Monthly Expenses
+            </Typography>
+            <Typography sx={{ fontSize: '1.1rem', fontWeight: 700, color: 'error.light' }}>
+              -{symbol}{convert(totalExpense).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+            </Typography>
+          </Box>
+          <Box sx={{ flex: 1, borderRadius: 2, border: '1px solid', borderColor: 'divider', p: 1.5, textAlign: 'center' }}>
+            <Typography sx={{ fontSize: '0.68rem', color: 'text.disabled', textTransform: 'uppercase', letterSpacing: '0.04em', mb: 0.25 }}>
+              Monthly Income
+            </Typography>
+            <Typography sx={{ fontSize: '1.1rem', fontWeight: 700, color: 'success.light' }}>
+              +{symbol}{convert(totalIncome).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+            </Typography>
+          </Box>
+        </Box>
+      )}
+
+      {/* Expense list */}
+      {expenses.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.68rem', letterSpacing: '0.06em', textTransform: 'uppercase', display: 'block', mb: 0.5, px: 0.5 }}>
+            Expenses ({expenses.length})
+          </Typography>
+          <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden' }}>
+            <List disablePadding sx={{ px: 2 }}>
+              {expenses.map(renderItem)}
+            </List>
+          </Box>
+        </Box>
+      )}
+
+      {/* Income list */}
+      {incomes.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.68rem', letterSpacing: '0.06em', textTransform: 'uppercase', display: 'block', mb: 0.5, px: 0.5 }}>
+            Income ({incomes.length})
+          </Typography>
+          <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden' }}>
+            <List disablePadding sx={{ px: 2 }}>
+              {incomes.map(renderItem)}
+            </List>
+          </Box>
+        </Box>
+      )}
+
+      {/* Empty state */}
+      {recurring.length === 0 && !showForm && (
+        <Box sx={{ textAlign: 'center', py: 6, color: 'text.disabled' }}>
+          <RepeatIcon sx={{ fontSize: 48, mb: 1, opacity: 0.3 }} />
+          <Typography sx={{ fontSize: '0.88rem', mb: 0.5 }}>No recurring transactions yet</Typography>
+          <Typography sx={{ fontSize: '0.75rem' }}>Add subscriptions, rent, salary — anything that repeats monthly.</Typography>
+        </Box>
+      )}
+
+      {/* Add form */}
+      {!showForm ? (
+        <Button
+          fullWidth
+          startIcon={<AddIcon />}
+          onClick={() => setShowForm(true)}
+          sx={{
+            color: 'text.secondary',
+            fontSize: '0.82rem',
+            borderStyle: 'dashed',
+            border: '1px dashed',
+            borderColor: 'divider',
+            borderRadius: 2,
+            py: 1.25,
+          }}
+        >
+          Add recurring transaction
+        </Button>
+      ) : (
+        <Box sx={{ bgcolor: 'action.hover', borderRadius: 2, p: 2, border: '1px solid', borderColor: 'divider' }}>
+          <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, mb: 1.5 }}>New Recurring</Typography>
+
+          {/* Type selector */}
+          <Box sx={{ display: 'flex', gap: 1, mb: 1.5 }}>
+            {(['expense', 'income'] as TransactionType[]).map((t) => (
+              <Box
+                key={t}
+                onClick={() => setDraft((d) => ({ ...d, type: t, item: '' }))}
+                sx={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 0.5,
+                  py: 0.75,
+                  borderRadius: 1.5,
+                  cursor: 'pointer',
+                  border: '1.5px solid',
+                  borderColor: draft.type === t
+                    ? (t === 'expense'
+                      ? (theme.palette.mode === 'dark' ? 'rgba(251,113,133,0.4)' : 'rgba(244,63,94,0.5)')
+                      : (theme.palette.mode === 'dark' ? 'rgba(52,211,153,0.4)' : 'rgba(16,185,129,0.5)'))
+                    : 'divider',
+                  bgcolor: draft.type === t
+                    ? (t === 'expense'
+                      ? (theme.palette.mode === 'dark' ? 'rgba(251,113,133,0.12)' : 'rgba(244,63,94,0.08)')
+                      : (theme.palette.mode === 'dark' ? 'rgba(52,211,153,0.12)' : 'rgba(16,185,129,0.08)'))
+                    : 'transparent',
+                }}
+              >
+                {t === 'expense'
+                  ? <TrendingDownIcon sx={{ fontSize: 14, color: 'error.main' }} />
+                  : <TrendingUpIcon sx={{ fontSize: 14, color: 'success.main' }} />}
+                <Typography
+                  variant="caption"
+                  fontWeight={700}
+                  sx={{
+                    fontSize: '0.72rem',
+                    color: draft.type === t
+                      ? (t === 'expense' ? 'error.main' : 'success.main')
+                      : 'text.secondary',
+                  }}
+                >
+                  {t === 'expense' ? 'Expense' : 'Income'}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+
+          {/* Item chips */}
+          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 1.5 }}>
+            {ITEM_PRESETS.filter((p) => p.type === draft.type).map((p) => (
+              <Chip
+                key={p.label}
+                label={p.label}
+                size="small"
+                clickable
+                onClick={() => setDraft((d) => ({ ...d, item: d.item === p.label ? '' : p.label, category: p.category }))}
+                sx={{
+                  fontSize: '0.68rem',
+                  height: 22,
+                  bgcolor: draft.item === p.label
+                    ? (theme.palette.mode === 'dark' ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.12)')
+                    : 'action.hover',
+                  color: draft.item === p.label ? 'primary.main' : 'text.disabled',
+                  border: '1px solid',
+                  borderColor: draft.item === p.label
+                    ? (theme.palette.mode === 'dark' ? 'rgba(129,140,248,0.35)' : 'rgba(99,102,241,0.3)')
+                    : 'divider',
+                }}
+              />
+            ))}
+          </Box>
+
+          {/* Fields */}
+          <TextField
+            label="Label"
+            placeholder='e.g. "Netflix"'
+            size="small"
+            fullWidth
+            value={draft.label}
+            onChange={(e) => setDraft((d) => ({ ...d, label: e.target.value }))}
+            sx={{ mb: 1 }}
+          />
+          <TextField
+            label="Description"
+            size="small"
+            fullWidth
+            value={draft.description}
+            onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))}
+            sx={{ mb: 1 }}
+          />
+          <TextField
+            label="Amount (HKD)"
+            type="number"
+            size="small"
+            fullWidth
+            value={draft.amount || ''}
+            onChange={(e) => setDraft((d) => ({ ...d, amount: parseFloat(e.target.value) || 0 }))}
+            sx={{ mb: 1 }}
+            inputProps={{ min: 0 }}
+          />
+          <TextField
+            label="Start Date"
+            type="date"
+            size="small"
+            fullWidth
+            value={draft.startDate || dayjs().format('YYYY-MM-DD')}
+            onChange={(e) => setDraft((d) => ({ ...d, startDate: e.target.value }))}
+            sx={{ mb: 1.5 }}
+            InputLabelProps={{ shrink: true }}
+          />
+
+          {/* Actions */}
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              size="small"
+              onClick={() => { setShowForm(false); setDraft(emptyRecurring()); }}
+              sx={{ color: 'text.secondary' }}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              disabled={!draft.amount || (!draft.label && !draft.description)}
+              onClick={() => {
+                addRecurring({
+                  ...draft,
+                  label: draft.label || draft.description,
+                  item: draft.item || undefined,
+                  category: draft.category || undefined,
+                });
+                setShowForm(false);
+                setDraft(emptyRecurring());
+              }}
+              sx={{ flex: 1 }}
+            >
+              Save
+            </Button>
+          </Box>
+        </Box>
+      )}
+
+      {/* Footer info */}
+      <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', mt: 2, textAlign: 'center' }}>
+        Recurring transactions are prompted at the start of each month.
+      </Typography>
+    </Box>
+  );
+};
+
+export default RecurringPage;

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -8,18 +8,12 @@ import {
   TextField,
   InputAdornment,
   IconButton,
-  List,
-  ListItem,
-  ListItemText,
   ToggleButtonGroup,
   ToggleButton,
   SvgIcon,
 } from '@mui/material';
 import LogoutIcon from '@mui/icons-material/Logout';
 import DeleteIcon from '@mui/icons-material/Delete';
-import AddIcon from '@mui/icons-material/Add';
-import TrendingDownIcon from '@mui/icons-material/TrendingDown';
-import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
@@ -31,11 +25,9 @@ import { clearToken } from '../../services/auth';
 import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
 import { useCurrencyPreferences } from '../../hooks/useCurrencyPreferences';
 import { useBudgets, BUDGET_CATEGORIES } from '../../hooks/useBudgets';
-import { useRecurring, RecurringItem } from '../../hooks/useRecurring';
 import FriendsSection from './FriendsSection';
 import { useItemPresets } from '../../hooks/useItemPresets';
 import { ITEM_PRESETS } from '../expenses/ItemPicker';
-import { TransactionType } from '../../types';
 import { useThemePreference } from '../../ThemeContext';
 import { ThemePreference } from '../../theme';
 
@@ -52,15 +44,6 @@ function getUserId(): string {
     return JSON.parse(atob(token.split('.')[1])).userId || '';
   } catch { return ''; }
 }
-
-const emptyRecurring = (): Omit<RecurringItem, 'id'> => ({
-  label: '',
-  item: '',
-  description: '',
-  amount: 0,
-  type: 'expense' as TransactionType,
-  category: '',
-});
 
 const THEME_OPTIONS: { value: ThemePreference; label: string; icon: React.ReactNode }[] = [
   { value: 'light', label: 'Light', icon: <LightModeIcon sx={{ fontSize: 16 }} /> },
@@ -101,13 +84,10 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const { symbol, convert } = useFxRates();
   const { enabledCurrencies, toggleCurrency, isEnabled } = useCurrencyPreferences();
   const { budgets, setBudget } = useBudgets();
-  const { items: recurring, addItem: addRecurring, deleteItem: deleteRecurring } = useRecurring();
   const { presets, setPreset, deletePreset } = useItemPresets();
   const [drafts, setDrafts] = useState<Record<string, string>>(() =>
     Object.fromEntries(BUDGET_CATEGORIES.map((c) => [c, budgets[c] ? String(budgets[c]) : '']))
   );
-  const [showRecurringForm, setShowRecurringForm] = useState(false);
-  const [recurringDraft, setRecurringDraft] = useState(emptyRecurring());
   const [editingItem, setEditingItem] = useState<string | null>(null);
   const [itemDraft, setItemDraft] = useState('');
 
@@ -357,75 +337,6 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
         </Typography>
         {renderItemSection('Expense Items', ITEM_PRESETS.filter((p) => p.type === 'expense'))}
         {renderItemSection('Income Items', ITEM_PRESETS.filter((p) => p.type === 'income'))}
-      </Box>
-
-      {/* Recurring transactions */}
-      <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>
-        <Box sx={{ px: 2, py: 1.5 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', mb: 0.5 }}>
-            Monthly Recurring
-          </Typography>
-          <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', mb: 1 }}>
-            Auto-prompted at the start of each month.
-          </Typography>
-
-          {recurring.length > 0 && (
-            <List disablePadding sx={{ mb: 1 }}>
-              {recurring.map((r) => (
-                <ListItem key={r.id} disableGutters sx={{ py: 0.75 }}>
-                  <ListItemText
-                    primary={<Typography sx={{ fontSize: '0.85rem', fontWeight: 600 }}>{r.label || r.description}</Typography>}
-                    secondary={<Typography variant="caption" color="text.disabled">{symbol}{convert(r.amount)} · {r.type}{r.item ? ` · ${r.item}` : ''}</Typography>}
-                  />
-                  <IconButton size="small" onClick={() => deleteRecurring(r.id)} sx={{ color: 'error.light', '&:hover': { color: 'error.main' } }}>
-                    <DeleteIcon sx={{ fontSize: 16 }} />
-                  </IconButton>
-                </ListItem>
-              ))}
-            </List>
-          )}
-
-          {!showRecurringForm ? (
-            <Button size="small" startIcon={<AddIcon />} onClick={() => setShowRecurringForm(true)} sx={{ color: 'text.secondary', fontSize: '0.78rem', borderStyle: 'dashed', border: '1px dashed', borderColor: 'divider', borderRadius: 1.5, px: 1.5, py: 0.5 }}>
-              Add recurring
-            </Button>
-          ) : (
-            <Box sx={{ bgcolor: 'action.hover', borderRadius: 2, p: 1.5, border: '1px solid', borderColor: 'divider', mt: 1 }}>
-              <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
-                {(['expense', 'income'] as TransactionType[]).map((t) => (
-                  <Box key={t} onClick={() => setRecurringDraft((d) => ({ ...d, type: t, item: '' }))}
-                    sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5, py: 0.75, borderRadius: 1.5, cursor: 'pointer', border: '1.5px solid', borderColor: recurringDraft.type === t ? (t === 'expense' ? (theme.palette.mode === 'dark' ? 'rgba(251,113,133,0.4)' : 'rgba(244,63,94,0.5)') : (theme.palette.mode === 'dark' ? 'rgba(52,211,153,0.4)' : 'rgba(16,185,129,0.5)')) : 'divider', bgcolor: recurringDraft.type === t ? (t === 'expense' ? (theme.palette.mode === 'dark' ? 'rgba(251,113,133,0.12)' : 'rgba(244,63,94,0.08)') : (theme.palette.mode === 'dark' ? 'rgba(52,211,153,0.12)' : 'rgba(16,185,129,0.08)')) : 'transparent' }}>
-                    {t === 'expense' ? <TrendingDownIcon sx={{ fontSize: 14, color: 'error.main' }} /> : <TrendingUpIcon sx={{ fontSize: 14, color: 'success.main' }} />}
-                    <Typography variant="caption" fontWeight={700} sx={{ fontSize: '0.72rem', color: recurringDraft.type === t ? (t === 'expense' ? 'error.main' : 'success.main') : 'text.secondary' }}>{t === 'expense' ? 'Expense' : 'Income'}</Typography>
-                  </Box>
-                ))}
-              </Box>
-              <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 1 }}>
-                {ITEM_PRESETS.filter((p) => p.type === recurringDraft.type).map((p) => (
-                  <Chip key={p.label} label={p.label} size="small" clickable onClick={() => setRecurringDraft((d) => ({ ...d, item: d.item === p.label ? '' : p.label, category: p.category }))}
-                    sx={{ fontSize: '0.68rem', height: 22, bgcolor: recurringDraft.item === p.label ? (theme.palette.mode === 'dark' ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.12)') : 'action.hover', color: recurringDraft.item === p.label ? 'primary.main' : 'text.disabled', border: '1px solid', borderColor: recurringDraft.item === p.label ? (theme.palette.mode === 'dark' ? 'rgba(129,140,248,0.35)' : 'rgba(99,102,241,0.3)') : 'divider' }}
-                  />
-                ))}
-              </Box>
-              <TextField label="Label" placeholder='e.g. "Netflix"' size="small" fullWidth value={recurringDraft.label} onChange={(e) => setRecurringDraft((d) => ({ ...d, label: e.target.value }))} sx={{ mb: 1 }} />
-              <TextField label="Description" size="small" fullWidth value={recurringDraft.description} onChange={(e) => setRecurringDraft((d) => ({ ...d, description: e.target.value }))} sx={{ mb: 1 }} />
-              <TextField label="Amount (HKD)" type="number" size="small" fullWidth value={recurringDraft.amount || ''} onChange={(e) => setRecurringDraft((d) => ({ ...d, amount: parseFloat(e.target.value) || 0 }))} sx={{ mb: 1.5 }} inputProps={{ min: 0 }} />
-              <Box sx={{ display: 'flex', gap: 1 }}>
-                <Button size="small" onClick={() => { setShowRecurringForm(false); setRecurringDraft(emptyRecurring()); }} sx={{ color: 'text.secondary' }}>Cancel</Button>
-                <Button size="small" variant="contained" disabled={!recurringDraft.amount || (!recurringDraft.label && !recurringDraft.description)}
-                  onClick={() => {
-                    addRecurring({ ...recurringDraft, label: recurringDraft.label || recurringDraft.description, item: recurringDraft.item || undefined, category: recurringDraft.category || undefined });
-                    setShowRecurringForm(false);
-                    setRecurringDraft(emptyRecurring());
-                  }}
-                  sx={{ flex: 1 }}
-                >
-                  Save
-                </Button>
-              </Box>
-            </Box>
-          )}
-        </Box>
       </Box>
 
       <Button

--- a/src/hooks/useRecurring.ts
+++ b/src/hooks/useRecurring.ts
@@ -12,6 +12,7 @@ export interface RecurringItem {
   category?: string;
   participants?: string[];
   frequency?: 'monthly' | 'weekly' | 'daily';
+  startDate?: string; // ISO date — when recurring begins
   lastApplied?: string; // 'YYYY-MM'
 }
 
@@ -60,6 +61,7 @@ function apiToItem(api: RecurringExpenseAPI, meta: Partial<RecurringItem> = {}):
     item: meta.item,
     participants: meta.participants,
     frequency: FREQ_FROM_API[api.frequency] || 'monthly',
+    startDate: api.start_date || meta.startDate,
     lastApplied: meta.lastApplied,
   };
 }
@@ -116,12 +118,12 @@ export function useRecurring() {
         name: item.label || item.description,
         amount: item.amount,
         category: item.category,
-        start_date: new Date().toISOString(),
+        start_date: item.startDate || new Date().toISOString(),
         frequency: FREQ_TO_API[item.frequency || 'monthly'] || 'MONTHLY',
         description: item.description,
       });
       const meta = loadMeta();
-      meta[created._id] = { type: item.type, item: item.item, participants: item.participants };
+      meta[created._id] = { type: item.type, item: item.item, participants: item.participants, startDate: item.startDate };
       persistMeta(meta);
       metaRef.current = meta;
       const newItem = apiToItem(created, meta[created._id]);


### PR DESCRIPTION
## Summary
- Extracted Monthly Recurring from Settings into its own dedicated **Recurring** tab (nav index 4)
- Added **start date picker** to the recurring form (was hardcoded to today)
- Settings page is now cleaner (5 sections instead of 7)
- Recurring page has summary cards showing monthly expense/income totals, grouped lists, and empty state

## Changes
- New: `src/components/recurring/RecurringPage.tsx` — full recurring management page
- Modified: `MainLayout.tsx` — added Recurring tab to nav (desktop sidebar + mobile bottom nav)
- Modified: `SettingsPage.tsx` — removed recurring section + unused imports
- Modified: `useRecurring.ts` — added `startDate` field to RecurringItem, passes through to API

## Test plan
- [ ] Recurring tab appears in both desktop sidebar and mobile bottom nav
- [ ] Existing recurring items display correctly with expense/income grouping
- [ ] Adding new recurring with start date works
- [ ] Deleting recurring items works
- [ ] Settings page no longer shows Monthly Recurring section
- [ ] Settings page renders cleanly with remaining sections
- [ ] Build passes: `CI=false yarn build`

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)