### PR TITLE
feat: smart auto-suggest from transaction history

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -62,6 +62,7 @@ import SettingsPage from './settings/SettingsPage';
 import { useBudgets } from '../hooks/useBudgets';
 import OnboardingFlow, { isOnboardingComplete, markOnboardingComplete } from './onboarding/OnboardingFlow';
 import SpendingInsightsPage from './insights/SpendingInsightsPage';
+import { useSmartSuggestions } from '../hooks/useSmartSuggestions';
 
 function getOwnerFromToken(): string {
   try {
@@ -306,6 +307,8 @@ const MainLayout: React.FC = () => {
       });
     return map;
   }, [transactions]);
+
+  const smartSuggestions = useSmartSuggestions(transactions);
 
   const handlePresetChange = (p: DatePreset) => {
     setDatePreset(p);
@@ -1008,11 +1011,13 @@ const MainLayout: React.FC = () => {
         onSubmit={handleAdd}
         existingCategories={existingCategories}
         descriptionsByItem={descriptionsByItem}
-        knownParticipants={knownParticipants}
+        knownParticipants={smartSuggestions.rankedParticipants}
         recentItems={recentItems}
         amountsByDescription={amountsByDescription}
         categoriesByDescription={categoriesByDescription}
         receiptPrefill={receiptPrefill}
+        participantsForItem={smartSuggestions.participantsForItem}
+        timeRelevantItems={smartSuggestions.timeRelevantItems}
       />
 
       <QuickExpenseInput

--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -64,6 +64,10 @@ interface Props {
   amountsByDescription?: Record<string, number>;
   categoriesByDescription?: Record<string, string>;
   receiptPrefill?: ReceiptPrefill;
+  /** Smart suggestions: participants ranked for current item */
+  participantsForItem?: (item: string) => string[];
+  /** Smart suggestions: time-relevant items for current hour */
+  timeRelevantItems?: string[];
 }
 
 const today = () => new Date().toISOString().split('T')[0];
@@ -75,7 +79,7 @@ const yesterday = () => {
 
 type QuickDate = 'today' | 'yesterday' | 'custom';
 
-const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, descriptionsByItem = {}, knownParticipants = [], recentItems = [], amountsByDescription = {}, categoriesByDescription = {}, receiptPrefill }) => {
+const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, descriptionsByItem = {}, knownParticipants = [], recentItems = [], amountsByDescription = {}, categoriesByDescription = {}, receiptPrefill, participantsForItem, timeRelevantItems = [] }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { templates, addTemplate, deleteTemplate } = useTemplates();
@@ -394,7 +398,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
         </Box>
 
         {/* Item picker — sets item + category, filtered by type */}
-        <ItemPicker value={item} type={type} onSelect={handleItemSelect} recentItems={recentItems} />
+        <ItemPicker value={item} type={type} onSelect={handleItemSelect} recentItems={recentItems} timeRelevantItems={timeRelevantItems} />
 
         {/* Description — tag picker */}
         {(() => {
@@ -498,7 +502,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
         </Box>
 
         <Collapse in={showMore}>
-          <ParticipantPicker value={participants} onChange={setParticipants} suggestions={knownParticipants} />
+          <ParticipantPicker value={participants} onChange={setParticipants} suggestions={participantsForItem && item ? participantsForItem(item) : knownParticipants} />
 
           {participants.length > 0 && (
             <Box sx={{ mt: 1, mb: 0.5 }}>

--- a/src/components/expenses/DescriptionPicker.tsx
+++ b/src/components/expenses/DescriptionPicker.tsx
@@ -39,7 +39,15 @@ const DescriptionPicker: React.FC<Props> = ({ value, onChange, suggestions, cate
         }
       }
 
-      setSuggestedCategory(bestMatch?.category || null);
+      if (bestMatch) {
+        setSuggestedCategory(bestMatch.category);
+        // Auto-apply category on exact or near-exact match
+        if (bestMatch.score >= 0.85 && onCategorySelect) {
+          onCategorySelect(bestMatch.category);
+        }
+      } else {
+        setSuggestedCategory(null);
+      }
     }, 300);
 
     return () => {

--- a/src/components/expenses/ItemPicker.tsx
+++ b/src/components/expenses/ItemPicker.tsx
@@ -66,16 +66,25 @@ interface Props {
   type: TransactionType;
   onSelect: (item: ItemPreset) => void;
   recentItems?: string[]; // ordered by most recently used
+  timeRelevantItems?: string[]; // items relevant to current time of day
 }
 
-const ItemPicker: React.FC<Props> = ({ value, type, onSelect, recentItems }) => {
+const ItemPicker: React.FC<Props> = ({ value, type, onSelect, recentItems, timeRelevantItems = [] }) => {
   const filtered = ITEM_PRESETS.filter((p) => p.type === type);
-  const presets = recentItems && recentItems.length
-    ? [
-        ...filtered.filter((p) => recentItems.includes(p.label)).sort((a, b) => recentItems.indexOf(a.label) - recentItems.indexOf(b.label)),
-        ...filtered.filter((p) => !recentItems.includes(p.label)),
-      ]
-    : filtered;
+  // Score each item: time relevance (highest priority) + recency
+  const presets = [...filtered].sort((a, b) => {
+    const aTimeIdx = timeRelevantItems.indexOf(a.en);
+    const bTimeIdx = timeRelevantItems.indexOf(b.en);
+    const aRecIdx = recentItems?.indexOf(a.label) ?? -1;
+    const bRecIdx = recentItems?.indexOf(b.label) ?? -1;
+    // Time-relevant items first (lower index = higher priority)
+    const aTimeScore = aTimeIdx >= 0 ? 100 - aTimeIdx : 0;
+    const bTimeScore = bTimeIdx >= 0 ? 100 - bTimeIdx : 0;
+    // Recent items get a boost
+    const aRecScore = aRecIdx >= 0 ? 50 - aRecIdx : 0;
+    const bRecScore = bRecIdx >= 0 ? 50 - bRecIdx : 0;
+    return (bTimeScore + bRecScore) - (aTimeScore + aRecScore);
+  });
 
   return (
     <Box sx={{ mb: 1.5 }}>

--- a/src/hooks/useSmartSuggestions.ts
+++ b/src/hooks/useSmartSuggestions.ts
@@ -1,0 +1,119 @@
+import { useMemo } from 'react';
+import { Transaction } from '../types';
+
+interface SmartSuggestions {
+  /** Participants ranked by relevance to current context */
+  rankedParticipants: string[];
+  /** Item labels sorted by time-of-day relevance */
+  timeRelevantItems: string[];
+  /** Category for a given description (auto-applied, not just suggested) */
+  categoryForDescription: (desc: string) => string | undefined;
+  /** Participants most associated with a given item */
+  participantsForItem: (item: string) => string[];
+}
+
+function getHourBucket(): 'morning' | 'afternoon' | 'evening' | 'night' {
+  const h = new Date().getHours();
+  if (h >= 5 && h < 12) return 'morning';
+  if (h >= 12 && h < 17) return 'afternoon';
+  if (h >= 17 && h < 22) return 'evening';
+  return 'night';
+}
+
+const MEAL_ITEMS: Record<string, string[]> = {
+  morning: ['Breakfast', 'Coffee'],
+  afternoon: ['Lunch', 'Coffee'],
+  evening: ['Dinner', 'Drinks'],
+  night: ['Supper', 'Drinks'],
+};
+
+export function useSmartSuggestions(transactions: Transaction[]): SmartSuggestions {
+  const bucket = getHourBucket();
+
+  const rankedParticipants = useMemo(() => {
+    const scores: Record<string, number> = {};
+    const now = Date.now();
+
+    transactions.forEach((t) => {
+      if (!t.participants?.length) return;
+      const age = (now - new Date(t.date || t.createdAt).getTime()) / (1000 * 60 * 60 * 24);
+      // Recency: recent transactions score higher (decay over 30 days)
+      const recencyScore = Math.max(0, 1 - age / 90);
+      // Time-of-day: transactions at similar hour score higher
+      const txHour = new Date(t.date || t.createdAt).getHours();
+      const currentHour = new Date().getHours();
+      const hourDiff = Math.abs(txHour - currentHour);
+      const timeScore = hourDiff <= 3 ? 0.3 : 0;
+
+      t.participants.forEach((p) => {
+        scores[p] = (scores[p] || 0) + 1 + recencyScore + timeScore;
+      });
+    });
+
+    return Object.entries(scores)
+      .sort((a, b) => b[1] - a[1])
+      .map(([name]) => name);
+  }, [transactions]);
+
+  const timeRelevantItems = useMemo(() => {
+    const preferred = MEAL_ITEMS[bucket] || [];
+    // Count how often each item appears at this time of day
+    const itemScores: Record<string, number> = {};
+    transactions.forEach((t) => {
+      if (!t.item) return;
+      const txHour = new Date(t.date || t.createdAt).getHours();
+      const txBucket = txHour >= 5 && txHour < 12 ? 'morning'
+        : txHour >= 12 && txHour < 17 ? 'afternoon'
+        : txHour >= 17 && txHour < 22 ? 'evening' : 'night';
+      if (txBucket === bucket) {
+        itemScores[t.item] = (itemScores[t.item] || 0) + 1;
+      }
+    });
+    // Return preferred items first, then history-based items
+    const historyItems = Object.entries(itemScores)
+      .sort((a, b) => b[1] - a[1])
+      .map(([item]) => item)
+      .filter((item) => !preferred.includes(item));
+    return [...preferred, ...historyItems];
+  }, [transactions, bucket]);
+
+  const categoryForDescription = useMemo(() => {
+    // Build map: lowercase description → category (most recent wins)
+    const map: Record<string, string> = {};
+    [...transactions]
+      .sort((a, b) => new Date(b.date || b.createdAt).getTime() - new Date(a.date || a.createdAt).getTime())
+      .forEach((t) => {
+        const key = (t.description?.trim() || '').toLowerCase();
+        if (key && t.category && !map[key]) map[key] = t.category;
+      });
+    return (desc: string): string | undefined => {
+      const key = desc.trim().toLowerCase();
+      return map[key];
+    };
+  }, [transactions]);
+
+  const participantsForItem = useMemo(() => {
+    // Build map: item → participant scores
+    const itemParticipants: Record<string, Record<string, number>> = {};
+    const now = Date.now();
+    transactions.forEach((t) => {
+      if (!t.item || !t.participants?.length) return;
+      const itemKey = t.item;
+      const age = (now - new Date(t.date || t.createdAt).getTime()) / (1000 * 60 * 60 * 24);
+      const recencyScore = Math.max(0, 1 - age / 90);
+      if (!itemParticipants[itemKey]) itemParticipants[itemKey] = {};
+      t.participants.forEach((p) => {
+        itemParticipants[itemKey][p] = (itemParticipants[itemKey][p] || 0) + 1 + recencyScore;
+      });
+    });
+    return (item: string): string[] => {
+      const scores = itemParticipants[item];
+      if (!scores) return [];
+      return Object.entries(scores)
+        .sort((a, b) => b[1] - a[1])
+        .map(([name]) => name);
+    };
+  }, [transactions]);
+
+  return { rankedParticipants, timeRelevantItems, categoryForDescription, participantsForItem };
+}


### PR DESCRIPTION
## Summary
- New `useSmartSuggestions` hook that mines transaction history for behavioral patterns
- Participants ranked by co-occurrence with selected item + recency + time-of-day
- Item picker reorders based on time relevance (breakfast items first in morning, dinner in evening)
- DescriptionPicker auto-applies category when match score >= 0.85 (was manual click only)

## How it works
- **No API calls** — pure client-side pattern matching from existing transactions
- **Recency decay** — recent transactions (< 90 days) weight higher
- **Time buckets** — morning/afternoon/evening/night map to meal types
- **Per-item participants** — "Dinner" suggests Casey first if you usually eat dinner with Casey

## Test plan
- [ ] Open Add Transaction in morning → breakfast/coffee items appear first
- [ ] Open Add Transaction in evening → dinner/drinks items appear first  
- [ ] Select "Dinner" item → participant suggestions show dinner companions first
- [ ] Type a description that matches history → category auto-applies
- [ ] Suggestions are still overridable (user can pick different item/participant/category)
- [ ] Build passes: `CI=false yarn build`

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)