### PR TITLE
feat: NLP sentence input for quick transaction entry

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -36,6 +36,8 @@ import TemplateChips from './TemplateChips';
 import ManageTemplatesDrawer from './ManageTemplatesDrawer';
 import ParticipantPicker from './ParticipantPicker';
 import PaymentMethodPicker from './PaymentMethodPicker';
+import NlpInput from './NlpInput';
+import { ParsedTransaction } from '../../services/api';
 import { useTemplates, TransactionTemplate } from '../../hooks/useTemplates';
 import { useFxRates, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
 import { useItemPresets } from '../../hooks/useItemPresets';
@@ -130,6 +132,21 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
     setDescription(t.description);
     if (t.item) setItem(t.item);
     if (t.defaultAmount) setAmount(String(t.defaultAmount));
+  };
+
+  const handleNlpParsed = (result: ParsedTransaction) => {
+    if (result.amount) setAmount(String(result.amount));
+    if (result.category) setCategory(result.category);
+    if (result.notes || result.merchant) setDescription(result.notes || result.merchant || '');
+    if (result.participants?.length) setParticipants(result.participants);
+    if (result.date) {
+      setQuickDate('custom');
+      setCustomDate(result.date);
+    }
+    // If amount exists, it's likely an expense unless explicitly income
+    if (result.missing_fields?.length) {
+      // Focus user's attention on missing fields — no-op for now, form is visible
+    }
   };
 
   const resolvedDate = quickDate === 'today' ? today() : quickDate === 'yesterday' ? yesterday() : customDate;
@@ -334,6 +351,9 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
             </Box>
           </Box>
         )}
+
+        {/* NLP quick entry */}
+        {!receiptPrefill && <NlpInput onParsed={handleNlpParsed} />}
 
         {/* Template quick-tap row */}
         <TemplateChips

--- a/src/components/expenses/NlpInput.tsx
+++ b/src/components/expenses/NlpInput.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { Box, TextField, IconButton, CircularProgress, Typography, Chip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import { parseTransactionText, ParsedTransaction } from '../../services/api';
+
+interface Props {
+  onParsed: (result: ParsedTransaction) => void;
+}
+
+const NlpInput: React.FC<Props> = ({ onParsed }) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+  const [text, setText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleParse = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    setError('');
+    try {
+      const result = await parseTransactionText(trimmed);
+      onParsed(result);
+      setText('');
+    } catch (err: any) {
+      const status = err?.response?.status;
+      if (status === 429) {
+        setError('Too many requests — try again in a minute');
+      } else {
+        setError('Could not parse — try entering manually');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ mb: 1.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+        <AutoFixHighIcon sx={{ fontSize: 14, color: 'primary.main' }} />
+        <Typography variant="caption" sx={{ fontSize: '0.68rem', color: 'primary.main', fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+          Quick Entry
+        </Typography>
+        <Chip label="AI" size="small" sx={{ height: 16, fontSize: '0.6rem', bgcolor: isDark ? 'rgba(129,140,248,0.15)' : 'rgba(99,102,241,0.12)', color: 'primary.main', ml: 0.5 }} />
+      </Box>
+      <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'flex-start' }}>
+        <TextField
+          size="small"
+          fullWidth
+          multiline
+          maxRows={2}
+          placeholder="e.g. 今日同Casey食咗麥當勞 $65"
+          value={text}
+          onChange={(e) => { setText(e.target.value); setError(''); }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleParse();
+            }
+          }}
+          disabled={loading}
+          error={!!error}
+          helperText={error || undefined}
+          sx={{
+            '& .MuiInputBase-root': {
+              fontSize: '0.88rem',
+              py: 0.5,
+              bgcolor: isDark ? 'rgba(129,140,248,0.04)' : 'rgba(99,102,241,0.04)',
+              borderRadius: 2,
+            },
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: isDark ? 'rgba(129,140,248,0.2)' : 'rgba(99,102,241,0.2)',
+            },
+            '& .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'primary.main',
+            },
+          }}
+        />
+        <IconButton
+          size="small"
+          onClick={handleParse}
+          disabled={loading || !text.trim()}
+          sx={{
+            mt: 0.25,
+            bgcolor: isDark ? 'rgba(129,140,248,0.12)' : 'rgba(99,102,241,0.12)',
+            border: `1px solid ${isDark ? 'rgba(129,140,248,0.25)' : 'rgba(99,102,241,0.25)'}`,
+            '&:hover': { bgcolor: isDark ? 'rgba(129,140,248,0.22)' : 'rgba(99,102,241,0.22)' },
+            '&.Mui-disabled': { opacity: 0.4 },
+          }}
+        >
+          {loading ? <CircularProgress size={18} /> : <AutoFixHighIcon sx={{ fontSize: 18, color: 'primary.main' }} />}
+        </IconButton>
+      </Box>
+    </Box>
+  );
+};
+
+export default NlpInput;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -287,6 +287,25 @@ export const removeFriend = async (id: string): Promise<void> => {
   await axiosInstance.delete(`/api/friends/${id}`);
 };
 
+// NLP Transaction Parsing
+export interface ParsedTransaction {
+  merchant?: string;
+  amount?: number;
+  currency?: string;
+  category?: string;
+  subcategory?: string;
+  participants?: string[];
+  date?: string;
+  notes?: string;
+  confidence?: number;
+  missing_fields?: string[];
+}
+
+export const parseTransactionText = async (text: string, locale = 'zh-HK'): Promise<ParsedTransaction> => {
+  const res = await axiosInstance.post('/api/transactions/parse-text', { text, locale }, { timeout: 15000 });
+  return res.data;
+};
+
 // Receipts
 export const scanReceipt = async (file: File): Promise<ReceiptScanResult> => {
   const form = new FormData();


### PR DESCRIPTION
## Summary
- New `NlpInput` component — AI-powered "Quick Entry" text field at the top of Add Transaction
- New `parseTransactionText` API function calling `POST /api/transactions/parse-text`
- Parsed result pre-fills: amount, category, description, participants, date
- Hidden when receipt prefill is active (no double input)

## How it works
1. User types: "今日同Casey食咗麥當勞 $65"
2. Presses Enter or tap the send button
3. Backend (Claude Haiku) parses → structured data
4. Fields auto-populate in the form
5. User reviews and saves

## Changes
- New: `NlpInput.tsx` — text field + parse button + loading/error states
- Modified: `AddExpenseModal.tsx` — integrates NlpInput, adds `handleNlpParsed`
- Modified: `api.ts` — adds `parseTransactionText()` + `ParsedTransaction` interface

## Dependencies
- Requires backend PR wkliwk/money-flow-backend#111 (`POST /api/transactions/parse-text`)
- Will show error until backend endpoint is deployed

## Test plan
- [ ] NLP input appears at top of Add Transaction modal
- [ ] NLP input hidden when receipt prefill is active
- [ ] Typing and pressing Enter triggers parse
- [ ] Parsed fields populate the form correctly
- [ ] Missing amount shows error (handled by form validation)
- [ ] Rate limit error shows user-friendly message
- [ ] Parse failure shows fallback message
- [ ] Build passes: `CI=false yarn build`

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)