### PR TITLE
feat: add 'participate' option for group expenses

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -93,7 +93,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
   const [quickDate, setQuickDate] = useState<QuickDate>('today');
   const [customDate, setCustomDate] = useState(today());
   const [participants, setParticipants] = useState<string[]>([]);
-  const [splitBillMode, setSplitBillMode] = useState<'treat' | 'split'>('treat');
+  const [splitBillMode, setSplitBillMode] = useState<'treat' | 'split' | 'participate'>('treat');
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState<RecurringFrequency>('monthly');
@@ -169,7 +169,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
       item: item || undefined,
       category: category || undefined,
       participants: participants,
-      splitBill: participants.length > 0 ? splitBillMode === 'split' : undefined,
+      splitBill: participants.length > 0 ? splitBillMode : undefined,
       paymentMethod: paymentMethod || undefined,
       notes: notes.trim() || undefined,
       date: resolvedDate,
@@ -514,6 +514,9 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
                 </ToggleButton>
                 <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
                   My treat
+                </ToggleButton>
+                <ToggleButton value="participate" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  Participate
                 </ToggleButton>
               </ToggleButtonGroup>
             </Box>

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -84,7 +84,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
   const [quickDate, setQuickDate] = useState<QuickDate>('today');
   const [customDate, setCustomDate] = useState(todayStr());
   const [participants, setParticipants] = useState<string[]>([]);
-  const [splitBillMode, setSplitBillMode] = useState<'treat' | 'split'>('treat');
+  const [splitBillMode, setSplitBillMode] = useState<'treat' | 'split' | 'participate'>('treat');
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
   const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(false);
@@ -107,7 +107,10 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
       setAmount(String(transaction.amount));
       setType(transaction.type);
       setParticipants(transaction.participants ?? []);
-      setSplitBillMode(transaction.splitBill === true ? 'split' : 'treat');
+      setSplitBillMode(
+        typeof transaction.splitBill === 'string' ? transaction.splitBill as 'split' | 'treat' | 'participate'
+          : transaction.splitBill === true ? 'split' : 'treat'
+      );
       setPaymentMethod((transaction.paymentMethod as PaymentMethod) || null);
       setTxCurrency((transaction.currency as Currency) || 'HKD');
       setNotes(transaction.notes || '');
@@ -150,7 +153,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         item: item || undefined,
         category: category || undefined,
         participants: participants,
-        splitBill: participants.length > 0 ? splitBillMode === 'split' : undefined,
+        splitBill: participants.length > 0 ? splitBillMode : undefined,
         paymentMethod: paymentMethod || undefined,
         notes: notes.trim() || undefined,
         date: resolvedDate,
@@ -411,6 +414,9 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
                 </ToggleButton>
                 <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
                   My treat
+                </ToggleButton>
+                <ToggleButton value="participate" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  Participate
                 </ToggleButton>
               </ToggleButtonGroup>
             </Box>

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -23,6 +23,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import RepeatIcon from '@mui/icons-material/Repeat';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
+import GroupIcon from '@mui/icons-material/Group';
 import EmptyState from '../EmptyState';
 import PaymentIcon from '@mui/icons-material/Payment';
 import NoteIcon from '@mui/icons-material/Notes';
@@ -387,17 +388,19 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                                 {t.description}
                               </Typography>
                             )}
-                            {t.participants && t.participants.length > 0 && (
+                            {t.participants && t.participants.length > 0 && (() => {
+                              const mode = typeof t.splitBill === 'string' ? t.splitBill : t.splitBill === true ? 'split' : 'treat';
+                              return (
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.375, mt: 0.25 }}>
-                                {t.splitBill
-                                  ? <CallSplitIcon sx={{ fontSize: 12, color: '#818cf8' }} />
-                                  : <CardGiftcardIcon sx={{ fontSize: 12, color: '#f472b6' }} />
-                                }
+                                {mode === 'split' ? <CallSplitIcon sx={{ fontSize: 12, color: '#818cf8' }} />
+                                  : mode === 'participate' ? <GroupIcon sx={{ fontSize: 12, color: '#94a3b8' }} />
+                                  : <CardGiftcardIcon sx={{ fontSize: 12, color: '#f472b6' }} />}
                                 <Typography sx={{ fontSize: '0.65rem', color: 'text.disabled' }}>
-                                  {t.splitBill ? 'split' : 'treat'} · {t.participants.join(', ')}
+                                  {mode} · {t.participants.join(', ')}
                                 </Typography>
                               </Box>
-                            )}
+                              );
+                            })()}
                             {t.paymentMethod && (
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
                                 <PaymentIcon sx={{ fontSize: 11, color: 'text.disabled' }} />
@@ -519,15 +522,17 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                   </Box>
                 </TableCell>
                 <TableCell sx={{ maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'text.secondary', fontSize: '0.8rem' }}>
-                  {t.participants && t.participants.length > 0 ? (
+                  {t.participants && t.participants.length > 0 ? (() => {
+                    const mode = typeof t.splitBill === 'string' ? t.splitBill : t.splitBill === true ? 'split' : 'treat';
+                    return (
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      {t.splitBill
-                        ? <CallSplitIcon sx={{ fontSize: 14, color: '#818cf8', flexShrink: 0 }} />
-                        : <CardGiftcardIcon sx={{ fontSize: 14, color: '#f472b6', flexShrink: 0 }} />
-                      }
+                      {mode === 'split' ? <CallSplitIcon sx={{ fontSize: 14, color: '#818cf8', flexShrink: 0 }} />
+                        : mode === 'participate' ? <GroupIcon sx={{ fontSize: 14, color: '#94a3b8', flexShrink: 0 }} />
+                        : <CardGiftcardIcon sx={{ fontSize: 14, color: '#f472b6', flexShrink: 0 }} />}
                       {t.participants.join(', ')}
                     </Box>
-                  ) : '—'}
+                    );
+                  })() : '—'}
                 </TableCell>
                 <TableCell>
                   <Chip label={t.type === 'income' ? 'Income' : 'Expense'} color={t.type === 'income' ? 'success' : 'error'} size="small" />

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface Transaction {
   category?: string;
   item?: string;
   participants?: string[];
-  splitBill?: boolean;
+  splitBill?: boolean | 'split' | 'treat' | 'participate';
   paymentMethod?: PaymentMethod | null;
   currency?: string;
   originalAmount?: number;
@@ -58,7 +58,7 @@ export interface TransactionRequest {
   category?: string;
   item?: string;
   participants?: string[];
-  splitBill?: boolean;
+  splitBill?: boolean | 'split' | 'treat' | 'participate';
   paymentMethod?: PaymentMethod | null;
   currency?: string;
   originalAmount?: number;


### PR DESCRIPTION
## Summary
- Third split mode: **Participate** — you were present but someone else paid
- Updated ToggleButtonGroup in both Add and Edit modals (Split / Treat / Participate)
- Transaction list shows distinct icons per mode: split (indigo), treat (pink), participate (grey)
- `splitBill` type updated to support string enum alongside legacy boolean
- Backward compatible: existing `true` → split, `false` → treat

## Changes
- `types.ts` — `splitBill` now accepts `boolean | 'split' | 'treat' | 'participate'`
- `AddExpenseModal.tsx` — third toggle, sends string mode instead of boolean
- `EditExpenseModal.tsx` — third toggle, loads string/boolean mode correctly
- `ExpenseList.tsx` — GroupIcon for participate, mode-aware rendering

## Test plan
- [ ] Add participants → 3 toggle options visible (Split / Treat / Participate)
- [ ] Select Participate → saves correctly
- [ ] Transaction list shows correct icon per mode
- [ ] Edit existing transaction with boolean splitBill → loads correct mode
- [ ] Edit existing transaction with string splitBill → loads correct mode
- [ ] Build passes

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)