### PR TITLE
fix: add icons to Split Bill / My Treat toggle buttons

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -27,6 +27,8 @@ import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import RepeatIcon from '@mui/icons-material/Repeat';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import CallSplitIcon from '@mui/icons-material/CallSplit';
+import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
 import { TransactionRequest, TransactionType, PaymentMethod } from '../../types';
 import { ReceiptConfidence } from '../../services/api';
 import NumPad from './NumPad';
@@ -534,9 +536,11 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
                 sx={{ height: 30 }}
               >
                 <ToggleButton value="split" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  <CallSplitIcon sx={{ fontSize: 14, mr: 0.5 }} />
                   Split bill
                 </ToggleButton>
                 <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  <CardGiftcardIcon sx={{ fontSize: 14, mr: 0.5 }} />
                   My treat
                 </ToggleButton>
                 <ToggleButton value="participate" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -27,6 +27,8 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import CallSplitIcon from '@mui/icons-material/CallSplit';
+import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../../types';
 import { updateExpense } from '../../services/api';
@@ -410,9 +412,11 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
                 sx={{ height: 30 }}
               >
                 <ToggleButton value="split" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  <CallSplitIcon sx={{ fontSize: 14, mr: 0.5 }} />
                   Split bill
                 </ToggleButton>
                 <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
+                  <CardGiftcardIcon sx={{ fontSize: 14, mr: 0.5 }} />
                   My treat
                 </ToggleButton>
                 <ToggleButton value="participate" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>


### PR DESCRIPTION
## Summary
- `AddExpenseModal` and `EditExpenseModal` toggle buttons now show distinct icons alongside text
- `CallSplitIcon` (matches purple display in ExpenseList) for Split bill
- `CardGiftcardIcon` (matches pink display in ExpenseList) for My treat

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)