### PR TITLE
Enhance split bill / my treat icons with active state colors

### DIFF
--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -536,11 +536,11 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
                 sx={{ height: 30 }}
               >
                 <ToggleButton value="split" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
-                  <CallSplitIcon sx={{ fontSize: 14, mr: 0.5 }} />
+                  <CallSplitIcon sx={{ fontSize: 14, mr: 0.5, color: splitBillMode === 'split' ? '#818cf8' : 'inherit' }} />
                   Split bill
                 </ToggleButton>
                 <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
-                  <CardGiftcardIcon sx={{ fontSize: 14, mr: 0.5 }} />
+                  <CardGiftcardIcon sx={{ fontSize: 14, mr: 0.5, color: splitBillMode === 'treat' ? '#f472b6' : 'inherit' }} />
                   My treat
                 </ToggleButton>
                 <ToggleButton value="participate" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -412,11 +412,11 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
                 sx={{ height: 30 }}
               >
                 <ToggleButton value="split" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
-                  <CallSplitIcon sx={{ fontSize: 14, mr: 0.5 }} />
+                  <CallSplitIcon sx={{ fontSize: 14, mr: 0.5, color: splitBillMode === 'split' ? '#818cf8' : 'inherit' }} />
                   Split bill
                 </ToggleButton>
                 <ToggleButton value="treat" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>
-                  <CardGiftcardIcon sx={{ fontSize: 14, mr: 0.5 }} />
+                  <CardGiftcardIcon sx={{ fontSize: 14, mr: 0.5, color: splitBillMode === 'treat' ? '#f472b6' : 'inherit' }} />
                   My treat
                 </ToggleButton>
                 <ToggleButton value="participate" sx={{ fontSize: '0.72rem', px: 1.5, textTransform: 'none', borderColor: 'rgba(148,163,184,0.15)' }}>


### PR DESCRIPTION
## What
Enhanced the visual styling of the Split Bill and My Treat toggle buttons in the Add Expense and Edit Expense modals by adding conditional icon colors that change based on the active state.

## Why
Closes #218

The icons already existed in the toggle buttons, but they lacked color styling when active. By applying the same colors used in ExpenseList (#818cf8 for split, #f472b6 for treat), users get better visual feedback about which option is currently selected.

## Acceptance Criteria
- [x] CallSplitIcon shows #818cf8 (indigo) when split bill is active
- [x] CardGiftcardIcon shows #f472b6 (pink) when my treat is active
- [x] Icons return to inherit color when not active
- [x] Applied to both AddExpenseModal and EditExpenseModal
- [x] No TypeScript errors
- [x] Visual consistency with ExpenseList component

## Test Plan
1. Open the Add Expense modal
2. Add a participant in the "More options" section
3. Verify the Split Bill icon turns indigo (#818cf8) when selected
4. Verify the My Treat icon turns pink (#f472b6) when selected
5. Verify the Participate button has no icon color
6. Repeat steps 2-5 in the Edit Expense modal with an existing transaction

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>