### PR TITLE
feat: savings goals — set target amount with progress tracking

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -28,6 +28,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import CategoryIcon from '@mui/icons-material/Category';
 import SettingsIcon from '@mui/icons-material/Settings';
+import SavingsIcon from '@mui/icons-material/Savings';
 import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType } from '../types';
 import { getExpenses, getExpense, createExpense, deleteExpense } from '../services/api';
@@ -48,6 +49,7 @@ import { useRecurring } from '../hooks/useRecurring';
 import ManageItemsPage from './items/ManageItemsPage';
 import SettingsPage from './settings/SettingsPage';
 import { useBudgets } from '../hooks/useBudgets';
+import GoalsPage from './goals/GoalsPage';
 
 function getOwnerFromToken(): string {
   try {
@@ -65,7 +67,7 @@ const MainLayout: React.FC = () => {
   const { currency, setCurrency, convert, symbol } = useFxRates();
   const { items: recurringItems, markApplied } = useRecurring();
   const { budgets } = useBudgets();
-  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3>(0);
+  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4>(0);
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
 
   useEffect(() => {
@@ -367,6 +369,7 @@ const MainLayout: React.FC = () => {
     { label: 'Home', icon: <DashboardIcon /> },
     { label: 'Transactions', icon: <ReceiptLongIcon /> },
     { label: 'Items', icon: <CategoryIcon /> },
+    { label: 'Goals', icon: <SavingsIcon /> },
     { label: 'Settings', icon: <SettingsIcon /> },
   ];
 
@@ -422,7 +425,7 @@ const MainLayout: React.FC = () => {
             <ListItemButton
               key={item.label}
               selected={activeTab === index}
-              onClick={() => setActiveTab(index as 0 | 1 | 2 | 3)}
+              onClick={() => setActiveTab(index as 0 | 1 | 2 | 3 | 4)}
               sx={{
                 '&.Mui-selected': { bgcolor: 'rgba(129,140,248,0.1)', color: '#818cf8' },
                 '&.Mui-selected .MuiListItemIcon-root': { color: '#818cf8' },
@@ -694,6 +697,10 @@ const MainLayout: React.FC = () => {
           {activeTab === 2 && <ManageItemsPage />}
 
           {activeTab === 3 && (
+            <GoalsPage convert={convert} symbol={symbol} />
+          )}
+
+          {activeTab === 4 && (
             <SettingsPage
               currency={currency}
               onCurrencyChange={(c: Currency) => setCurrency(c)}
@@ -723,6 +730,7 @@ const MainLayout: React.FC = () => {
           <BottomNavigationAction label="Home" icon={<DashboardIcon />} />
           <BottomNavigationAction label="Txns" icon={<ReceiptLongIcon />} />
           <BottomNavigationAction label="Items" icon={<CategoryIcon />} />
+          <BottomNavigationAction label="Goals" icon={<SavingsIcon />} />
           <BottomNavigationAction label="Settings" icon={<SettingsIcon />} />
         </BottomNavigation>
       </Box>

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -1,0 +1,270 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardActionArea,
+  CardContent,
+  LinearProgress,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  IconButton,
+  Chip,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import SavingsIcon from '@mui/icons-material/Savings';
+import dayjs from 'dayjs';
+import { useGoals } from '../../hooks/useGoals';
+
+interface Props {
+  convert: (hkd: number) => number;
+  symbol: string;
+}
+
+const fmt = (n: number, symbol: string) =>
+  `${symbol}${n.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+
+const GoalsPage: React.FC<Props> = ({ convert, symbol }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const { goals, addGoal, updateAmount, deleteGoal } = useGoals();
+  const [addOpen, setAddOpen] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editAmount, setEditAmount] = useState('');
+  const [form, setForm] = useState({ name: '', targetAmount: '', deadline: '', category: '' });
+
+  const handleAdd = () => {
+    if (!form.name || !form.targetAmount) return;
+    addGoal({
+      name: form.name,
+      targetAmount: Number(form.targetAmount),
+      deadline: form.deadline || undefined,
+      category: form.category || undefined,
+    });
+    setForm({ name: '', targetAmount: '', deadline: '', category: '' });
+    setAddOpen(false);
+  };
+
+  const handleUpdateAmount = () => {
+    if (editId && editAmount) {
+      updateAmount(editId, Number(editAmount));
+      setEditId(null);
+      setEditAmount('');
+    }
+  };
+
+  const sortedGoals = [...goals].sort((a, b) => {
+    const aComplete = a.currentAmount >= a.targetAmount;
+    const bComplete = b.currentAmount >= b.targetAmount;
+    if (aComplete !== bComplete) return aComplete ? 1 : -1;
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+
+  return (
+    <Box sx={{ pb: 10 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          Savings Goals
+        </Typography>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => setAddOpen(true)}
+          sx={{ borderRadius: 2 }}
+        >
+          Add Goal
+        </Button>
+      </Box>
+
+      {sortedGoals.length === 0 && (
+        <Box sx={{ textAlign: 'center', py: 8 }}>
+          <SavingsIcon sx={{ fontSize: 56, color: 'text.secondary', opacity: 0.4, mb: 2 }} />
+          <Typography variant="h6" sx={{ color: 'text.secondary', mb: 1 }}>No goals yet</Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
+            Add your first goal to start tracking your savings
+          </Typography>
+          <Button variant="outlined" startIcon={<AddIcon />} onClick={() => setAddOpen(true)}>
+            Add Goal
+          </Button>
+        </Box>
+      )}
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(auto-fill, minmax(320px, 1fr))', gap: 2 }}>
+        {sortedGoals.map((goal) => {
+          const pct = Math.min(100, (goal.currentAmount / goal.targetAmount) * 100);
+          const isComplete = pct >= 100;
+          const daysLeft = goal.deadline ? dayjs(goal.deadline).diff(dayjs(), 'day') : null;
+
+          return (
+            <Card
+              key={goal.id}
+              sx={{
+                position: 'relative',
+                overflow: 'visible',
+                border: isComplete ? `1px solid ${theme.palette.success.main}` : undefined,
+                background: isComplete
+                  ? `linear-gradient(135deg, ${theme.palette.mode === 'dark' ? 'rgba(52,211,153,0.08)' : 'rgba(16,185,129,0.06)'} 0%, transparent 100%)`
+                  : undefined,
+              }}
+            >
+              <CardActionArea
+                onClick={() => {
+                  setEditId(goal.id);
+                  setEditAmount(String(goal.currentAmount));
+                }}
+              >
+                <CardContent sx={{ p: 2.5 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mb: 1.5 }}>
+                    <Box sx={{ flex: 1 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                        {isComplete && <CheckCircleIcon sx={{ color: 'success.main', fontSize: 20 }} />}
+                        <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+                          {goal.name}
+                        </Typography>
+                      </Box>
+                      {goal.category && (
+                        <Chip label={goal.category} size="small" sx={{ mt: 0.5, fontSize: '0.68rem', height: 22 }} />
+                      )}
+                    </Box>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteGoal(goal.id);
+                      }}
+                      sx={{ color: 'text.secondary', opacity: 0.5, '&:hover': { opacity: 1, color: 'error.main' } }}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+
+                  <Box sx={{ mb: 1.5 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                      <Typography variant="h6" sx={{ fontWeight: 700, color: isComplete ? 'success.main' : 'text.primary' }}>
+                        {fmt(convert(goal.currentAmount), symbol)}
+                      </Typography>
+                      <Typography variant="body2" sx={{ color: 'text.secondary', alignSelf: 'flex-end' }}>
+                        of {fmt(convert(goal.targetAmount), symbol)}
+                      </Typography>
+                    </Box>
+                    <LinearProgress
+                      variant="determinate"
+                      value={pct}
+                      sx={{
+                        height: 8,
+                        borderRadius: 4,
+                        bgcolor: theme.palette.mode === 'dark' ? 'rgba(148,163,184,0.1)' : 'rgba(100,116,139,0.1)',
+                        '& .MuiLinearProgress-bar': {
+                          borderRadius: 4,
+                          background: isComplete
+                            ? `linear-gradient(90deg, ${theme.palette.success.main}, ${theme.palette.success.light})`
+                            : `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.primary.light})`,
+                        },
+                      }}
+                    />
+                  </Box>
+
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
+                      {pct.toFixed(0)}% complete
+                    </Typography>
+                    {daysLeft !== null && !isComplete && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: daysLeft < 0 ? 'error.main' : daysLeft < 30 ? 'warning.main' : 'text.secondary',
+                          fontWeight: 600,
+                        }}
+                      >
+                        {daysLeft < 0 ? `${Math.abs(daysLeft)}d overdue` : `${daysLeft}d left`}
+                      </Typography>
+                    )}
+                  </Box>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          );
+        })}
+      </Box>
+
+      {/* Add Goal Dialog */}
+      <Dialog open={addOpen} onClose={() => setAddOpen(false)} fullWidth maxWidth="xs" fullScreen={isMobile}>
+        <DialogTitle sx={{ fontWeight: 700 }}>New Savings Goal</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '8px !important' }}>
+          <TextField
+            label="Goal name"
+            value={form.name}
+            onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            fullWidth
+            autoFocus
+          />
+          <TextField
+            label="Target amount (HKD)"
+            type="number"
+            value={form.targetAmount}
+            onChange={(e) => setForm((f) => ({ ...f, targetAmount: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            label="Deadline (optional)"
+            type="date"
+            value={form.deadline}
+            onChange={(e) => setForm((f) => ({ ...f, deadline: e.target.value }))}
+            fullWidth
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            label="Category (optional)"
+            value={form.category}
+            onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))}
+            fullWidth
+            placeholder="e.g. Vacation, Emergency Fund"
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setAddOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleAdd} disabled={!form.name || !form.targetAmount}>
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Update Amount Dialog */}
+      <Dialog
+        open={!!editId}
+        onClose={() => { setEditId(null); setEditAmount(''); }}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>Update Progress</DialogTitle>
+        <DialogContent sx={{ pt: '8px !important' }}>
+          <TextField
+            label="Current amount saved (HKD)"
+            type="number"
+            value={editAmount}
+            onChange={(e) => setEditAmount(e.target.value)}
+            fullWidth
+            autoFocus
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => { setEditId(null); setEditAmount(''); }}>Cancel</Button>
+          <Button variant="contained" onClick={handleUpdateAmount} disabled={!editAmount}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default GoalsPage;

--- a/src/hooks/useGoals.ts
+++ b/src/hooks/useGoals.ts
@@ -1,0 +1,42 @@
+import { useState, useCallback } from 'react';
+import { SavingsGoal } from '../types';
+
+const KEY = 'mf_savings_goals';
+
+function load(): SavingsGoal[] {
+  try { return JSON.parse(localStorage.getItem(KEY) || '[]'); } catch { return []; }
+}
+
+function save(goals: SavingsGoal[]) {
+  localStorage.setItem(KEY, JSON.stringify(goals));
+}
+
+export function useGoals() {
+  const [goals, setGoals] = useState<SavingsGoal[]>(load);
+
+  const addGoal = useCallback((goal: Omit<SavingsGoal, 'id' | 'createdAt' | 'currentAmount'>) => {
+    setGoals((prev) => {
+      const next = [...prev, { ...goal, id: crypto.randomUUID(), currentAmount: 0, createdAt: new Date().toISOString() }];
+      save(next);
+      return next;
+    });
+  }, []);
+
+  const updateAmount = useCallback((id: string, amount: number) => {
+    setGoals((prev) => {
+      const next = prev.map((g) => g.id === id ? { ...g, currentAmount: Math.max(0, amount) } : g);
+      save(next);
+      return next;
+    });
+  }, []);
+
+  const deleteGoal = useCallback((id: string) => {
+    setGoals((prev) => {
+      const next = prev.filter((g) => g.id !== id);
+      save(next);
+      return next;
+    });
+  }, []);
+
+  return { goals, addGoal, updateAmount, deleteGoal };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,3 +24,13 @@ export interface TransactionRequest {
   participants?: string[];
   date?: string;
 }
+
+export interface SavingsGoal {
+  id: string;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  deadline?: string;
+  category?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- New **Goals** tab (between Items and Settings) for tracking savings goals
- `useGoals` hook with localStorage persistence (no backend needed for Phase 2)
- Goal cards with progress bars, % complete, days remaining, and celebration state at 100%
- Add/edit/delete goals with name, target amount, optional deadline and category
- Mobile-responsive with fullscreen dialog on small screens

Closes #34

## Test plan
- [ ] Navigate to Goals tab — shows empty state
- [ ] Add a goal with name + target amount — card appears with 0% progress
- [ ] Tap card → update current amount → verify progress bar updates
- [ ] Add goal with deadline → verify days remaining shows
- [ ] Set current amount >= target → verify success state (green, checkmark)
- [ ] Delete a goal → verify removed
- [ ] Refresh page → verify goals persist (localStorage)
- [ ] Test on mobile (375px) — fullscreen dialog, responsive cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)