### PR TITLE
feat: sync recurring expenses to backend API

### DIFF
--- a/src/hooks/__tests__/useRecurring.test.ts
+++ b/src/hooks/__tests__/useRecurring.test.ts
@@ -1,9 +1,27 @@
 import { renderHook, act } from '@testing-library/react';
+
+const mockGetRecurring = jest.fn().mockResolvedValue([]);
+const mockCreateRecurring = jest.fn().mockResolvedValue({ id: 'server-1', _id: 'server-1' });
+const mockDeleteRecurring = jest.fn().mockResolvedValue(null);
+const mockUpdateRecurring = jest.fn().mockResolvedValue({});
+
+jest.mock('../../services/api', () => ({
+  getRecurring: (...args: unknown[]) => mockGetRecurring(...args),
+  createRecurring: (...args: unknown[]) => mockCreateRecurring(...args),
+  deleteRecurring: (...args: unknown[]) => mockDeleteRecurring(...args),
+  updateRecurring: (...args: unknown[]) => mockUpdateRecurring(...args),
+}));
+
 import { useRecurring } from '../useRecurring';
 
 describe('useRecurring', () => {
   beforeEach(() => {
     localStorage.clear();
+    jest.clearAllMocks();
+    mockGetRecurring.mockResolvedValue([]);
+    mockCreateRecurring.mockResolvedValue({ id: 'server-1', _id: 'server-1' });
+    mockDeleteRecurring.mockResolvedValue(null);
+    mockUpdateRecurring.mockResolvedValue({});
   });
 
   it('starts with empty items', () => {
@@ -26,6 +44,16 @@ describe('useRecurring', () => {
     expect(result.current.items[0].id).toBeDefined();
   });
 
+  it('addItem calls createRecurring API', () => {
+    const { result } = renderHook(() => useRecurring());
+    act(() => {
+      result.current.addItem({ label: 'Netflix', description: 'Streaming', amount: 100, type: 'expense' });
+    });
+    expect(mockCreateRecurring).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Netflix', amount: 100 })
+    );
+  });
+
   it('deleteItem removes item by id', () => {
     const { result } = renderHook(() => useRecurring());
     act(() => {
@@ -38,6 +66,18 @@ describe('useRecurring', () => {
     expect(result.current.items).toHaveLength(0);
   });
 
+  it('deleteItem calls deleteRecurring API', () => {
+    const { result } = renderHook(() => useRecurring());
+    act(() => {
+      result.current.addItem({ label: 'Netflix', description: '', amount: 100, type: 'expense' });
+    });
+    const id = result.current.items[0].id;
+    act(() => {
+      result.current.deleteItem(id);
+    });
+    expect(mockDeleteRecurring).toHaveBeenCalledWith(id);
+  });
+
   it('markApplied sets lastApplied on specified ids', () => {
     const { result } = renderHook(() => useRecurring());
     act(() => {
@@ -48,6 +88,18 @@ describe('useRecurring', () => {
       result.current.markApplied([id], '2026-03');
     });
     expect(result.current.items[0].lastApplied).toBe('2026-03');
+  });
+
+  it('markApplied syncs to server', () => {
+    const { result } = renderHook(() => useRecurring());
+    act(() => {
+      result.current.addItem({ label: 'Rent', description: '', amount: 5000, type: 'expense' });
+    });
+    const id = result.current.items[0].id;
+    act(() => {
+      result.current.markApplied([id], '2026-03');
+    });
+    expect(mockUpdateRecurring).toHaveBeenCalledWith(id, { lastApplied: '2026-03' });
   });
 
   it('persists items to localStorage', () => {

--- a/src/hooks/useRecurring.ts
+++ b/src/hooks/useRecurring.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { TransactionType } from '../types';
+import { getRecurring, createRecurring, deleteRecurring, updateRecurring } from '../services/api';
 
 export interface RecurringItem {
   id: string;
@@ -16,7 +17,7 @@ export interface RecurringItem {
 
 const KEY = 'mf_recurring';
 
-function load(): RecurringItem[] {
+function loadLocal(): RecurringItem[] {
   try {
     const raw = localStorage.getItem(KEY);
     return raw ? JSON.parse(raw) : [];
@@ -25,36 +26,87 @@ function load(): RecurringItem[] {
   }
 }
 
-function persist(items: RecurringItem[]) {
+function persistLocal(items: RecurringItem[]) {
   try {
     localStorage.setItem(KEY, JSON.stringify(items));
   } catch {}
 }
 
 export function useRecurring() {
-  const [items, setItems] = useState<RecurringItem[]>(load);
+  const [items, setItems] = useState<RecurringItem[]>(loadLocal);
+  const fetched = useRef(false);
+
+  useEffect(() => {
+    if (fetched.current) return;
+    fetched.current = true;
+    getRecurring()
+      .then((data) => {
+        const mapped: RecurringItem[] = data.map((d) => ({
+          id: d.id || d._id,
+          label: d.label,
+          item: d.item,
+          description: d.description,
+          amount: d.amount,
+          type: d.type,
+          category: d.category,
+          participants: d.participants,
+          frequency: d.frequency,
+          lastApplied: d.lastApplied,
+        }));
+        setItems(mapped);
+        persistLocal(mapped);
+      })
+      .catch(() => {/* use localStorage fallback */});
+  }, []);
 
   const addItem = useCallback((item: Omit<RecurringItem, 'id'>) => {
+    // Optimistic local update
+    const tempId = String(Date.now());
+    const newItem: RecurringItem = { ...item, id: tempId };
     setItems((prev) => {
-      const next = [...prev, { ...item, id: String(Date.now()) }];
-      persist(next);
+      const next = [...prev, newItem];
+      persistLocal(next);
       return next;
     });
+
+    // Sync to server
+    createRecurring({
+      label: item.label,
+      description: item.description,
+      amount: item.amount,
+      type: item.type,
+      item: item.item,
+      category: item.category,
+      participants: item.participants,
+      frequency: item.frequency,
+    }).then((saved) => {
+      // Replace temp ID with server ID
+      setItems((prev) => {
+        const next = prev.map((r) => r.id === tempId ? { ...r, id: saved.id || saved._id } : r);
+        persistLocal(next);
+        return next;
+      });
+    }).catch(() => {/* keep local version */});
   }, []);
 
   const deleteItem = useCallback((id: string) => {
     setItems((prev) => {
       const next = prev.filter((r) => r.id !== id);
-      persist(next);
+      persistLocal(next);
       return next;
     });
+    deleteRecurring(id).catch(() => {/* already removed locally */});
   }, []);
 
   const markApplied = useCallback((ids: string[], month: string) => {
     setItems((prev) => {
       const next = prev.map((r) => ids.includes(r.id) ? { ...r, lastApplied: month } : r);
-      persist(next);
+      persistLocal(next);
       return next;
+    });
+    // Sync each updated item to server
+    ids.forEach((id) => {
+      updateRecurring(id, { lastApplied: month }).catch(() => {});
     });
   }, []);
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -53,3 +53,37 @@ export const saveBudgets = async (budgets: Budget[]): Promise<Budget[]> => {
   const res = await axiosInstance.put('/api/budgets', { budgets });
   return res.data.budgets;
 };
+
+// Recurring
+export interface RecurringItemAPI {
+  id: string;
+  _id: string;
+  label: string;
+  item?: string;
+  description: string;
+  amount: number;
+  type: 'income' | 'expense';
+  category?: string;
+  participants?: string[];
+  frequency?: 'monthly' | 'weekly' | 'daily';
+  lastApplied?: string;
+}
+
+export const getRecurring = async (): Promise<RecurringItemAPI[]> => {
+  const res = await axiosInstance.get('/api/recurring');
+  return res.data;
+};
+
+export const createRecurring = async (data: Omit<RecurringItemAPI, 'id' | '_id'>): Promise<RecurringItemAPI> => {
+  const res = await axiosInstance.post('/api/recurring', data);
+  return res.data;
+};
+
+export const updateRecurring = async (id: string, data: Partial<RecurringItemAPI>): Promise<RecurringItemAPI> => {
+  const res = await axiosInstance.put(`/api/recurring/${id}`, data);
+  return res.data;
+};
+
+export const deleteRecurring = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/recurring/${id}`);
+};


### PR DESCRIPTION
## Summary
- Backend: New `RecurringExpense` model + CRUD routes at `/api/recurring` (PR wkliwk/money-flow-backend#114, merged)
- Frontend: `useRecurring` hook now fetches from API on mount with localStorage fallback
- Optimistic local updates with async server sync
- API functions added to `api.ts`: getRecurring, createRecurring, updateRecurring, deleteRecurring
- 9 tests updated with API mocks

Closes #224

## Test plan
- [ ] Recurring items persist across browser sessions (server-backed)
- [ ] Works offline (falls back to localStorage)
- [ ] Add/delete/markApplied sync to server
- [ ] Existing RecurringPage UI unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)