### PR TITLE
feat: sync savings goals to backend API

### DIFF
--- a/src/hooks/__tests__/useGoals.test.ts
+++ b/src/hooks/__tests__/useGoals.test.ts
@@ -1,9 +1,27 @@
 import { renderHook, act } from '@testing-library/react';
+
+const mockGetGoals = jest.fn().mockResolvedValue([]);
+const mockCreateGoal = jest.fn().mockResolvedValue({ id: 'server-1', _id: 'server-1', createdAt: '2026-01-01' });
+const mockUpdateGoal = jest.fn().mockResolvedValue({});
+const mockDeleteGoalAPI = jest.fn().mockResolvedValue(null);
+
+jest.mock('../../services/api', () => ({
+  getGoals: (...args: unknown[]) => mockGetGoals(...args),
+  createGoal: (...args: unknown[]) => mockCreateGoal(...args),
+  updateGoal: (...args: unknown[]) => mockUpdateGoal(...args),
+  deleteGoalAPI: (...args: unknown[]) => mockDeleteGoalAPI(...args),
+}));
+
 import { useGoals } from '../useGoals';
 
 describe('useGoals', () => {
   beforeEach(() => {
     localStorage.clear();
+    jest.clearAllMocks();
+    mockGetGoals.mockResolvedValue([]);
+    mockCreateGoal.mockResolvedValue({ id: 'server-1', _id: 'server-1', createdAt: '2026-01-01' });
+    mockUpdateGoal.mockResolvedValue({});
+    mockDeleteGoalAPI.mockResolvedValue(null);
   });
 
   it('starts with empty goals when localStorage is empty', () => {
@@ -22,6 +40,16 @@ describe('useGoals', () => {
     expect(result.current.goals[0].currentAmount).toBe(0);
     expect(result.current.goals[0].id).toBeDefined();
     expect(result.current.goals[0].createdAt).toBeDefined();
+  });
+
+  it('addGoal calls createGoal API', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Emergency Fund', targetAmount: 10000 });
+    });
+    expect(mockCreateGoal).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Emergency Fund', targetAmount: 10000 })
+    );
   });
 
   it('addGoal persists to localStorage', () => {
@@ -60,6 +88,18 @@ describe('useGoals', () => {
     expect(result.current.goals[0].currentAmount).toBe(500);
   });
 
+  it('updateAmount calls updateGoal API', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Test', targetAmount: 1000 });
+    });
+    const id = result.current.goals[0].id;
+    act(() => {
+      result.current.updateAmount(id, 500);
+    });
+    expect(mockUpdateGoal).toHaveBeenCalledWith(id, { currentAmount: 500 });
+  });
+
   it('updateAmount clamps to 0', () => {
     const { result } = renderHook(() => useGoals());
     act(() => {
@@ -87,7 +127,7 @@ describe('useGoals', () => {
     expect(result.current.goals[0].name).toBe('B');
   });
 
-  it('deleteGoal persists to localStorage', () => {
+  it('deleteGoal calls deleteGoalAPI', () => {
     const { result } = renderHook(() => useGoals());
     act(() => {
       result.current.addGoal({ name: 'Del', targetAmount: 100 });
@@ -96,8 +136,7 @@ describe('useGoals', () => {
     act(() => {
       result.current.deleteGoal(id);
     });
-    const stored = JSON.parse(localStorage.getItem('mf_savings_goals') || '[]');
-    expect(stored).toHaveLength(0);
+    expect(mockDeleteGoalAPI).toHaveBeenCalledWith(id);
   });
 
   it('loads existing goals from localStorage on mount', () => {

--- a/src/hooks/useGoals.ts
+++ b/src/hooks/useGoals.ts
@@ -1,42 +1,84 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { SavingsGoal } from '../types';
+import { getGoals, createGoal, updateGoal, deleteGoalAPI } from '../services/api';
 
 const KEY = 'mf_savings_goals';
 
-function load(): SavingsGoal[] {
+function loadLocal(): SavingsGoal[] {
   try { return JSON.parse(localStorage.getItem(KEY) || '[]'); } catch { return []; }
 }
 
-function save(goals: SavingsGoal[]) {
+function persistLocal(goals: SavingsGoal[]) {
   localStorage.setItem(KEY, JSON.stringify(goals));
 }
 
 export function useGoals() {
-  const [goals, setGoals] = useState<SavingsGoal[]>(load);
+  const [goals, setGoals] = useState<SavingsGoal[]>(loadLocal);
+  const fetched = useRef(false);
+
+  useEffect(() => {
+    if (fetched.current) return;
+    fetched.current = true;
+    getGoals()
+      .then((data) => {
+        const mapped: SavingsGoal[] = data.map((d) => ({
+          id: d.id || d._id,
+          name: d.name,
+          targetAmount: d.targetAmount,
+          currentAmount: d.currentAmount,
+          deadline: d.deadline,
+          category: d.category,
+          createdAt: d.createdAt,
+        }));
+        setGoals(mapped);
+        persistLocal(mapped);
+      })
+      .catch(() => {/* use localStorage fallback */});
+  }, []);
 
   const addGoal = useCallback((goal: Omit<SavingsGoal, 'id' | 'createdAt' | 'currentAmount'>) => {
+    const tempId = typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const newGoal: SavingsGoal = { ...goal, id: tempId, currentAmount: 0, createdAt: new Date().toISOString() };
+
     setGoals((prev) => {
-      const id = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      const next = [...prev, { ...goal, id, currentAmount: 0, createdAt: new Date().toISOString() }];
-      save(next);
+      const next = [...prev, newGoal];
+      persistLocal(next);
       return next;
     });
+
+    createGoal({
+      name: goal.name,
+      targetAmount: goal.targetAmount,
+      deadline: goal.deadline,
+      category: goal.category,
+    }).then((saved) => {
+      setGoals((prev) => {
+        const next = prev.map((g) => g.id === tempId ? { ...g, id: saved.id || saved._id, createdAt: saved.createdAt } : g);
+        persistLocal(next);
+        return next;
+      });
+    }).catch(() => {/* keep local version */});
   }, []);
 
   const updateAmount = useCallback((id: string, amount: number) => {
+    const clamped = Math.max(0, amount);
     setGoals((prev) => {
-      const next = prev.map((g) => g.id === id ? { ...g, currentAmount: Math.max(0, amount) } : g);
-      save(next);
+      const next = prev.map((g) => g.id === id ? { ...g, currentAmount: clamped } : g);
+      persistLocal(next);
       return next;
     });
+    updateGoal(id, { currentAmount: clamped }).catch(() => {});
   }, []);
 
   const deleteGoal = useCallback((id: string) => {
     setGoals((prev) => {
       const next = prev.filter((g) => g.id !== id);
-      save(next);
+      persistLocal(next);
       return next;
     });
+    deleteGoalAPI(id).catch(() => {});
   }, []);
 
   return { goals, addGoal, updateAmount, deleteGoal };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -87,3 +87,34 @@ export const updateRecurring = async (id: string, data: Partial<RecurringItemAPI
 export const deleteRecurring = async (id: string): Promise<void> => {
   await axiosInstance.delete(`/api/recurring/${id}`);
 };
+
+// Goals
+export interface GoalAPI {
+  id: string;
+  _id: string;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  deadline?: string;
+  category?: string;
+  createdAt: string;
+}
+
+export const getGoals = async (): Promise<GoalAPI[]> => {
+  const res = await axiosInstance.get('/api/goals');
+  return res.data;
+};
+
+export const createGoal = async (data: { name: string; targetAmount: number; deadline?: string; category?: string }): Promise<GoalAPI> => {
+  const res = await axiosInstance.post('/api/goals', data);
+  return res.data;
+};
+
+export const updateGoal = async (id: string, data: Partial<GoalAPI>): Promise<GoalAPI> => {
+  const res = await axiosInstance.put(`/api/goals/${id}`, data);
+  return res.data;
+};
+
+export const deleteGoalAPI = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/goals/${id}`);
+};


### PR DESCRIPTION
## Summary
- Backend: New `Goal` model + CRUD routes at `/api/goals` (PR wkliwk/money-flow-backend#115, merged)
- Frontend: `useGoals` hook now fetches from API with localStorage fallback
- Optimistic local updates with async server sync
- API functions added: getGoals, createGoal, updateGoal, deleteGoalAPI
- 12 tests updated with API mocks

Closes #226

## Test plan
- [ ] Goals persist across browser sessions (server-backed)
- [ ] Works offline (falls back to localStorage)
- [ ] Add/update/delete sync to server
- [ ] GoalsPage UI unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)