### PR TITLE
feat: sync transaction templates to backend API with localStorage fallback

### DIFF
--- a/src/hooks/__tests__/useTemplates.test.ts
+++ b/src/hooks/__tests__/useTemplates.test.ts
@@ -1,9 +1,24 @@
 import { renderHook, act } from '@testing-library/react';
+
+const mockGetTemplates = jest.fn().mockResolvedValue([]);
+const mockCreateTemplate = jest.fn().mockResolvedValue({ id: 'server-1', _id: 'server-1' });
+const mockDeleteTemplateAPI = jest.fn().mockResolvedValue(null);
+
+jest.mock('../../services/api', () => ({
+  getTemplates: (...args: unknown[]) => mockGetTemplates(...args),
+  createTemplate: (...args: unknown[]) => mockCreateTemplate(...args),
+  deleteTemplateAPI: (...args: unknown[]) => mockDeleteTemplateAPI(...args),
+}));
+
 import { useTemplates } from '../useTemplates';
 
 describe('useTemplates', () => {
   beforeEach(() => {
     localStorage.clear();
+    jest.clearAllMocks();
+    mockGetTemplates.mockResolvedValue([]);
+    mockCreateTemplate.mockResolvedValue({ id: 'server-1', _id: 'server-1' });
+    mockDeleteTemplateAPI.mockResolvedValue(null);
   });
 
   it('starts with empty templates', () => {
@@ -26,6 +41,21 @@ describe('useTemplates', () => {
     expect(result.current.templates[0].id).toBeDefined();
   });
 
+  it('addTemplate calls createTemplate API', () => {
+    const { result } = renderHook(() => useTemplates());
+    act(() => {
+      result.current.addTemplate({
+        label: 'Coffee',
+        description: 'Morning coffee',
+        type: 'expense',
+        category: 'Food & Drink',
+      });
+    });
+    expect(mockCreateTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Coffee', category: 'Food & Drink' })
+    );
+  });
+
   it('deleteTemplate removes template by id', () => {
     const { result } = renderHook(() => useTemplates());
     act(() => {
@@ -41,6 +71,23 @@ describe('useTemplates', () => {
       result.current.deleteTemplate(id);
     });
     expect(result.current.templates).toHaveLength(0);
+  });
+
+  it('deleteTemplate calls deleteTemplateAPI', () => {
+    const { result } = renderHook(() => useTemplates());
+    act(() => {
+      result.current.addTemplate({
+        label: 'Lunch',
+        description: '',
+        type: 'expense',
+        category: 'Food & Drink',
+      });
+    });
+    const id = result.current.templates[0].id;
+    act(() => {
+      result.current.deleteTemplate(id);
+    });
+    expect(mockDeleteTemplateAPI).toHaveBeenCalledWith(id);
   });
 
   it('persists templates to localStorage', () => {

--- a/src/hooks/useTemplates.ts
+++ b/src/hooks/useTemplates.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { TransactionType } from '../types';
+import { getTemplates, createTemplate, deleteTemplateAPI } from '../services/api';
 
 export interface TransactionTemplate {
   id: string;
@@ -13,7 +14,7 @@ export interface TransactionTemplate {
 
 const KEY = 'money_flow_templates';
 
-function load(): TransactionTemplate[] {
+function loadLocal(): TransactionTemplate[] {
   try {
     const raw = localStorage.getItem(KEY);
     return raw ? JSON.parse(raw) : [];
@@ -22,7 +23,7 @@ function load(): TransactionTemplate[] {
   }
 }
 
-function save(templates: TransactionTemplate[]) {
+function persistLocal(templates: TransactionTemplate[]) {
   try {
     localStorage.setItem(KEY, JSON.stringify(templates));
   } catch {
@@ -31,19 +32,64 @@ function save(templates: TransactionTemplate[]) {
 }
 
 export function useTemplates() {
-  const [templates, setTemplates] = useState<TransactionTemplate[]>(load);
+  const [templates, setTemplates] = useState<TransactionTemplate[]>(loadLocal);
+  const fetched = useRef(false);
+
+  useEffect(() => {
+    if (fetched.current) return;
+    fetched.current = true;
+    getTemplates()
+      .then((data) => {
+        const mapped: TransactionTemplate[] = data.map((d) => ({
+          id: d.id || d._id,
+          label: d.label,
+          item: d.item,
+          description: d.description,
+          type: d.type,
+          category: d.category,
+          defaultAmount: d.defaultAmount,
+        }));
+        setTemplates(mapped);
+        persistLocal(mapped);
+      })
+      .catch(() => {/* use localStorage fallback */});
+  }, []);
 
   const addTemplate = useCallback((t: Omit<TransactionTemplate, 'id'>) => {
-    const next = [...templates, { ...t, id: String(Date.now()) }];
-    setTemplates(next);
-    save(next);
-  }, [templates]);
+    const tempId = String(Date.now());
+    const newTemplate: TransactionTemplate = { ...t, id: tempId };
+    setTemplates((prev) => {
+      const next = [...prev, newTemplate];
+      persistLocal(next);
+      return next;
+    });
+
+    createTemplate({
+      label: t.label,
+      description: t.description,
+      type: t.type,
+      category: t.category,
+      item: t.item,
+      defaultAmount: t.defaultAmount,
+    }).then((saved) => {
+      setTemplates((prev) => {
+        const next = prev.map((tmpl) =>
+          tmpl.id === tempId ? { ...tmpl, id: saved.id || saved._id } : tmpl
+        );
+        persistLocal(next);
+        return next;
+      });
+    }).catch(() => {/* keep local version */});
+  }, []);
 
   const deleteTemplate = useCallback((id: string) => {
-    const next = templates.filter((t) => t.id !== id);
-    setTemplates(next);
-    save(next);
-  }, [templates]);
+    setTemplates((prev) => {
+      const next = prev.filter((t) => t.id !== id);
+      persistLocal(next);
+      return next;
+    });
+    deleteTemplateAPI(id).catch(() => {/* already removed locally */});
+  }, []);
 
   return { templates, addTemplate, deleteTemplate };
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -118,3 +118,29 @@ export const updateGoal = async (id: string, data: Partial<GoalAPI>): Promise<Go
 export const deleteGoalAPI = async (id: string): Promise<void> => {
   await axiosInstance.delete(`/api/goals/${id}`);
 };
+
+// Templates
+export interface TemplateAPI {
+  id: string;
+  _id: string;
+  label: string;
+  item?: string;
+  description: string;
+  type: 'income' | 'expense';
+  category: string;
+  defaultAmount?: number;
+}
+
+export const getTemplates = async (): Promise<TemplateAPI[]> => {
+  const res = await axiosInstance.get('/api/templates');
+  return res.data;
+};
+
+export const createTemplate = async (data: Omit<TemplateAPI, 'id' | '_id'>): Promise<TemplateAPI> => {
+  const res = await axiosInstance.post('/api/templates', data);
+  return res.data;
+};
+
+export const deleteTemplateAPI = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/templates/${id}`);
+};


### PR DESCRIPTION
## What
Updates `useTemplates` hook to fetch templates from the `/api/templates` backend API on mount, with localStorage as a fallback if the API is unavailable. Adds optimistic local updates with async server sync — the same pattern as `useRecurring`.

Adds `TemplateAPI` interface and three API functions to `src/services/api.ts`: `getTemplates`, `createTemplate`, `deleteTemplateAPI`.

## Why
Closes #225

## Acceptance Criteria
- [x] `useTemplates` fetches from API on mount via `getTemplates`
- [x] Falls back to localStorage if API fails
- [x] `addTemplate` — optimistic local update + async `createTemplate` call, temp ID replaced with server ID on success
- [x] `deleteTemplate` — optimistic local removal + async `deleteTemplateAPI` call
- [x] localStorage kept in sync for offline resilience
- [x] 7 tests passing (includes 2 new API mock tests)
- [x] Zero new TypeScript errors (`npx tsc --noEmit`)
- [x] Production build passes

## Test Plan
1. Add a template — should appear immediately, then ID updates to server ID after API responds
2. Delete a template — should disappear immediately
3. Disconnect from API (block /api/templates in devtools) — templates still load from localStorage
4. Run `npx react-scripts test --testPathPattern="useTemplates" --watchAll=false --no-coverage` — all 7 pass