### PR TITLE
feat: savings goals with backend sync

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -36,6 +36,7 @@ import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import DataObjectIcon from '@mui/icons-material/DataObject';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import SavingsIcon from '@mui/icons-material/Savings';
 import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../types';
 import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult } from '../services/api';
@@ -65,6 +66,7 @@ import { useBudgets } from '../hooks/useBudgets';
 import OnboardingFlow, { isOnboardingComplete, markOnboardingComplete } from './onboarding/OnboardingFlow';
 import SpendingInsightsPage from './insights/SpendingInsightsPage';
 import { useSmartSuggestions } from '../hooks/useSmartSuggestions';
+import GoalsPage from './goals/GoalsPage';
 
 function getOwnerFromToken(): string {
   try {
@@ -82,7 +84,7 @@ const MainLayout: React.FC = () => {
   const { currency, setCurrency, convert, symbol } = useFxRates();
   const { items: recurringItems, markApplied } = useRecurring();
   const { budgets } = useBudgets();
-  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4 | 5>(0);
+  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4 | 5 | 6>(0);
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
 
   useEffect(() => {
@@ -498,6 +500,7 @@ const MainLayout: React.FC = () => {
     { label: 'Net Worth', icon: <AccountBalanceIcon /> },
     { label: 'Insights', icon: <BarChartIcon /> },
     { label: 'Recurring', icon: <RepeatIcon /> },
+    { label: 'Goals', icon: <SavingsIcon /> },
     { label: 'Settings', icon: <SettingsIcon /> },
   ];
 
@@ -598,7 +601,7 @@ const MainLayout: React.FC = () => {
               <ListItemButton
                 key={item.label}
                 selected={activeTab === index}
-                onClick={() => setActiveTab(index as 0 | 1 | 2 | 3 | 4 | 5)}
+                onClick={() => setActiveTab(index as 0 | 1 | 2 | 3 | 4 | 5 | 6)}
                 sx={{
                   '&.Mui-selected': { bgcolor: theme.palette.mode === 'dark' ? 'rgba(129,140,248,0.1)' : 'rgba(99,102,241,0.12)', color: 'primary.main' },
                   '&.Mui-selected .MuiListItemIcon-root': { color: 'primary.main' },
@@ -923,6 +926,10 @@ const MainLayout: React.FC = () => {
           )}
 
           {activeTab === 5 && (
+            <GoalsPage convert={convert} symbol={symbol} />
+          )}
+
+          {activeTab === 6 && (
             <SettingsPage
               currency={currency}
               onCurrencyChange={(c: Currency) => setCurrency(c)}
@@ -955,6 +962,7 @@ const MainLayout: React.FC = () => {
           <BottomNavigationAction label="Worth" icon={<AccountBalanceIcon />} />
           <BottomNavigationAction label="Insights" icon={<BarChartIcon />} />
           <BottomNavigationAction label="Repeat" icon={<RepeatIcon />} />
+          <BottomNavigationAction label="Goals" icon={<SavingsIcon />} />
           <BottomNavigationAction label="Settings" icon={<SettingsIcon />} />
         </BottomNavigation>
       </Box>

--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -1,0 +1,270 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardActionArea,
+  CardContent,
+  LinearProgress,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  IconButton,
+  Chip,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import SavingsIcon from '@mui/icons-material/Savings';
+import dayjs from 'dayjs';
+import { useGoals } from '../../hooks/useGoals';
+
+interface Props {
+  convert: (hkd: number) => number;
+  symbol: string;
+}
+
+const fmt = (n: number, symbol: string) =>
+  `${symbol}${n.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+
+const GoalsPage: React.FC<Props> = ({ convert, symbol }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const { goals, addGoal, updateAmount, deleteGoal } = useGoals();
+  const [addOpen, setAddOpen] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editAmount, setEditAmount] = useState('');
+  const [form, setForm] = useState({ name: '', targetAmount: '', deadline: '', category: '' });
+
+  const handleAdd = () => {
+    if (!form.name || !form.targetAmount) return;
+    addGoal({
+      name: form.name,
+      targetAmount: Number(form.targetAmount),
+      deadline: form.deadline || undefined,
+      category: form.category || undefined,
+    });
+    setForm({ name: '', targetAmount: '', deadline: '', category: '' });
+    setAddOpen(false);
+  };
+
+  const handleUpdateAmount = () => {
+    if (editId && editAmount) {
+      updateAmount(editId, Number(editAmount));
+      setEditId(null);
+      setEditAmount('');
+    }
+  };
+
+  const sortedGoals = [...goals].sort((a, b) => {
+    const aComplete = a.currentAmount >= a.targetAmount;
+    const bComplete = b.currentAmount >= b.targetAmount;
+    if (aComplete !== bComplete) return aComplete ? 1 : -1;
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+
+  return (
+    <Box sx={{ pb: 10 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          Savings Goals
+        </Typography>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => setAddOpen(true)}
+          sx={{ borderRadius: 2 }}
+        >
+          Add Goal
+        </Button>
+      </Box>
+
+      {sortedGoals.length === 0 && (
+        <Box sx={{ textAlign: 'center', py: 8 }}>
+          <SavingsIcon sx={{ fontSize: 56, color: 'text.secondary', opacity: 0.4, mb: 2 }} />
+          <Typography variant="h6" sx={{ color: 'text.secondary', mb: 1 }}>No goals yet</Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
+            Add your first goal to start tracking your savings
+          </Typography>
+          <Button variant="outlined" startIcon={<AddIcon />} onClick={() => setAddOpen(true)}>
+            Add Goal
+          </Button>
+        </Box>
+      )}
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(auto-fill, minmax(320px, 1fr))', gap: 2 }}>
+        {sortedGoals.map((goal) => {
+          const pct = Math.min(100, (goal.currentAmount / goal.targetAmount) * 100);
+          const isComplete = pct >= 100;
+          const daysLeft = goal.deadline ? dayjs(goal.deadline).diff(dayjs(), 'day') : null;
+
+          return (
+            <Card
+              key={goal.id}
+              sx={{
+                position: 'relative',
+                overflow: 'visible',
+                border: isComplete ? `1px solid ${theme.palette.success.main}` : undefined,
+                background: isComplete
+                  ? `linear-gradient(135deg, ${theme.palette.mode === 'dark' ? 'rgba(52,211,153,0.08)' : 'rgba(16,185,129,0.06)'} 0%, transparent 100%)`
+                  : undefined,
+              }}
+            >
+              <CardActionArea
+                onClick={() => {
+                  setEditId(goal.id);
+                  setEditAmount(String(goal.currentAmount));
+                }}
+              >
+                <CardContent sx={{ p: 2.5 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mb: 1.5 }}>
+                    <Box sx={{ flex: 1 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                        {isComplete && <CheckCircleIcon sx={{ color: 'success.main', fontSize: 20 }} />}
+                        <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+                          {goal.name}
+                        </Typography>
+                      </Box>
+                      {goal.category && (
+                        <Chip label={goal.category} size="small" sx={{ mt: 0.5, fontSize: '0.68rem', height: 22 }} />
+                      )}
+                    </Box>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteGoal(goal.id);
+                      }}
+                      sx={{ color: 'text.secondary', opacity: 0.5, '&:hover': { opacity: 1, color: 'error.main' } }}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+
+                  <Box sx={{ mb: 1.5 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                      <Typography variant="h6" sx={{ fontWeight: 700, color: isComplete ? 'success.main' : 'text.primary' }}>
+                        {fmt(convert(goal.currentAmount), symbol)}
+                      </Typography>
+                      <Typography variant="body2" sx={{ color: 'text.secondary', alignSelf: 'flex-end' }}>
+                        of {fmt(convert(goal.targetAmount), symbol)}
+                      </Typography>
+                    </Box>
+                    <LinearProgress
+                      variant="determinate"
+                      value={pct}
+                      sx={{
+                        height: 8,
+                        borderRadius: 4,
+                        bgcolor: theme.palette.mode === 'dark' ? 'rgba(148,163,184,0.1)' : 'rgba(100,116,139,0.1)',
+                        '& .MuiLinearProgress-bar': {
+                          borderRadius: 4,
+                          background: isComplete
+                            ? `linear-gradient(90deg, ${theme.palette.success.main}, ${theme.palette.success.light})`
+                            : `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.primary.light})`,
+                        },
+                      }}
+                    />
+                  </Box>
+
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
+                      {pct.toFixed(0)}% complete
+                    </Typography>
+                    {daysLeft !== null && !isComplete && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: daysLeft < 0 ? 'error.main' : daysLeft < 30 ? 'warning.main' : 'text.secondary',
+                          fontWeight: 600,
+                        }}
+                      >
+                        {daysLeft < 0 ? `${Math.abs(daysLeft)}d overdue` : `${daysLeft}d left`}
+                      </Typography>
+                    )}
+                  </Box>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          );
+        })}
+      </Box>
+
+      {/* Add Goal Dialog */}
+      <Dialog open={addOpen} onClose={() => setAddOpen(false)} fullWidth maxWidth="xs" fullScreen={isMobile}>
+        <DialogTitle sx={{ fontWeight: 700 }}>New Savings Goal</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '8px !important' }}>
+          <TextField
+            label="Goal name"
+            value={form.name}
+            onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            fullWidth
+            autoFocus
+          />
+          <TextField
+            label="Target amount (HKD)"
+            type="number"
+            value={form.targetAmount}
+            onChange={(e) => setForm((f) => ({ ...f, targetAmount: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            label="Deadline (optional)"
+            type="date"
+            value={form.deadline}
+            onChange={(e) => setForm((f) => ({ ...f, deadline: e.target.value }))}
+            fullWidth
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            label="Category (optional)"
+            value={form.category}
+            onChange={(e) => setForm((f) => ({ ...f, category: e.target.value }))}
+            fullWidth
+            placeholder="e.g. Vacation, Emergency Fund"
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setAddOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleAdd} disabled={!form.name || !form.targetAmount}>
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Update Amount Dialog */}
+      <Dialog
+        open={!!editId}
+        onClose={() => { setEditId(null); setEditAmount(''); }}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>Update Progress</DialogTitle>
+        <DialogContent sx={{ pt: '8px !important' }}>
+          <TextField
+            label="Current amount saved (HKD)"
+            type="number"
+            value={editAmount}
+            onChange={(e) => setEditAmount(e.target.value)}
+            fullWidth
+            autoFocus
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => { setEditId(null); setEditAmount(''); }}>Cancel</Button>
+          <Button variant="contained" onClick={handleUpdateAmount} disabled={!editAmount}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default GoalsPage;

--- a/src/components/goals/__tests__/GoalsPage.test.tsx
+++ b/src/components/goals/__tests__/GoalsPage.test.tsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import GoalsPage from '../GoalsPage';
+
+const mockAddGoal = jest.fn();
+const mockUpdateAmount = jest.fn();
+const mockDeleteGoal = jest.fn();
+let mockGoals: any[] = [];
+
+jest.mock('../../../hooks/useGoals', () => ({
+  useGoals: () => ({
+    goals: mockGoals,
+    addGoal: mockAddGoal,
+    updateAmount: mockUpdateAmount,
+    deleteGoal: mockDeleteGoal,
+  }),
+}));
+
+const defaultProps = {
+  convert: (n: number) => n,
+  symbol: 'HK$',
+};
+
+describe('GoalsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGoals = [];
+  });
+
+  it('renders empty state when no goals', () => {
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText('No goals yet')).toBeInTheDocument();
+    expect(screen.getByText('Savings Goals')).toBeInTheDocument();
+    expect(screen.getByText('Add your first goal to start tracking your savings')).toBeInTheDocument();
+  });
+
+  it('renders header with Add Goal button', () => {
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getAllByText(/Add Goal/i).length).toBeGreaterThan(0);
+  });
+
+  it('opens add dialog when clicking header Add Goal button', () => {
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getAllByText(/Add Goal/i)[0]);
+    expect(screen.getByText('New Savings Goal')).toBeInTheDocument();
+  });
+
+  it('opens add dialog from empty state button', () => {
+    render(<GoalsPage {...defaultProps} />);
+    // Empty state has its own Add Goal button
+    const buttons = screen.getAllByText(/Add Goal/i);
+    fireEvent.click(buttons[buttons.length - 1]);
+    expect(screen.getByText('New Savings Goal')).toBeInTheDocument();
+  });
+
+  it('add dialog has all form fields', () => {
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getAllByText(/Add Goal/i)[0]);
+    expect(screen.getByLabelText('Goal name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Target amount (HKD)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Deadline (optional)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Category (optional)')).toBeInTheDocument();
+  });
+
+  it('Create button is disabled when form is empty', () => {
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getAllByText(/Add Goal/i)[0]);
+    expect(screen.getByText('Create')).toBeDisabled();
+  });
+
+  it('Create button enables when name and amount are filled', () => {
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getAllByText(/Add Goal/i)[0]);
+    fireEvent.change(screen.getByLabelText('Goal name'), { target: { value: 'Vacation' } });
+    fireEvent.change(screen.getByLabelText('Target amount (HKD)'), { target: { value: '5000' } });
+    expect(screen.getByText('Create')).not.toBeDisabled();
+  });
+
+  it('calls addGoal and closes dialog on Create', async () => {
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getAllByText(/Add Goal/i)[0]);
+    fireEvent.change(screen.getByLabelText('Goal name'), { target: { value: 'Vacation' } });
+    fireEvent.change(screen.getByLabelText('Target amount (HKD)'), { target: { value: '5000' } });
+    fireEvent.change(screen.getByLabelText('Category (optional)'), { target: { value: 'Travel' } });
+    fireEvent.click(screen.getByText('Create'));
+    expect(mockAddGoal).toHaveBeenCalledWith({
+      name: 'Vacation',
+      targetAmount: 5000,
+      deadline: undefined,
+      category: 'Travel',
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('New Savings Goal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes add dialog on Cancel', async () => {
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getAllByText(/Add Goal/i)[0]);
+    expect(screen.getByText('New Savings Goal')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cancel'));
+    await waitFor(() => {
+      expect(screen.queryByText('New Savings Goal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders goal cards when goals exist', () => {
+    mockGoals = [
+      { id: '1', name: 'Emergency Fund', targetAmount: 10000, currentAmount: 3000, createdAt: '2026-01-01' },
+      { id: '2', name: 'Vacation', targetAmount: 5000, currentAmount: 0, createdAt: '2026-02-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText('Emergency Fund')).toBeInTheDocument();
+    expect(screen.getByText('Vacation')).toBeInTheDocument();
+    expect(screen.queryByText('No goals yet')).not.toBeInTheDocument();
+  });
+
+  it('shows progress percentage', () => {
+    mockGoals = [
+      { id: '1', name: 'Test Goal', targetAmount: 1000, currentAmount: 500, createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText('50% complete')).toBeInTheDocument();
+  });
+
+  it('shows formatted amounts with symbol', () => {
+    mockGoals = [
+      { id: '1', name: 'Test', targetAmount: 10000, currentAmount: 5000, createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText('HK$5,000')).toBeInTheDocument();
+    expect(screen.getByText('of HK$10,000')).toBeInTheDocument();
+  });
+
+  it('shows days remaining for goals with deadlines', () => {
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 45);
+    mockGoals = [
+      { id: '1', name: 'Goal', targetAmount: 1000, currentAmount: 0, deadline: futureDate.toISOString().split('T')[0], createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText(/\d+d left/)).toBeInTheDocument();
+  });
+
+  it('shows overdue for past deadline goals', () => {
+    mockGoals = [
+      { id: '1', name: 'Overdue', targetAmount: 1000, currentAmount: 0, deadline: '2020-01-01', createdAt: '2019-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText(/\d+d overdue/)).toBeInTheDocument();
+  });
+
+  it('shows completion state for 100% goals', () => {
+    mockGoals = [
+      { id: '1', name: 'Done Goal', targetAmount: 1000, currentAmount: 1000, createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText('100% complete')).toBeInTheDocument();
+  });
+
+  it('shows category chip when category is set', () => {
+    mockGoals = [
+      { id: '1', name: 'Tagged', targetAmount: 1000, currentAmount: 0, category: 'Travel', createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByText('Travel')).toBeInTheDocument();
+  });
+
+  it('opens update amount dialog when clicking a goal card', () => {
+    mockGoals = [
+      { id: '1', name: 'Clickable', targetAmount: 1000, currentAmount: 500, createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getByText('Clickable'));
+    expect(screen.getByText('Update Progress')).toBeInTheDocument();
+    expect(screen.getByLabelText('Current amount saved (HKD)')).toBeInTheDocument();
+  });
+
+  it('calls updateAmount on save', () => {
+    mockGoals = [
+      { id: '1', name: 'Update Me', targetAmount: 1000, currentAmount: 500, createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    fireEvent.click(screen.getByText('Update Me'));
+    fireEvent.change(screen.getByLabelText('Current amount saved (HKD)'), { target: { value: '750' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(mockUpdateAmount).toHaveBeenCalledWith('1', 750);
+  });
+
+  it('calls deleteGoal when clicking delete icon', () => {
+    mockGoals = [
+      { id: '1', name: 'Delete Me', targetAmount: 1000, currentAmount: 0, createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    const deleteBtn = document.querySelector('[data-testid="DeleteIcon"]')?.closest('button');
+    if (deleteBtn) {
+      fireEvent.click(deleteBtn);
+    }
+    expect(mockDeleteGoal).toHaveBeenCalledWith('1');
+  });
+
+  it('sorts completed goals after active goals', () => {
+    mockGoals = [
+      { id: '1', name: 'Complete', targetAmount: 100, currentAmount: 100, createdAt: '2026-03-01' },
+      { id: '2', name: 'Active', targetAmount: 100, currentAmount: 50, createdAt: '2026-01-01' },
+    ];
+    render(<GoalsPage {...defaultProps} />);
+    const cards = screen.getAllByText(/% complete/);
+    // Active should appear first
+    expect(cards[0].textContent).toBe('50% complete');
+    expect(cards[1].textContent).toBe('100% complete');
+  });
+});

--- a/src/hooks/__tests__/useGoals.test.ts
+++ b/src/hooks/__tests__/useGoals.test.ts
@@ -1,0 +1,158 @@
+import { renderHook, act } from '@testing-library/react';
+
+const mockGetGoals = jest.fn().mockResolvedValue([]);
+const mockCreateGoal = jest.fn().mockResolvedValue({ id: 'server-1', _id: 'server-1', createdAt: '2026-01-01' });
+const mockUpdateGoal = jest.fn().mockResolvedValue({});
+const mockDeleteGoalAPI = jest.fn().mockResolvedValue(null);
+
+jest.mock('../../services/api', () => ({
+  getGoals: (...args: unknown[]) => mockGetGoals(...args),
+  createGoal: (...args: unknown[]) => mockCreateGoal(...args),
+  updateGoal: (...args: unknown[]) => mockUpdateGoal(...args),
+  deleteGoalAPI: (...args: unknown[]) => mockDeleteGoalAPI(...args),
+}));
+
+import { useGoals } from '../useGoals';
+
+describe('useGoals', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+    mockGetGoals.mockResolvedValue([]);
+    mockCreateGoal.mockResolvedValue({ id: 'server-1', _id: 'server-1', createdAt: '2026-01-01' });
+    mockUpdateGoal.mockResolvedValue({});
+    mockDeleteGoalAPI.mockResolvedValue(null);
+  });
+
+  it('starts with empty goals when localStorage is empty', () => {
+    const { result } = renderHook(() => useGoals());
+    expect(result.current.goals).toEqual([]);
+  });
+
+  it('addGoal creates a goal with id and createdAt', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Vacation', targetAmount: 5000 });
+    });
+    expect(result.current.goals).toHaveLength(1);
+    expect(result.current.goals[0].name).toBe('Vacation');
+    expect(result.current.goals[0].targetAmount).toBe(5000);
+    expect(result.current.goals[0].currentAmount).toBe(0);
+    expect(result.current.goals[0].id).toBeDefined();
+    expect(result.current.goals[0].createdAt).toBeDefined();
+  });
+
+  it('addGoal calls createGoal API', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Emergency Fund', targetAmount: 10000 });
+    });
+    expect(mockCreateGoal).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Emergency Fund', targetAmount: 10000 })
+    );
+  });
+
+  it('addGoal persists to localStorage', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Emergency Fund', targetAmount: 10000 });
+    });
+    const stored = JSON.parse(localStorage.getItem('mf_savings_goals') || '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].name).toBe('Emergency Fund');
+  });
+
+  it('addGoal with optional fields', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({
+        name: 'New Laptop',
+        targetAmount: 8000,
+        deadline: '2026-06-01',
+        category: 'Tech',
+      });
+    });
+    expect(result.current.goals[0].deadline).toBe('2026-06-01');
+    expect(result.current.goals[0].category).toBe('Tech');
+  });
+
+  it('updateAmount changes currentAmount', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Test', targetAmount: 1000 });
+    });
+    const id = result.current.goals[0].id;
+    act(() => {
+      result.current.updateAmount(id, 500);
+    });
+    expect(result.current.goals[0].currentAmount).toBe(500);
+  });
+
+  it('updateAmount calls updateGoal API', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Test', targetAmount: 1000 });
+    });
+    const id = result.current.goals[0].id;
+    act(() => {
+      result.current.updateAmount(id, 500);
+    });
+    expect(mockUpdateGoal).toHaveBeenCalledWith(id, { currentAmount: 500 });
+  });
+
+  it('updateAmount clamps to 0', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Test', targetAmount: 1000 });
+    });
+    const id = result.current.goals[0].id;
+    act(() => {
+      result.current.updateAmount(id, -100);
+    });
+    expect(result.current.goals[0].currentAmount).toBe(0);
+  });
+
+  it('deleteGoal removes the goal', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'A', targetAmount: 100 });
+      result.current.addGoal({ name: 'B', targetAmount: 200 });
+    });
+    expect(result.current.goals).toHaveLength(2);
+    const idToDelete = result.current.goals[0].id;
+    act(() => {
+      result.current.deleteGoal(idToDelete);
+    });
+    expect(result.current.goals).toHaveLength(1);
+    expect(result.current.goals[0].name).toBe('B');
+  });
+
+  it('deleteGoal calls deleteGoalAPI', () => {
+    const { result } = renderHook(() => useGoals());
+    act(() => {
+      result.current.addGoal({ name: 'Del', targetAmount: 100 });
+    });
+    const id = result.current.goals[0].id;
+    act(() => {
+      result.current.deleteGoal(id);
+    });
+    expect(mockDeleteGoalAPI).toHaveBeenCalledWith(id);
+  });
+
+  it('loads existing goals from localStorage on mount', () => {
+    const existing = [
+      { id: 'x1', name: 'Saved', targetAmount: 3000, currentAmount: 1500, createdAt: '2026-01-01' },
+    ];
+    localStorage.setItem('mf_savings_goals', JSON.stringify(existing));
+    const { result } = renderHook(() => useGoals());
+    expect(result.current.goals).toHaveLength(1);
+    expect(result.current.goals[0].name).toBe('Saved');
+    expect(result.current.goals[0].currentAmount).toBe(1500);
+  });
+
+  it('returns empty array on bad JSON in localStorage', () => {
+    localStorage.setItem('mf_savings_goals', 'not-valid');
+    const { result } = renderHook(() => useGoals());
+    expect(result.current.goals).toEqual([]);
+  });
+});

--- a/src/hooks/useGoals.ts
+++ b/src/hooks/useGoals.ts
@@ -1,0 +1,85 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { SavingsGoal } from '../types';
+import { getGoals, createGoal, updateGoal, deleteGoalAPI } from '../services/api';
+
+const KEY = 'mf_savings_goals';
+
+function loadLocal(): SavingsGoal[] {
+  try { return JSON.parse(localStorage.getItem(KEY) || '[]'); } catch { return []; }
+}
+
+function persistLocal(goals: SavingsGoal[]) {
+  localStorage.setItem(KEY, JSON.stringify(goals));
+}
+
+export function useGoals() {
+  const [goals, setGoals] = useState<SavingsGoal[]>(loadLocal);
+  const fetched = useRef(false);
+
+  useEffect(() => {
+    if (fetched.current) return;
+    fetched.current = true;
+    getGoals()
+      .then((data) => {
+        const mapped: SavingsGoal[] = data.map((d) => ({
+          id: d.id || d._id,
+          name: d.name,
+          targetAmount: d.targetAmount,
+          currentAmount: d.currentAmount,
+          deadline: d.deadline,
+          category: d.category,
+          createdAt: d.createdAt,
+        }));
+        setGoals(mapped);
+        persistLocal(mapped);
+      })
+      .catch(() => {/* use localStorage fallback */});
+  }, []);
+
+  const addGoal = useCallback((goal: Omit<SavingsGoal, 'id' | 'createdAt' | 'currentAmount'>) => {
+    const tempId = typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const newGoal: SavingsGoal = { ...goal, id: tempId, currentAmount: 0, createdAt: new Date().toISOString() };
+
+    setGoals((prev) => {
+      const next = [...prev, newGoal];
+      persistLocal(next);
+      return next;
+    });
+
+    createGoal({
+      name: goal.name,
+      targetAmount: goal.targetAmount,
+      deadline: goal.deadline,
+      category: goal.category,
+    }).then((saved) => {
+      setGoals((prev) => {
+        const next = prev.map((g) => g.id === tempId ? { ...g, id: saved.id || saved._id, createdAt: saved.createdAt } : g);
+        persistLocal(next);
+        return next;
+      });
+    }).catch(() => {/* keep local version */});
+  }, []);
+
+  const updateAmount = useCallback((id: string, amount: number) => {
+    const clamped = Math.max(0, amount);
+    setGoals((prev) => {
+      const next = prev.map((g) => g.id === id ? { ...g, currentAmount: clamped } : g);
+      persistLocal(next);
+      return next;
+    });
+    updateGoal(id, { currentAmount: clamped }).catch(() => {});
+  }, []);
+
+  const deleteGoal = useCallback((id: string) => {
+    setGoals((prev) => {
+      const next = prev.filter((g) => g.id !== id);
+      persistLocal(next);
+      return next;
+    });
+    deleteGoalAPI(id).catch(() => {});
+  }, []);
+
+  return { goals, addGoal, updateAmount, deleteGoal };
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -316,3 +316,34 @@ export const scanReceipt = async (file: File): Promise<ReceiptScanResult> => {
   });
   return res.data;
 };
+
+// Goals
+export interface GoalAPI {
+  id: string;
+  _id: string;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  deadline?: string;
+  category?: string;
+  createdAt: string;
+}
+
+export const getGoals = async (): Promise<GoalAPI[]> => {
+  const res = await axiosInstance.get('/api/goals');
+  return res.data;
+};
+
+export const createGoal = async (data: { name: string; targetAmount: number; deadline?: string; category?: string }): Promise<GoalAPI> => {
+  const res = await axiosInstance.post('/api/goals', data);
+  return res.data;
+};
+
+export const updateGoal = async (id: string, data: Partial<GoalAPI>): Promise<GoalAPI> => {
+  const res = await axiosInstance.put(`/api/goals/${id}`, data);
+  return res.data;
+};
+
+export const deleteGoalAPI = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/goals/${id}`);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,3 +66,13 @@ export interface TransactionRequest {
   notes?: string;
   date?: string;
 }
+
+export interface SavingsGoal {
+  id: string;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  deadline?: string;
+  category?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- New **Goals** tab (between Recurring and Settings) for savings goal tracking
- Backend-synced via `/api/goals` with localStorage offline fallback
- GoalsPage: card grid with progress bars, deadlines, categories, completion state
- 32 tests (20 component + 12 hook)

Closes #34, closes #226, closes #232

## Test plan
- [ ] Goals tab visible in navigation
- [ ] Add/edit/delete goals works
- [ ] Progress bars update correctly
- [ ] Data persists across sessions (backend)
- [ ] Works offline (localStorage fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)