### PR TITLE
feat: spending comparison delta on SummaryCards (#236)

### DIFF
--- a/src/components/dashboard/SummaryCards.tsx
+++ b/src/components/dashboard/SummaryCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Card, CardContent, Typography, Box } from '@mui/material';
+import { Grid, Card, CardContent, Typography, Box, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
@@ -16,9 +16,57 @@ interface Props {
 const fmt = (n: number) =>
   n.toLocaleString('en-HK', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 
+function pctChange(current: number, previous: number): number | null {
+  if (previous === 0) return null;
+  return Math.round(((current - previous) / Math.abs(previous)) * 100);
+}
+
+interface DeltaBadgeProps {
+  pct: number | null;
+  higherIsBetter: boolean;
+  prevAmount: number | null;
+  symbol: string;
+  convert: (n: number) => number;
+}
+
+const DeltaBadge: React.FC<DeltaBadgeProps> = ({ pct, higherIsBetter, prevAmount, symbol, convert }) => {
+  const theme = useTheme();
+
+  if (pct === null || prevAmount === null) {
+    return null;
+  }
+
+  const favorable = higherIsBetter ? pct >= 0 : pct <= 0;
+  const color = favorable ? theme.palette.success.light : theme.palette.error.light;
+  const arrow = pct > 0 ? '\u2191' : pct < 0 ? '\u2193' : '\u2192';
+  const absPct = Math.abs(pct);
+  const label = pct === 0 ? '\u2192 0%' : `${arrow}${absPct}%`;
+  const tooltipText = `vs ${symbol}${fmt(convert(prevAmount))} last month`;
+
+  return (
+    <Tooltip title={tooltipText} arrow placement="bottom">
+      <Typography
+        component="span"
+        sx={{
+          display: 'inline-block',
+          fontSize: '0.65rem',
+          fontWeight: 700,
+          mt: 0.5,
+          color,
+          cursor: 'default',
+          letterSpacing: '0.02em',
+        }}
+      >
+        {label}
+      </Typography>
+    </Tooltip>
+  );
+};
+
 const SummaryCards: React.FC<Props> = ({ transactions, prevMonthTransactions, convert, symbol }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
+
   const income = transactions
     .filter((t) => t.type === 'income')
     .reduce((sum, t) => sum + t.amount, 0);
@@ -29,11 +77,22 @@ const SummaryCards: React.FC<Props> = ({ transactions, prevMonthTransactions, co
 
   const net = income - expenses;
 
-  const prevExpenses = (prevMonthTransactions ?? [])
-    .filter((t) => t.type === 'expense')
-    .reduce((sum, t) => sum + t.amount, 0);
+  const hasPrev = prevMonthTransactions !== undefined && prevMonthTransactions.length > 0;
 
-  const expenseDelta = prevMonthTransactions && prevMonthTransactions.length > 0 ? expenses - prevExpenses : null;
+  const prevIncome = hasPrev
+    ? prevMonthTransactions!.filter((t) => t.type === 'income').reduce((sum, t) => sum + t.amount, 0)
+    : null;
+
+  const prevExpensesAmount = hasPrev
+    ? prevMonthTransactions!.filter((t) => t.type === 'expense').reduce((sum, t) => sum + t.amount, 0)
+    : null;
+
+  const prevNet =
+    prevIncome !== null && prevExpensesAmount !== null ? prevIncome - prevExpensesAmount : null;
+
+  const incomePct = prevIncome !== null ? pctChange(income, prevIncome) : null;
+  const expensesPct = prevExpensesAmount !== null ? pctChange(expenses, prevExpensesAmount) : null;
+  const netPct = prevNet !== null ? pctChange(net, prevNet) : null;
 
   const todayStr = new Date().toISOString().split('T')[0];
   const todayExpenses = transactions
@@ -43,10 +102,13 @@ const SummaryCards: React.FC<Props> = ({ transactions, prevMonthTransactions, co
   const now = new Date();
   const daysElapsed = now.getDate();
   const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  const isCurrentMonth = transactions.some((t) => (t.date || t.createdAt || '').startsWith(todayStr.slice(0, 7)));
-  const projectedExpenses = isCurrentMonth && expenses > 0 && daysElapsed < daysInMonth
-    ? (expenses / daysElapsed) * daysInMonth
-    : null;
+  const isCurrentMonth = transactions.some((t) =>
+    (t.date || t.createdAt || '').startsWith(todayStr.slice(0, 7)),
+  );
+  const projectedExpenses =
+    isCurrentMonth && expenses > 0 && daysElapsed < daysInMonth
+      ? (expenses / daysElapsed) * daysInMonth
+      : null;
 
   const cards = [
     {
@@ -59,6 +121,9 @@ const SummaryCards: React.FC<Props> = ({ transactions, prevMonthTransactions, co
       border: isDark ? 'rgba(52, 211, 153, 0.2)' : 'rgba(16, 185, 129, 0.25)',
       glow: isDark ? 'rgba(52, 211, 153, 0.08)' : 'rgba(16, 185, 129, 0.1)',
       icon: <TrendingUpIcon sx={{ fontSize: 20 }} />,
+      deltaPct: incomePct,
+      prevAmount: prevIncome,
+      higherIsBetter: true,
     },
     {
       label: 'Expenses',
@@ -70,25 +135,42 @@ const SummaryCards: React.FC<Props> = ({ transactions, prevMonthTransactions, co
       border: isDark ? 'rgba(251, 113, 133, 0.2)' : 'rgba(244, 63, 94, 0.25)',
       glow: isDark ? 'rgba(251, 113, 133, 0.08)' : 'rgba(244, 63, 94, 0.1)',
       icon: <TrendingDownIcon sx={{ fontSize: 20 }} />,
+      deltaPct: expensesPct,
+      prevAmount: prevExpensesAmount,
+      higherIsBetter: false,
     },
     {
       label: 'Net Balance',
       value: `${net >= 0 ? '+' : '-'}${symbol}${fmt(convert(Math.abs(net)))}`,
       color: net >= 0 ? theme.palette.primary.main : theme.palette.error.light,
-      gradient: net >= 0
-        ? isDark
-          ? 'linear-gradient(135deg, rgba(129, 140, 248, 0.12) 0%, rgba(99, 102, 241, 0.04) 100%)'
-          : 'linear-gradient(135deg, rgba(99, 102, 241, 0.15) 0%, rgba(99, 102, 241, 0.05) 100%)'
-        : isDark
+      gradient:
+        net >= 0
+          ? isDark
+            ? 'linear-gradient(135deg, rgba(129, 140, 248, 0.12) 0%, rgba(99, 102, 241, 0.04) 100%)'
+            : 'linear-gradient(135deg, rgba(99, 102, 241, 0.15) 0%, rgba(99, 102, 241, 0.05) 100%)'
+          : isDark
           ? 'linear-gradient(135deg, rgba(251, 113, 133, 0.12) 0%, rgba(244, 63, 94, 0.04) 100%)'
           : 'linear-gradient(135deg, rgba(244, 63, 94, 0.15) 0%, rgba(244, 63, 94, 0.05) 100%)',
-      border: net >= 0
-        ? isDark ? 'rgba(129, 140, 248, 0.2)' : 'rgba(99, 102, 241, 0.25)'
-        : isDark ? 'rgba(251, 113, 133, 0.2)' : 'rgba(244, 63, 94, 0.25)',
-      glow: net >= 0
-        ? isDark ? 'rgba(129, 140, 248, 0.08)' : 'rgba(99, 102, 241, 0.1)'
-        : isDark ? 'rgba(251, 113, 133, 0.08)' : 'rgba(244, 63, 94, 0.1)',
+      border:
+        net >= 0
+          ? isDark
+            ? 'rgba(129, 140, 248, 0.2)'
+            : 'rgba(99, 102, 241, 0.25)'
+          : isDark
+          ? 'rgba(251, 113, 133, 0.2)'
+          : 'rgba(244, 63, 94, 0.25)',
+      glow:
+        net >= 0
+          ? isDark
+            ? 'rgba(129, 140, 248, 0.08)'
+            : 'rgba(99, 102, 241, 0.1)'
+          : isDark
+          ? 'rgba(251, 113, 133, 0.08)'
+          : 'rgba(244, 63, 94, 0.1)',
       icon: <AccountBalanceIcon sx={{ fontSize: 20 }} />,
+      deltaPct: netPct,
+      prevAmount: prevNet,
+      higherIsBetter: true,
     },
   ];
 
@@ -129,23 +211,34 @@ const SummaryCards: React.FC<Props> = ({ transactions, prevMonthTransactions, co
               <Typography variant="h5" fontWeight={700} sx={{ color: card.color, letterSpacing: '-0.02em' }}>
                 {card.value}
               </Typography>
+              <DeltaBadge
+                pct={card.deltaPct}
+                higherIsBetter={card.higherIsBetter}
+                prevAmount={card.prevAmount}
+                symbol={symbol}
+                convert={convert}
+              />
               {card.label === 'Expenses' && todayExpenses > 0 && (
                 <Typography sx={{ fontSize: '0.65rem', mt: 0.5, color: 'text.disabled', fontWeight: 600 }}>
-                  Today: {symbol}{fmt(convert(todayExpenses))}
+                  Today: {symbol}
+                  {fmt(convert(todayExpenses))}
                 </Typography>
               )}
               {card.label === 'Expenses' && projectedExpenses !== null && (
                 <Typography sx={{ fontSize: '0.65rem', mt: 0.25, color: 'text.disabled', fontWeight: 500 }}>
-                  On pace for {symbol}{fmt(convert(projectedExpenses))}
-                </Typography>
-              )}
-              {card.label === 'Expenses' && expenseDelta !== null && (
-                <Typography sx={{ fontSize: '0.65rem', mt: 0.25, color: expenseDelta > 0 ? theme.palette.error.light : theme.palette.success.light, fontWeight: 600 }}>
-                  {expenseDelta > 0 ? '↑' : '↓'} {symbol}{fmt(convert(Math.abs(expenseDelta)))} vs last month
+                  On pace for {symbol}
+                  {fmt(convert(projectedExpenses))}
                 </Typography>
               )}
               {card.label === 'Net Balance' && income > 0 && (
-                <Typography sx={{ fontSize: '0.65rem', mt: 0.5, color: net >= 0 ? theme.palette.success.light : theme.palette.error.light, fontWeight: 600 }}>
+                <Typography
+                  sx={{
+                    fontSize: '0.65rem',
+                    mt: 0.5,
+                    color: net >= 0 ? theme.palette.success.light : theme.palette.error.light,
+                    fontWeight: 600,
+                  }}
+                >
                   {net >= 0
                     ? `${Math.round((net / income) * 100)}% savings rate`
                     : `${Math.round((Math.abs(net) / income) * 100)}% over income`}

--- a/src/components/dashboard/__tests__/SummaryCards.extended.test.tsx
+++ b/src/components/dashboard/__tests__/SummaryCards.extended.test.tsx
@@ -7,7 +7,6 @@ import SummaryCards from '../SummaryCards';
 import { Transaction } from '../../../types';
 
 const today = new Date().toISOString().split('T')[0];
-const thisMonth = today.slice(0, 7);
 
 const makeTx = (overrides: Partial<Transaction> = {}): Transaction => ({
   _id: String(Math.random()),
@@ -22,7 +21,7 @@ const makeTx = (overrides: Partial<Transaction> = {}): Transaction => ({
 });
 
 describe('SummaryCards — extended coverage', () => {
-  it('shows expense delta decrease (↓) when current expenses < prev', () => {
+  it('shows expense delta decrease (\u2193) when current expenses < prev', () => {
     const current = [makeTx({ type: 'expense', amount: 50, date: today })];
     const prev = [makeTx({ type: 'expense', amount: 200 })];
     render(
@@ -31,13 +30,13 @@ describe('SummaryCards — extended coverage', () => {
         prevMonthTransactions={prev}
         convert={(n) => n}
         symbol="$"
-      />
+      />,
     );
-    expect(screen.getByText(/↓/)).toBeInTheDocument();
-    expect(screen.getByText(/vs last month/)).toBeInTheDocument();
+    // 50 vs 200 = -75%; expenses down is favorable, shown as ↓75%
+    expect(screen.getAllByText(/\u219375%/).length).toBeGreaterThan(0);
   });
 
-  it('shows expense delta increase (↑) when current expenses > prev', () => {
+  it('shows expense delta increase (\u2191) when current expenses > prev', () => {
     const current = [makeTx({ type: 'expense', amount: 300, date: today })];
     const prev = [makeTx({ type: 'expense', amount: 100 })];
     render(
@@ -46,22 +45,60 @@ describe('SummaryCards — extended coverage', () => {
         prevMonthTransactions={prev}
         convert={(n) => n}
         symbol="$"
-      />
+      />,
     );
-    expect(screen.getByText(/↑/)).toBeInTheDocument();
+    // 300 vs 100 = +200%; expenses up is unfavorable, shown as ↑200%
+    expect(screen.getAllByText(/\u2191200%/).length).toBeGreaterThan(0);
+  });
+
+  it('shows income delta increase when current income > prev', () => {
+    const current = [makeTx({ type: 'income', amount: 15000, date: today })];
+    const prev = [makeTx({ type: 'income', amount: 10000 })];
+    render(
+      <SummaryCards
+        transactions={current}
+        prevMonthTransactions={prev}
+        convert={(n) => n}
+        symbol="$"
+      />,
+    );
+    // 15000 vs 10000 = +50%; income up is favorable, shown as ↑50%
+    expect(screen.getAllByText(/\u219150%/).length).toBeGreaterThan(0);
+  });
+
+  it('shows income delta decrease when current income < prev', () => {
+    const current = [makeTx({ type: 'income', amount: 8000, date: today })];
+    const prev = [makeTx({ type: 'income', amount: 10000 })];
+    render(
+      <SummaryCards
+        transactions={current}
+        prevMonthTransactions={prev}
+        convert={(n) => n}
+        symbol="$"
+      />,
+    );
+    // 8000 vs 10000 = -20%; income down is unfavorable, shown as ↓20%
+    expect(screen.getAllByText(/\u219320%/).length).toBeGreaterThan(0);
+  });
+
+  it('shows no delta badges when prevMonthTransactions is empty array', () => {
+    const current = [makeTx({ type: 'expense', amount: 300, date: today })];
+    render(
+      <SummaryCards
+        transactions={current}
+        prevMonthTransactions={[]}
+        convert={(n) => n}
+        symbol="$"
+      />,
+    );
+    expect(screen.queryByText(/\u2191|\u2193/)).not.toBeInTheDocument();
   });
 
   it('uses createdAt when date is missing on today transaction', () => {
     const tx = makeTx({ type: 'expense', amount: 100 });
     delete (tx as any).date;
     tx.createdAt = today;
-    render(
-      <SummaryCards
-        transactions={[tx]}
-        convert={(n) => n}
-        symbol="$"
-      />
-    );
+    render(<SummaryCards transactions={[tx]} convert={(n) => n} symbol="$" />);
     expect(screen.getByText('Expenses')).toBeInTheDocument();
   });
 
@@ -69,13 +106,7 @@ describe('SummaryCards — extended coverage', () => {
     const tx = makeTx({ type: 'expense', amount: 100 });
     delete (tx as any).date;
     delete (tx as any).createdAt;
-    render(
-      <SummaryCards
-        transactions={[tx]}
-        convert={(n) => n}
-        symbol="$"
-      />
-    );
+    render(<SummaryCards transactions={[tx]} convert={(n) => n} symbol="$" />);
     expect(screen.getByText('Expenses')).toBeInTheDocument();
   });
 
@@ -83,14 +114,7 @@ describe('SummaryCards — extended coverage', () => {
     const tx = makeTx({ type: 'expense', amount: 200 });
     delete (tx as any).date;
     tx.createdAt = today;
-    render(
-      <SummaryCards
-        transactions={[tx]}
-        convert={(n) => n}
-        symbol="$"
-      />
-    );
-    // Should render On pace for... (projectedExpenses path) or just not crash
+    render(<SummaryCards transactions={[tx]} convert={(n) => n} symbol="$" />);
     expect(screen.getByText('Expenses')).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/__tests__/SummaryCards.test.tsx
+++ b/src/components/dashboard/__tests__/SummaryCards.test.tsx
@@ -18,13 +18,7 @@ const makeTransaction = (overrides: Partial<Transaction>): Transaction => ({
 
 describe('SummaryCards', () => {
   it('renders Income, Expenses, and Net Balance cards', () => {
-    render(
-      <SummaryCards
-        transactions={[]}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={[]} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText('Income')).toBeInTheDocument();
     expect(screen.getByText('Expenses')).toBeInTheDocument();
     expect(screen.getByText('Net Balance')).toBeInTheDocument();
@@ -32,25 +26,13 @@ describe('SummaryCards', () => {
 
   it('shows correct income value', () => {
     const transactions = [makeTransaction({ type: 'income', amount: 5000 })];
-    render(
-      <SummaryCards
-        transactions={transactions}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getAllByText('+HK$5,000').length).toBeGreaterThan(0);
   });
 
   it('shows correct expense value', () => {
     const transactions = [makeTransaction({ type: 'expense', amount: 1000 })];
-    render(
-      <SummaryCards
-        transactions={transactions}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getAllByText('-HK$1,000').length).toBeGreaterThan(0);
   });
 
@@ -59,13 +41,7 @@ describe('SummaryCards', () => {
       makeTransaction({ type: 'income', amount: 5000 }),
       makeTransaction({ type: 'expense', amount: 1000 }),
     ];
-    render(
-      <SummaryCards
-        transactions={transactions}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText('+HK$4,000')).toBeInTheDocument();
   });
 
@@ -74,13 +50,7 @@ describe('SummaryCards', () => {
       makeTransaction({ type: 'income', amount: 1000 }),
       makeTransaction({ type: 'expense', amount: 2000 }),
     ];
-    render(
-      <SummaryCards
-        transactions={transactions}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText('-HK$1,000')).toBeInTheDocument();
   });
 
@@ -89,13 +59,7 @@ describe('SummaryCards', () => {
       makeTransaction({ type: 'income', amount: 10000 }),
       makeTransaction({ type: 'expense', amount: 2000 }),
     ];
-    render(
-      <SummaryCards
-        transactions={transactions}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText(/savings rate/i)).toBeInTheDocument();
   });
 
@@ -104,40 +68,50 @@ describe('SummaryCards', () => {
       makeTransaction({ type: 'income', amount: 1000 }),
       makeTransaction({ type: 'expense', amount: 2000 }),
     ];
-    render(
-      <SummaryCards
-        transactions={transactions}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText(/over income/i)).toBeInTheDocument();
   });
 
-  it('shows expense delta vs previous month', () => {
+  it('shows percentage delta badge when prevMonthTransactions provided', () => {
     const prevMonth = [makeTransaction({ type: 'expense', amount: 500 })];
-    const thisMonth = [makeTransaction({ type: 'expense', amount: 800 })];
+    const thisMonth = [makeTransaction({ type: 'expense', amount: 600 })];
     render(
       <SummaryCards
         transactions={thisMonth}
         prevMonthTransactions={prevMonth}
         convert={(n) => n}
         symbol="HK$"
-      />
+      />,
     );
-    expect(screen.getByText(/vs last month/i)).toBeInTheDocument();
+    // 600 vs 500 = +20%; expenses up is unfavorable — rendered as ↑20%
+    expect(screen.getAllByText(/\u219120%/).length).toBeGreaterThan(0);
+  });
+
+  it('shows income percentage delta vs previous month', () => {
+    const prevMonth = [makeTransaction({ type: 'income', amount: 10000 })];
+    const thisMonth = [makeTransaction({ type: 'income', amount: 11000 })];
+    render(
+      <SummaryCards
+        transactions={thisMonth}
+        prevMonthTransactions={prevMonth}
+        convert={(n) => n}
+        symbol="HK$"
+      />,
+    );
+    // 11000 vs 10000 = +10%
+    expect(screen.getAllByText(/\u219110%/).length).toBeGreaterThan(0);
   });
 
   it('shows today expenses when transactions from today exist', () => {
     const todayDate = dayjs().format('YYYY-MM-DD');
     const transactions = [makeTransaction({ type: 'expense', amount: 100, date: todayDate })];
-    render(
-      <SummaryCards
-        transactions={transactions}
-        convert={(n) => n}
-        symbol="HK$"
-      />
-    );
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText(/Today:/i)).toBeInTheDocument();
+  });
+
+  it('does not show delta badges when no prevMonthTransactions provided', () => {
+    const transactions = [makeTransaction({ type: 'expense', amount: 1000 })];
+    render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
+    expect(screen.queryByText(/\u2191|\u2193/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What
Added percentage delta badges to all three SummaryCards showing month-over-month comparison.

- Each card (Income, Expenses, Net Balance) shows a percentage badge: ↑12% or ↓8%
- Green for favorable changes (income up, expenses down, net up), red for unfavorable
- No badge when no previous month data
- MUI Tooltip on hover: 'vs HK$X,XXX last month'
- Removed old Expenses-only absolute delta text, replaced by unified percentage format

## Why
Closes #236

## Acceptance Criteria
- [x] Each SummaryCard shows a delta indicator: ↑12% or ↓8%
- [x] Green arrow for favorable changes
- [x] Red arrow for unfavorable changes
- [x] Hidden if no previous month data
- [x] Tooltip on hover: 'vs HK$X,XXX last month'
- [x] Uses prevMonthTransactions already passed from MainLayout

## Test Plan
1. Log in with transactions in 2+ consecutive months
2. Set date filter to 'This Month'
3. Verify all 3 cards show a percentage badge
4. Hover each badge — tooltip shows previous month absolute value
5. Select month with no prior month data — badges hidden