### PR TITLE
feat: Spending Pulse card on dashboard (#240)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -65,6 +65,7 @@ import RecurringPage from './recurring/RecurringPage';
 import { useBudgets } from '../hooks/useBudgets';
 import OnboardingFlow, { isOnboardingComplete, markOnboardingComplete } from './onboarding/OnboardingFlow';
 import SpendingInsightsPage from './insights/SpendingInsightsPage';
+import SpendingPulse from './dashboard/SpendingPulse';
 import { useSmartSuggestions } from '../hooks/useSmartSuggestions';
 import GoalsPage from './goals/GoalsPage';
 
@@ -694,6 +695,8 @@ const MainLayout: React.FC = () => {
                   </Box>
                 );
               })()}
+
+              <SpendingPulse />
 
               {/* Mobile: preset chips + hero card */}
               <Box sx={{ display: { xs: 'block', sm: 'none' } }}>

--- a/src/components/dashboard/SpendingPulse.tsx
+++ b/src/components/dashboard/SpendingPulse.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { Box, Typography, IconButton, CircularProgress, Collapse } from '@mui/material';
+import { useTheme, alpha } from '@mui/material/styles';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import { getWeeklyPulse, generateWeeklyPulse, getPreviousPulse, WeeklyPulse } from '../../services/api';
+
+const SpendingPulse: React.FC = () => {
+  const theme = useTheme();
+  const [pulse, setPulse] = useState<WeeklyPulse | null | undefined>(undefined);
+  const [previousPulse, setPreviousPulse] = useState<WeeklyPulse | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [showPrevious, setShowPrevious] = useState(false);
+
+  const currentWeekStart = (() => {
+    const d = new Date();
+    const day = d.getDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    d.setDate(d.getDate() + diff);
+    return d.toISOString().split('T')[0];
+  })();
+
+  const isCurrentWeek = pulse && pulse.weekStart === currentWeekStart;
+
+  const load = useCallback(async () => {
+    try {
+      const [p, prev] = await Promise.all([getWeeklyPulse(), getPreviousPulse()]);
+      setPulse(p);
+      setPreviousPulse(prev);
+    } catch {
+      setPulse(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleGenerate = async (force = false) => {
+    setGenerating(true);
+    try {
+      const result = await generateWeeklyPulse(force);
+      if (result.pulse) {
+        setPulse(result.pulse);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  if (pulse === undefined) return null;
+
+  const accentColor = theme.palette.mode === 'dark' ? '#a78bfa' : '#7c3aed';
+  const bgColor = theme.palette.mode === 'dark' ? alpha('#7c3aed', 0.08) : alpha('#7c3aed', 0.06);
+  const borderColor = theme.palette.mode === 'dark' ? alpha('#a78bfa', 0.2) : alpha('#7c3aed', 0.2);
+
+  if (!pulse) {
+    return (
+      <Box
+        sx={{
+          mb: 2,
+          p: 2,
+          borderRadius: 2,
+          bgcolor: bgColor,
+          border: `1px solid ${borderColor}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AutoAwesomeIcon sx={{ fontSize: 16, color: accentColor }} />
+          <Typography sx={{ fontSize: '0.82rem', color: 'text.secondary' }}>
+            How was your week in money?
+          </Typography>
+        </Box>
+        {generating ? (
+          <CircularProgress size={16} sx={{ color: accentColor }} />
+        ) : (
+          <Typography
+            component="span"
+            onClick={() => handleGenerate(false)}
+            sx={{ fontSize: '0.78rem', color: accentColor, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}
+          >
+            Generate
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  const formattedDate = new Date(pulse.weekStart).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Box
+        sx={{
+          p: 2,
+          borderRadius: 2,
+          bgcolor: bgColor,
+          border: `1px solid ${borderColor}`,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 1, mb: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+            <AutoAwesomeIcon sx={{ fontSize: 14, color: accentColor, mt: '1px' }} />
+            <Typography sx={{ fontSize: '0.7rem', fontWeight: 700, color: accentColor, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+              Spending Pulse · {formattedDate}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0 }}>
+            {!isCurrentWeek && (
+              <IconButton
+                size="small"
+                onClick={() => handleGenerate(true)}
+                disabled={generating}
+                sx={{ p: 0.5, color: accentColor }}
+                title="Generate this week's pulse"
+              >
+                {generating ? <CircularProgress size={13} sx={{ color: accentColor }} /> : <RefreshIcon sx={{ fontSize: 14 }} />}
+              </IconButton>
+            )}
+          </Box>
+        </Box>
+
+        <Typography sx={{ fontSize: '0.85rem', color: 'text.primary', lineHeight: 1.55 }}>
+          {pulse.narrative}
+        </Typography>
+
+        {previousPulse && (
+          <Box sx={{ mt: 1.5 }}>
+            <Typography
+              component="span"
+              onClick={() => setShowPrevious((v) => !v)}
+              sx={{
+                fontSize: '0.73rem',
+                color: accentColor,
+                fontWeight: 600,
+                cursor: 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.25,
+              }}
+            >
+              How was last week?
+              {showPrevious ? <KeyboardArrowUpIcon sx={{ fontSize: 14 }} /> : <KeyboardArrowDownIcon sx={{ fontSize: 14 }} />}
+            </Typography>
+            <Collapse in={showPrevious}>
+              <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary', lineHeight: 1.5, mt: 1 }}>
+                {previousPulse.narrative}
+              </Typography>
+            </Collapse>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default SpendingPulse;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -347,3 +347,38 @@ export const updateGoal = async (id: string, data: Partial<GoalAPI>): Promise<Go
 export const deleteGoalAPI = async (id: string): Promise<void> => {
   await axiosInstance.delete(`/api/goals/${id}`);
 };
+
+// Weekly Spending Pulse
+export interface WeeklyPulseStats {
+  totalSpend: number;
+  fourWeekAverage: number;
+  deltaPercent: number;
+  topCategory: string;
+  highestSpendDay: string;
+  largestTransaction: { description: string; amount: number; category: string } | null;
+  transactionCount: number;
+}
+
+export interface WeeklyPulse {
+  _id: string;
+  userId: string;
+  weekStart: string;
+  narrative: string;
+  stats: WeeklyPulseStats;
+  createdAt: string;
+}
+
+export const getWeeklyPulse = async (): Promise<WeeklyPulse | null> => {
+  const res = await axiosInstance.get('/api/insights/weekly-pulse');
+  return res.data.pulse;
+};
+
+export const getPreviousPulse = async (): Promise<WeeklyPulse | null> => {
+  const res = await axiosInstance.get('/api/insights/previous-pulse');
+  return res.data.pulse;
+};
+
+export const generateWeeklyPulse = async (force = false): Promise<{ pulse: WeeklyPulse | null; generated: boolean; reason?: string }> => {
+  const res = await axiosInstance.post(`/api/insights/weekly-pulse/generate${force ? '?force=true' : ''}`);
+  return res.data;
+};


### PR DESCRIPTION
## Summary
- New `SpendingPulse` component shown at top of dashboard (tab 0)
- Calls `GET /api/insights/weekly-pulse` on load — shows "Generate" prompt if no pulse exists
- `POST /api/insights/weekly-pulse/generate` called on click
- If pulse exists: displays narrative with week date label
- "How was last week?" link expands previous week's narrative (via `GET /api/insights/previous-pulse`)
- Refresh icon re-generates the current week's pulse with `?force=true`
- Hidden when loading (returns `null` during initial fetch)

## Test plan
- [ ] Dashboard loads — SpendingPulse card appears with "How was your week?" prompt
- [ ] Tap "Generate" — loading spinner, then narrative appears
- [ ] If < 3 transactions this week — no pulse generated, prompt remains
- [ ] "How was last week?" toggles previous week's narrative
- [ ] Build passes: `CI=false yarn build`

Closes wkliwk/money-flow-frontend#240

🤖 Generated with [Claude Code](https://claude.com/claude-code)