### PR TITLE
feat: add server-side CSV/PDF export to transaction list

### DIFF
--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -46,6 +46,7 @@ const defaultFilterProps = {
   onCategoryFilterChange: jest.fn(),
   onSortChange: jest.fn(),
   onExport: jest.fn(),
+  onExportJson: jest.fn(),
 };
 
 describe('Filter and search workflow', () => {

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -37,9 +37,10 @@ import TableChartIcon from '@mui/icons-material/TableChart';
 import DataObjectIcon from '@mui/icons-material/DataObject';
 import RepeatIcon from '@mui/icons-material/Repeat';
 import SavingsIcon from '@mui/icons-material/Savings';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../types';
-import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult } from '../services/api';
+import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult, exportCSV, exportPDF, ExportFilters } from '../services/api';
 import SummaryCards from './dashboard/SummaryCards';
 import DateRangeControl, { DatePreset } from './dashboard/DateRangeControl';
 import MobileHero from './dashboard/MobileHero';
@@ -108,6 +109,7 @@ const MainLayout: React.FC = () => {
   const [categoryFilter, setCategoryFilter] = useState<string | 'all'>('all');
   const [sortBy, setSortBy] = useState<'date' | 'amount'>('date');
   const [exportMenuAnchor, setExportMenuAnchor] = useState<null | HTMLElement>(null);
+  const [serverExportLoading, setServerExportLoading] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   const [quickExpenseOpen, setQuickExpenseOpen] = useState(false);
   const [editTransaction, setEditTransaction] = useState<Transaction | null>(null);
@@ -494,6 +496,68 @@ const MainLayout: React.FC = () => {
     URL.revokeObjectURL(url);
   };
 
+  const buildExportFilters = useCallback((): ExportFilters => {
+    const filters: ExportFilters = {};
+    if (search) filters.q = search;
+    if (typeFilter !== 'all') filters.type = typeFilter;
+    if (paymentMethodFilter !== 'all') filters.paymentMethod = paymentMethodFilter;
+    if (categoryFilter !== 'all') filters.category = categoryFilter;
+
+    if (datePreset === 'month' && selectedMonth) {
+      filters.from = selectedMonth.startOf('month').format('YYYY-MM-DD');
+      filters.to = selectedMonth.endOf('month').format('YYYY-MM-DD');
+    } else if (datePreset === 'last-month') {
+      const lm = dayjs().subtract(1, 'month');
+      filters.from = lm.startOf('month').format('YYYY-MM-DD');
+      filters.to = lm.endOf('month').format('YYYY-MM-DD');
+    } else if (datePreset === 'week') {
+      filters.from = dayjs().startOf('week').format('YYYY-MM-DD');
+      filters.to = dayjs().endOf('week').format('YYYY-MM-DD');
+    } else if (datePreset === 'custom' && customStart && customEnd) {
+      filters.from = customStart;
+      filters.to = customEnd;
+    }
+    return filters;
+  }, [search, typeFilter, paymentMethodFilter, categoryFilter, datePreset, selectedMonth, customStart, customEnd]);
+
+  const downloadBlob = (blob: Blob, filename: string) => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const getFileSuffix = (): string => {
+    if (search) return 'search';
+    if (datePreset === 'month' && selectedMonth) return selectedMonth.format('YYYY-MM');
+    if (datePreset === 'last-month') return dayjs().subtract(1, 'month').format('YYYY-MM');
+    if (datePreset === 'week') return `week-${dayjs().startOf('week').format('YYYY-MM-DD')}`;
+    if (datePreset === 'custom' && customStart) return `${customStart}_${customEnd}`;
+    return 'all';
+  };
+
+  const handleExportServerCsv = async () => {
+    setServerExportLoading(true);
+    try {
+      const blob = await exportCSV(buildExportFilters());
+      downloadBlob(blob, `money-flow-${getFileSuffix()}.csv`);
+    } finally {
+      setServerExportLoading(false);
+    }
+  };
+
+  const handleExportServerPdf = async () => {
+    setServerExportLoading(true);
+    try {
+      const blob = await exportPDF(buildExportFilters());
+      downloadBlob(blob, `money-flow-${getFileSuffix()}.pdf`);
+    } finally {
+      setServerExportLoading(false);
+    }
+  };
+
   const navItems = [
     { label: 'Home', icon: <DashboardIcon /> },
     { label: 'Transactions', icon: <ReceiptLongIcon /> },
@@ -532,16 +596,16 @@ const MainLayout: React.FC = () => {
             </Typography>
           )}
           <Button
-            startIcon={<FileDownloadIcon />}
+            startIcon={serverExportLoading ? <CircularProgress size={16} /> : <FileDownloadIcon />}
             onClick={(e) => setExportMenuAnchor(e.currentTarget)}
-            disabled={transactions.length === 0}
+            disabled={transactions.length === 0 || serverExportLoading}
             sx={{ ml: 2, fontSize: '0.75rem' }}
             variant="outlined"
             size="small"
             aria-haspopup="true"
             aria-expanded={Boolean(exportMenuAnchor)}
           >
-            Export
+            {serverExportLoading ? 'Exporting...' : 'Export'}
           </Button>
           <Menu
             anchorEl={exportMenuAnchor}
@@ -573,6 +637,32 @@ const MainLayout: React.FC = () => {
                 <DataObjectIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText>Export JSON</ListItemText>
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                setExportMenuAnchor(null);
+                handleExportServerCsv();
+              }}
+              disabled={serverExportLoading}
+              dense
+            >
+              <ListItemIcon>
+                {serverExportLoading ? <CircularProgress size={18} /> : <TableChartIcon fontSize="small" />}
+              </ListItemIcon>
+              <ListItemText>Export CSV (Server)</ListItemText>
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                setExportMenuAnchor(null);
+                handleExportServerPdf();
+              }}
+              disabled={serverExportLoading}
+              dense
+            >
+              <ListItemIcon>
+                {serverExportLoading ? <CircularProgress size={18} /> : <PictureAsPdfIcon fontSize="small" />}
+              </ListItemIcon>
+              <ListItemText>Export PDF</ListItemText>
             </MenuItem>
           </Menu>
         </Toolbar>
@@ -890,6 +980,9 @@ const MainLayout: React.FC = () => {
                 onSortChange={setSortBy}
                 onExport={handleExport}
                 onExportJson={handleExportJson}
+                onExportServerCsv={handleExportServerCsv}
+                onExportServerPdf={handleExportServerPdf}
+                exportLoading={serverExportLoading}
               />
               {filteredTransactions.length > 0 && (() => {
                 const fIncome = filteredTransactions.filter((t) => t.type === 'income').reduce((s, t) => s + t.amount, 0);

--- a/src/components/expenses/FilterBar.tsx
+++ b/src/components/expenses/FilterBar.tsx
@@ -21,6 +21,8 @@ import ClearIcon from '@mui/icons-material/Clear';
 import DownloadIcon from '@mui/icons-material/Download';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import DataObjectIcon from '@mui/icons-material/DataObject';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import CircularProgress from '@mui/material/CircularProgress';
 import SortIcon from '@mui/icons-material/Sort';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import LabelIcon from '@mui/icons-material/Label';
@@ -43,6 +45,9 @@ interface Props {
   onSortChange: (v: 'date' | 'amount') => void;
   onExport: () => void;
   onExportJson: () => void;
+  onExportServerCsv?: () => void;
+  onExportServerPdf?: () => void;
+  exportLoading?: boolean;
 }
 
 const FilterBar: React.FC<Props> = ({
@@ -62,6 +67,9 @@ const FilterBar: React.FC<Props> = ({
   onSortChange,
   onExport,
   onExportJson,
+  onExportServerCsv,
+  onExportServerPdf,
+  exportLoading,
 }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
@@ -151,18 +159,18 @@ const FilterBar: React.FC<Props> = ({
             <SortIcon fontSize="small" />
           </IconButton>
         </Tooltip>
-        <Tooltip title={filtered === 0 ? 'No transactions to export' : 'Export'}>
+        <Tooltip title={filtered === 0 ? 'No transactions to export' : exportLoading ? 'Exporting...' : 'Export'}>
           <span>
             <IconButton
               size="small"
               onClick={(e) => setExportMenuAnchor(e.currentTarget)}
-              disabled={filtered === 0}
+              disabled={filtered === 0 || exportLoading}
               aria-label="Export options"
               aria-haspopup="true"
               aria-expanded={Boolean(exportMenuAnchor)}
               sx={{ color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
             >
-              <DownloadIcon fontSize="small" />
+              {exportLoading ? <CircularProgress size={18} /> : <DownloadIcon fontSize="small" />}
             </IconButton>
           </span>
         </Tooltip>
@@ -197,6 +205,36 @@ const FilterBar: React.FC<Props> = ({
             </ListItemIcon>
             <ListItemText>Export JSON</ListItemText>
           </MenuItem>
+          {onExportServerCsv && (
+            <MenuItem
+              onClick={() => {
+                setExportMenuAnchor(null);
+                onExportServerCsv();
+              }}
+              disabled={exportLoading}
+              dense
+            >
+              <ListItemIcon>
+                {exportLoading ? <CircularProgress size={18} /> : <TableChartIcon fontSize="small" />}
+              </ListItemIcon>
+              <ListItemText>Export CSV (Server)</ListItemText>
+            </MenuItem>
+          )}
+          {onExportServerPdf && (
+            <MenuItem
+              onClick={() => {
+                setExportMenuAnchor(null);
+                onExportServerPdf();
+              }}
+              disabled={exportLoading}
+              dense
+            >
+              <ListItemIcon>
+                {exportLoading ? <CircularProgress size={18} /> : <PictureAsPdfIcon fontSize="small" />}
+              </ListItemIcon>
+              <ListItemText>Export PDF</ListItemText>
+            </MenuItem>
+          )}
         </Menu>
       </Box>
       <Collapse in={showPaymentFilter}>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -347,3 +347,46 @@ export const updateGoal = async (id: string, data: Partial<GoalAPI>): Promise<Go
 export const deleteGoalAPI = async (id: string): Promise<void> => {
   await axiosInstance.delete(`/api/goals/${id}`);
 };
+
+// Export
+export interface ExportFilters {
+  from?: string;
+  to?: string;
+  type?: string;
+  category?: string;
+  q?: string;
+  paymentMethod?: string;
+  minAmount?: number;
+  maxAmount?: number;
+}
+
+function buildExportParams(filters: ExportFilters): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (filters.from) params.from = filters.from;
+  if (filters.to) params.to = filters.to;
+  if (filters.type) params.type = filters.type;
+  if (filters.category) params.category = filters.category;
+  if (filters.q) params.q = filters.q;
+  if (filters.paymentMethod) params.paymentMethod = filters.paymentMethod;
+  if (filters.minAmount !== undefined) params.minAmount = String(filters.minAmount);
+  if (filters.maxAmount !== undefined) params.maxAmount = String(filters.maxAmount);
+  return params;
+}
+
+export const exportCSV = async (filters: ExportFilters): Promise<Blob> => {
+  const res = await axiosInstance.get('/api/export/csv', {
+    params: buildExportParams(filters),
+    responseType: 'blob',
+    timeout: 30000,
+  });
+  return res.data as Blob;
+};
+
+export const exportPDF = async (filters: ExportFilters): Promise<Blob> => {
+  const res = await axiosInstance.get('/api/export/pdf', {
+    params: buildExportParams(filters),
+    responseType: 'blob',
+    timeout: 60000,
+  });
+  return res.data as Blob;
+};


### PR DESCRIPTION
## What
Added server-side CSV and PDF export functionality to the transaction list page. Two new export options ("Export CSV (Server)" and "Export PDF") appear in both the FilterBar dropdown menu and the desktop AppBar export menu.

## Why
Closes #245

## Acceptance Criteria
- [x] "Export CSV" button visible on transaction list page (via server endpoint)
- [x] "Export PDF" button visible on transaction list page
- [x] Clicking export triggers download of the file with correct filename
- [x] Active filters are passed to the export endpoint (date range, type, category, payment method, search)
- [x] Loading spinner shown while export is generating
- [x] Error toast shown if export fails (via existing axios interceptor)
- [x] Buttons are disabled while an export is in progress

## Test Plan
1. Navigate to Transactions tab
2. Click the export (download) icon in the filter bar or the "Export" button in the AppBar
3. Verify "Export CSV (Server)" and "Export PDF" menu items appear
4. Apply filters (date range, type, category, search) then export -- confirm query params are sent
5. Confirm loading spinner appears on the export icon/button while request is in progress
6. Confirm file downloads with correct name (e.g., `money-flow-2026-04.csv`)
7. Simulate network error -- confirm error toast appears

Generated with [Claude Code](https://claude.com/claude-code)