### PR TITLE
feat: add personal data export (JSON) to Settings

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  CircularProgress,
 } from '@mui/material';
 import LogoutIcon from '@mui/icons-material/Logout';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -24,6 +25,7 @@ import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
 import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
+import DownloadIcon from '@mui/icons-material/Download';
 import { useTheme } from '@mui/material/styles';
 import { clearToken } from '../../services/auth';
 import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
@@ -34,6 +36,7 @@ import { useItemPresets } from '../../hooks/useItemPresets';
 import { ITEM_PRESETS } from '../expenses/ItemPicker';
 import { useThemePreference } from '../../ThemeContext';
 import { ThemePreference } from '../../theme';
+import { exportJSON } from '../../services/api';
 
 interface Props {
   currency: string;
@@ -95,6 +98,7 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const [editingItem, setEditingItem] = useState<string | null>(null);
   const [itemDraft, setItemDraft] = useState('');
   const [signOutConfirm, setSignOutConfirm] = useState(false);
+  const [exportLoading, setExportLoading] = useState(false);
 
   const handleBudgetBlur = (category: string) => {
     const val = parseFloat(drafts[category]);
@@ -122,6 +126,24 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const confirmLogout = () => {
     setSignOutConfirm(false);
     handleLogout();
+  };
+
+  const handleExportJSON = async () => {
+    setExportLoading(true);
+    try {
+      const blob = await exportJSON();
+      const dateStr = new Date().toISOString().split('T')[0];
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `money-flow-export-${dateStr}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } finally {
+      setExportLoading(false);
+    }
   };
 
   const renderItemSection = (label: string, items: typeof ITEM_PRESETS) => (
@@ -347,6 +369,28 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
         </Typography>
         {renderItemSection('Expense Items', ITEM_PRESETS.filter((p) => p.type === 'expense'))}
         {renderItemSection('Income Items', ITEM_PRESETS.filter((p) => p.type === 'income'))}
+      </Box>
+
+      {/* Your Data */}
+      <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>
+        <Box sx={{ px: 2, py: 1.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', mb: 0.5 }}>
+            Your Data
+          </Typography>
+          <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', mb: 1.5 }}>
+            Download a complete copy of all your data as a JSON file.
+          </Typography>
+          <Button
+            variant="outlined"
+            startIcon={exportLoading ? <CircularProgress size={16} color="inherit" /> : <DownloadIcon />}
+            onClick={handleExportJSON}
+            disabled={exportLoading}
+            fullWidth
+            aria-label="Download all data as JSON"
+          >
+            {exportLoading ? 'Exporting...' : 'Download All Data'}
+          </Button>
+        </Box>
       </Box>
 
       <Button

--- a/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -7,6 +7,11 @@ const mockToggleCurrency = jest.fn();
 
 jest.mock('../FriendsSection', () => () => null);
 
+const mockExportJSON = jest.fn().mockResolvedValue(new Blob(['{}'], { type: 'application/json' }));
+jest.mock('../../../services/api', () => ({
+  exportJSON: (...args: unknown[]) => mockExportJSON(...args),
+}));
+
 jest.mock('../../../hooks/useCurrencyPreferences', () => ({
   useCurrencyPreferences: () => ({
     enabledCurrencies: ['HKD', 'USD'],
@@ -55,6 +60,8 @@ describe('SettingsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.removeItem('mf_theme');
+    global.URL.createObjectURL = jest.fn(() => 'blob:test');
+    global.URL.revokeObjectURL = jest.fn();
   });
 
   it('renders without crashing', () => {
@@ -235,5 +242,17 @@ describe('SettingsPage', () => {
     expect(localStorage.getItem('mf_theme')).toBe('dark');
     fireEvent.click(screen.getByRole('button', { name: 'System' }));
     expect(localStorage.getItem('mf_theme')).toBe('system');
+  });
+
+  it('shows Your Data section with download button', () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    expect(screen.getByText('Your Data')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download all data as JSON' })).toBeInTheDocument();
+  });
+
+  it('calls exportJSON when download button is clicked', async () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Download all data as JSON' }));
+    expect(mockExportJSON).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -390,3 +390,11 @@ export const exportPDF = async (filters: ExportFilters): Promise<Blob> => {
   });
   return res.data as Blob;
 };
+
+export const exportJSON = async (): Promise<Blob> => {
+  const res = await axiosInstance.get('/api/export/json', {
+    responseType: 'blob',
+    timeout: 60000,
+  });
+  return res.data as Blob;
+};


### PR DESCRIPTION
## What
Added a "Your Data" section to the Settings page with a "Download All Data" button that exports all user data as a JSON file.

## Why
Closes #249

## Acceptance Criteria
- [x] Settings page shows "Your Data" section with "Download All Data" button
- [x] Button triggers download, shows loading spinner during fetch
- [x] `exportJSON()` API function calls GET /api/export/json with blob response
- [x] Downloaded file named `money-flow-export-YYYY-MM-DD.json`
- [x] Frontend build passes
- [x] Tests added for new section

## Test Plan
1. Navigate to Settings page
2. Scroll to "Your Data" section (above Sign Out)
3. Click "Download All Data" button
4. Verify loading spinner appears
5. Verify JSON file downloads with correct filename
6. Open file and verify valid JSON with expenses, recurringExpenses, templates, goals, budgets, preferences keys

Backend PR: wkliwk/money-flow-backend (feature/issue-249-data-export-json)