### PR TITLE
feat: add change-password UI to Settings page

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
+  Alert,
   Box,
+  Collapse,
   Typography,
   Button,
   Divider,
@@ -26,6 +28,9 @@ import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import DownloadIcon from '@mui/icons-material/Download';
+import LockIcon from '@mui/icons-material/Lock';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { useTheme } from '@mui/material/styles';
 import { clearToken } from '../../services/auth';
 import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
@@ -36,7 +41,9 @@ import { useItemPresets } from '../../hooks/useItemPresets';
 import { ITEM_PRESETS } from '../expenses/ItemPicker';
 import { useThemePreference } from '../../ThemeContext';
 import { ThemePreference } from '../../theme';
-import { exportJSON } from '../../services/api';
+import { exportJSON, getUserMe, changePassword, UserProfile } from '../../services/api';
+import { AxiosError } from 'axios';
+import { emitToast } from '../../toastEvents';
 
 interface Props {
   currency: string;
@@ -85,6 +92,162 @@ const ThemeToggle: React.FC = () => {
   );
 };
 
+const ChangePasswordSection: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const newTooShort = newPassword.length > 0 && newPassword.length < 6;
+  const confirmMismatch = confirmPassword.length > 0 && newPassword !== confirmPassword;
+  const canSubmit =
+    currentPassword.length > 0 &&
+    newPassword.length >= 6 &&
+    newPassword === confirmPassword &&
+    !loading;
+
+  const resetForm = useCallback(() => {
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setShowCurrent(false);
+    setShowNew(false);
+    setError('');
+  }, []);
+
+  const handleToggle = () => {
+    if (open) resetForm();
+    setOpen((prev) => !prev);
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setLoading(true);
+    setError('');
+    try {
+      await changePassword(currentPassword, newPassword);
+      emitToast('Password updated', 'success');
+      resetForm();
+      setOpen(false);
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+      const msg =
+        axiosErr.response?.data?.error ||
+        axiosErr.response?.data?.message ||
+        'Failed to update password';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>
+      <Box sx={{ px: 2, py: 1.5 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', mb: 1 }}>
+          Security
+        </Typography>
+        <Button
+          variant="outlined"
+          startIcon={<LockIcon />}
+          onClick={handleToggle}
+          fullWidth
+          aria-expanded={open}
+          aria-controls="change-password-form"
+        >
+          Change Password
+        </Button>
+        <Collapse in={open}>
+          <Box
+            id="change-password-form"
+            component="form"
+            onSubmit={(e: React.FormEvent) => { e.preventDefault(); handleSubmit(); }}
+            sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}
+          >
+            {error && (
+              <Alert severity="error" sx={{ fontSize: '0.82rem' }}>
+                {error}
+              </Alert>
+            )}
+            <TextField
+              label="Current Password"
+              type={showCurrent ? 'text' : 'password'}
+              size="small"
+              fullWidth
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      onClick={() => setShowCurrent((s) => !s)}
+                      aria-label={showCurrent ? 'Hide current password' : 'Show current password'}
+                      edge="end"
+                    >
+                      {showCurrent ? <VisibilityOffIcon sx={{ fontSize: 18 }} /> : <VisibilityIcon sx={{ fontSize: 18 }} />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <TextField
+              label="New Password"
+              type={showNew ? 'text' : 'password'}
+              size="small"
+              fullWidth
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              error={newTooShort}
+              helperText={newTooShort ? 'Must be at least 6 characters' : undefined}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size="small"
+                      onClick={() => setShowNew((s) => !s)}
+                      aria-label={showNew ? 'Hide new password' : 'Show new password'}
+                      edge="end"
+                    >
+                      {showNew ? <VisibilityOffIcon sx={{ fontSize: 18 }} /> : <VisibilityIcon sx={{ fontSize: 18 }} />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <TextField
+              label="Confirm New Password"
+              type="password"
+              size="small"
+              fullWidth
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              error={confirmMismatch}
+              helperText={confirmMismatch ? 'Passwords do not match' : undefined}
+            />
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={!canSubmit}
+              startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
+              fullWidth
+            >
+              {loading ? 'Updating...' : 'Update Password'}
+            </Button>
+          </Box>
+        </Collapse>
+      </Box>
+    </Box>
+  );
+};
+
 const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpend = {} }) => {
   const theme = useTheme();
   const userId = getUserId();
@@ -99,6 +262,18 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const [itemDraft, setItemDraft] = useState('');
   const [signOutConfirm, setSignOutConfirm] = useState(false);
   const [exportLoading, setExportLoading] = useState(false);
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
+
+  useEffect(() => {
+    getUserMe()
+      .then((data) => {
+        const profile = (data as { user?: UserProfile }).user || data;
+        setUserProfile(profile as UserProfile);
+      })
+      .catch(() => {});
+  }, []);
+
+  const isSocialOnly = Boolean(userProfile && (userProfile.googleId || userProfile.appleId));
 
   const handleBudgetBlur = (category: string) => {
     const val = parseFloat(drafts[category]);
@@ -370,6 +545,9 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
         {renderItemSection('Expense Items', ITEM_PRESETS.filter((p) => p.type === 'expense'))}
         {renderItemSection('Income Items', ITEM_PRESETS.filter((p) => p.type === 'income'))}
       </Box>
+
+      {/* Security — only for email/password users */}
+      {!isSocialOnly && <ChangePasswordSection />}
 
       {/* Your Data */}
       <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>

--- a/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -7,10 +7,24 @@ const mockToggleCurrency = jest.fn();
 
 jest.mock('../FriendsSection', () => () => null);
 
-const mockExportJSON = jest.fn().mockResolvedValue(new Blob(['{}'], { type: 'application/json' }));
 jest.mock('../../../services/api', () => ({
-  exportJSON: (...args: unknown[]) => mockExportJSON(...args),
+  __esModule: true,
+  exportJSON: jest.fn().mockResolvedValue(new Blob(['{}'], { type: 'application/json' })),
+  getUserMe: jest.fn().mockResolvedValue({ _id: '1', email: 'test@test.com', themePreference: 'system' }),
+  changePassword: jest.fn().mockResolvedValue({ message: 'Password updated' }),
+  patchUserPreferences: jest.fn().mockResolvedValue(undefined),
 }));
+
+jest.mock('../../../toastEvents', () => ({
+  __esModule: true,
+  emitToast: jest.fn(),
+  subscribeToast: jest.fn(),
+}));
+
+import * as apiModule from '../../../services/api';
+const mockExportJSON = apiModule.exportJSON as jest.Mock;
+const mockGetUserMe = apiModule.getUserMe as jest.Mock;
+const mockChangePassword = apiModule.changePassword as jest.Mock;
 
 jest.mock('../../../hooks/useCurrencyPreferences', () => ({
   useCurrencyPreferences: () => ({
@@ -59,6 +73,9 @@ describe('SettingsPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetUserMe.mockResolvedValue({ _id: '1', email: 'test@test.com', themePreference: 'system' });
+    mockExportJSON.mockResolvedValue(new Blob(['{}'], { type: 'application/json' }));
+    mockChangePassword.mockResolvedValue({ message: 'Password updated' });
     localStorage.removeItem('mf_theme');
     global.URL.createObjectURL = jest.fn(() => 'blob:test');
     global.URL.revokeObjectURL = jest.fn();
@@ -254,5 +271,66 @@ describe('SettingsPage', () => {
     renderWithTheme(<SettingsPage {...defaultProps} />);
     fireEvent.click(screen.getByRole('button', { name: 'Download all data as JSON' }));
     expect(mockExportJSON).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Security section with Change Password button for email users', async () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    await screen.findByText('Security');
+    expect(screen.getByText('Security')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /change password/i })).toBeInTheDocument();
+  });
+
+  it('hides Security section for social-auth users', async () => {
+    mockGetUserMe.mockResolvedValue({ _id: '1', email: 'test@test.com', themePreference: 'system', googleId: 'google123' });
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    // Wait for profile fetch to complete
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText('Security')).not.toBeInTheDocument();
+  });
+
+  it('expands change password form when button is clicked', async () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    await screen.findByText('Security');
+    fireEvent.click(screen.getByRole('button', { name: /change password/i }));
+    expect(screen.getByLabelText('Current Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('New Password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Confirm New Password')).toBeInTheDocument();
+  });
+
+  it('shows validation error when new password is too short', async () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    await screen.findByText('Security');
+    fireEvent.click(screen.getByRole('button', { name: /change password/i }));
+    fireEvent.change(screen.getByLabelText('New Password'), { target: { value: 'abc' } });
+    expect(screen.getByText('Must be at least 6 characters')).toBeInTheDocument();
+  });
+
+  it('shows mismatch error when confirm password differs', async () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    await screen.findByText('Security');
+    fireEvent.click(screen.getByRole('button', { name: /change password/i }));
+    fireEvent.change(screen.getByLabelText('New Password'), { target: { value: 'newpass123' } });
+    fireEvent.change(screen.getByLabelText('Confirm New Password'), { target: { value: 'different' } });
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+  });
+
+  it('calls changePassword API on valid submit', async () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    await screen.findByText('Security');
+    fireEvent.click(screen.getByRole('button', { name: /change password/i }));
+    fireEvent.change(screen.getByLabelText('Current Password'), { target: { value: 'oldpass' } });
+    fireEvent.change(screen.getByLabelText('New Password'), { target: { value: 'newpass123' } });
+    fireEvent.change(screen.getByLabelText('Confirm New Password'), { target: { value: 'newpass123' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockChangePassword).toHaveBeenCalledWith('oldpass', 'newpass123');
+  });
+
+  it('disables submit button when fields are incomplete', async () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    await screen.findByText('Security');
+    fireEvent.click(screen.getByRole('button', { name: /change password/i }));
+    const submitBtn = screen.getByRole('button', { name: /update password/i });
+    expect(submitBtn).toBeDisabled();
   });
 });

--- a/src/components/settings/__tests__/SettingsPageRecurring.test.tsx
+++ b/src/components/settings/__tests__/SettingsPageRecurring.test.tsx
@@ -3,6 +3,23 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import SettingsPage from '../SettingsPage';
 import { AppThemeProvider } from '../../../ThemeContext';
 
+jest.mock('../../../services/api', () => ({
+  __esModule: true,
+  exportJSON: jest.fn().mockResolvedValue(new Blob(['{}'], { type: 'application/json' })),
+  getUserMe: jest.fn().mockResolvedValue({ _id: '1', email: 'test@test.com', themePreference: 'system' }),
+  changePassword: jest.fn().mockResolvedValue({ message: 'Password updated' }),
+  patchUserPreferences: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../toastEvents', () => ({
+  __esModule: true,
+  emitToast: jest.fn(),
+  subscribeToast: jest.fn(),
+}));
+
+import * as apiModule from '../../../services/api';
+const mockGetUserMe = apiModule.getUserMe as jest.Mock;
+
 jest.mock('../../../hooks/useFxRates', () => ({
   useFxRates: () => ({
     symbol: 'HK$',
@@ -37,7 +54,10 @@ jest.mock('../../../hooks/useBudgets', () => ({
 }));
 
 describe('SettingsPage (with recurring items)', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUserMe.mockResolvedValue({ _id: '1', email: 'test@test.com', themePreference: 'system' });
+  });
 
   it('renders Netflix recurring item', () => {
     render(<AppThemeProvider><SettingsPage currency="HKD" onCurrencyChange={jest.fn()} /></AppThemeProvider>);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -29,6 +29,8 @@ export interface UserProfile {
   _id: string;
   email: string;
   themePreference: ThemePreference;
+  googleId?: string;
+  appleId?: string;
 }
 
 export const getUserMe = async (): Promise<UserProfile> => {
@@ -38,6 +40,17 @@ export const getUserMe = async (): Promise<UserProfile> => {
 
 export const patchUserPreferences = async (prefs: { themePreference: ThemePreference }): Promise<void> => {
   await axiosInstance.patch('/api/users/preferences', prefs);
+};
+
+export const changePassword = async (
+  currentPassword: string,
+  newPassword: string,
+): Promise<{ message: string }> => {
+  const res = await axiosInstance.patch('/api/users/password', {
+    currentPassword,
+    newPassword,
+  });
+  return res.data;
 };
 
 // Expenses


### PR DESCRIPTION
## What
Added a Security section to the Settings page with a Change Password form. The form includes current password, new password, and confirm new password fields with client-side validation, loading state, inline error display, and success toast notification. Social-auth (Google/Apple) users do not see this section.

## Why
Closes #248

## Acceptance Criteria
- [x] A "Security" section appears in Settings below existing sections (for email/password users only)
- [x] Contains a "Change Password" button that expands an inline form
- [x] Form has three fields: Current Password, New Password, Confirm New Password
- [x] Client-side validation: new password min 6 chars, new password matches confirm field
- [x] On submit, calls `PATCH /api/users/password` with `{ currentPassword, newPassword }`
- [x] Shows success toast on 200 response, clears form
- [x] Shows error message on 400 (wrong current password, validation error)
- [x] Loading state on submit button while request is in flight
- [x] Social-auth users (Google/Apple sign-in) do NOT see the Change Password section
- [x] Follows existing MUI styling patterns (consistent with other Settings sections)
- [x] Build passes: `CI=false yarn build`

## Test Plan
1. Log in with email/password account, navigate to Settings
2. Verify "Security" section appears with "Change Password" button
3. Click the button -- form expands with 3 password fields
4. Test validation: type a short new password (< 6 chars), confirm mismatch
5. Submit with correct current password -- verify success toast and form reset
6. Submit with wrong current password -- verify inline error message
7. Log in with Google/Apple account -- verify Security section is hidden

Generated with [Claude Code](https://claude.com/claude-code)