### PR TITLE
feat: add inline receipt scan button to expense form

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1141,6 +1141,8 @@ const MainLayout: React.FC = () => {
         amountsByDescription={amountsByDescription}
         categoriesByDescription={categoriesByDescription}
         receiptPrefill={receiptPrefill}
+        onScanReceipt={handleScanReceipt}
+        scanLoading={scanLoading}
         participantsForItem={smartSuggestions.participantsForItem}
         timeRelevantItems={smartSuggestions.timeRelevantItems}
       />

--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -39,6 +39,7 @@ import ManageTemplatesDrawer from './ManageTemplatesDrawer';
 import ParticipantPicker from './ParticipantPicker';
 import PaymentMethodPicker from './PaymentMethodPicker';
 import NlpInput from './NlpInput';
+import ReceiptScanButton from './ReceiptScanButton';
 import { ParsedTransaction } from '../../services/api';
 import { useTemplates, TransactionTemplate } from '../../hooks/useTemplates';
 import { useFxRates, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
@@ -68,6 +69,10 @@ interface Props {
   amountsByDescription?: Record<string, number>;
   categoriesByDescription?: Record<string, string>;
   receiptPrefill?: ReceiptPrefill;
+  /** Callback to trigger receipt scan from within the modal */
+  onScanReceipt?: (file: File) => void;
+  /** Whether a receipt scan is in progress */
+  scanLoading?: boolean;
   /** Smart suggestions: participants ranked for current item */
   participantsForItem?: (item: string) => string[];
   /** Smart suggestions: time-relevant items for current hour */
@@ -83,7 +88,7 @@ const yesterday = () => {
 
 type QuickDate = 'today' | 'yesterday' | 'custom';
 
-const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, descriptionsByItem = {}, knownParticipants = [], recentItems = [], amountsByDescription = {}, categoriesByDescription = {}, receiptPrefill, participantsForItem, timeRelevantItems = [] }) => {
+const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, descriptionsByItem = {}, knownParticipants = [], recentItems = [], amountsByDescription = {}, categoriesByDescription = {}, receiptPrefill, onScanReceipt, scanLoading = false, participantsForItem, timeRelevantItems = [] }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { templates, addTemplate, deleteTemplate } = useTemplates();
@@ -358,8 +363,19 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
           </Box>
         )}
 
-        {/* NLP quick entry */}
-        {!receiptPrefill && <NlpInput onParsed={handleNlpParsed} />}
+        {/* NLP quick entry + receipt scan inline */}
+        {!receiptPrefill && (
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 0.5 }}>
+            <Box sx={{ flex: 1 }}>
+              <NlpInput onParsed={handleNlpParsed} />
+            </Box>
+            {onScanReceipt && (
+              <Box sx={{ pt: 0.5 }}>
+                <ReceiptScanButton onFileSelected={onScanReceipt} loading={scanLoading} size="small" />
+              </Box>
+            )}
+          </Box>
+        )}
 
         {/* Template quick-tap row */}
         <TemplateChips

--- a/src/components/expenses/__tests__/AddExpenseModal.test.tsx
+++ b/src/components/expenses/__tests__/AddExpenseModal.test.tsx
@@ -528,4 +528,43 @@ describe('AddExpenseModal', () => {
       expect(screen.queryByText('Scanned from receipt')).not.toBeInTheDocument();
     });
   });
+
+  describe('inline receipt scan button', () => {
+    it('shows scan button when onScanReceipt is provided', () => {
+      render(<AddExpenseModal {...defaultProps} onScanReceipt={jest.fn()} />);
+      expect(screen.getByRole('button', { name: /scan receipt/i })).toBeInTheDocument();
+    });
+
+    it('does not show scan button when onScanReceipt is not provided', () => {
+      render(<AddExpenseModal {...defaultProps} />);
+      expect(screen.queryByRole('button', { name: /scan receipt/i })).not.toBeInTheDocument();
+    });
+
+    it('hides scan button when receiptPrefill is active', () => {
+      render(
+        <AddExpenseModal
+          {...defaultProps}
+          onScanReceipt={jest.fn()}
+          receiptPrefill={{ amount: 50, description: 'Test', confidence: 'high' }}
+        />,
+      );
+      expect(screen.queryByRole('button', { name: /scan receipt/i })).not.toBeInTheDocument();
+    });
+
+    it('calls onScanReceipt when a file is selected via inline button', () => {
+      const onScanReceipt = jest.fn();
+      render(<AddExpenseModal {...defaultProps} onScanReceipt={onScanReceipt} />);
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      expect(input).not.toBeNull();
+      const file = new File(['receipt'], 'receipt.png', { type: 'image/png' });
+      fireEvent.change(input, { target: { files: [file] } });
+      expect(onScanReceipt).toHaveBeenCalledWith(file);
+    });
+
+    it('shows loading state on inline scan button when scanLoading is true', () => {
+      render(<AddExpenseModal {...defaultProps} onScanReceipt={jest.fn()} scanLoading={true} />);
+      const button = screen.getByRole('button', { name: /scan receipt/i });
+      expect(button).toBeDisabled();
+    });
+  });
 });


### PR DESCRIPTION
## What
Added an inline receipt scan button directly inside the Add Expense modal, next to the NLP quick-entry input. This gives users a second entry point to OCR-scan receipts without needing to use the floating action button.

## Why
Closes #253

The backend OCR endpoint (`POST /api/receipts/scan`) already existed, and the FAB-based scan flow was wired up, but there was no scan button visible inside the expense form itself. This closes the gap so users can discover and use receipt scanning from within the form.

## Acceptance Criteria
- [x] Receipt upload button visible on the add expense form
- [x] User can select image from file picker (accept JPEG, PNG via `image/*`)
- [x] Image preview shown after OCR completes (via existing receipt prefill banner)
- [x] Loading indicator during OCR processing (button disables + spinner)
- [x] Parsed data (amount, description, date) auto-fills the expense form
- [x] User can review and edit auto-filled fields before saving
- [x] Error states: OCR failure shows snackbar, unsupported format handled by browser
- [x] Build passes: `CI=false yarn build`

## Test Plan
- Open Add Expense modal and verify scan receipt icon button appears next to NLP input
- Click scan button, select an image file, verify loading spinner appears
- After OCR, verify form fields are pre-filled with scanned data
- Verify "Scanned from receipt" banner with image preview appears
- Verify scan button is hidden when receipt prefill is active
- Run `yarn test --testPathPattern=AddExpenseModal` -- all 60 tests pass (5 new)

Generated with [Claude Code](https://claude.com/claude-code)