### PR TITLE
feat: transaction tagging UI (#271)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -68,6 +68,8 @@ const SpendingInsightsPage = React.lazy(() => import('./insights/SpendingInsight
 import SpendingPulse from './dashboard/SpendingPulse';
 import { useSmartSuggestions } from '../hooks/useSmartSuggestions';
 const GoalsPage = React.lazy(() => import('./goals/GoalsPage'));
+const MonthlyReportPage = React.lazy(() => import('./reports/MonthlyReportPage'));
+import AssessmentIcon from '@mui/icons-material/Assessment';
 
 function getOwnerFromToken(): string {
   try {
@@ -85,7 +87,7 @@ const MainLayout: React.FC = () => {
   const { currency, setCurrency, convert, symbol } = useFxRates();
   const { items: recurringItems, markApplied } = useRecurring();
   const { budgets } = useBudgets();
-  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4 | 5 | 6>(0);
+  const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4 | 5 | 6 | 7>(0);
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
 
   useEffect(() => {
@@ -502,6 +504,7 @@ const MainLayout: React.FC = () => {
     { label: 'Insights', icon: <BarChartIcon /> },
     { label: 'Recurring', icon: <RepeatIcon /> },
     { label: 'Goals', icon: <SavingsIcon /> },
+    { label: 'Reports', icon: <AssessmentIcon /> },
     { label: 'Settings', icon: <SettingsIcon /> },
   ];
 
@@ -602,7 +605,7 @@ const MainLayout: React.FC = () => {
               <ListItemButton
                 key={item.label}
                 selected={activeTab === index}
-                onClick={() => setActiveTab(index as 0 | 1 | 2 | 3 | 4 | 5 | 6)}
+                onClick={() => setActiveTab(index as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7)}
                 sx={{
                   '&.Mui-selected': { bgcolor: theme.palette.mode === 'dark' ? 'rgba(129,140,248,0.1)' : 'rgba(99,102,241,0.12)', color: 'primary.main' },
                   '&.Mui-selected .MuiListItemIcon-root': { color: 'primary.main' },
@@ -950,6 +953,10 @@ const MainLayout: React.FC = () => {
             )}
 
             {activeTab === 6 && (
+              <MonthlyReportPage transactions={transactions} convert={convert} symbol={symbol} />
+            )}
+
+            {activeTab === 7 && (
               <SettingsPage
                 currency={currency}
                 onCurrencyChange={(c: Currency) => setCurrency(c)}
@@ -985,6 +992,7 @@ const MainLayout: React.FC = () => {
           <BottomNavigationAction label="Insights" icon={<BarChartIcon />} />
           <BottomNavigationAction label="Repeat" icon={<RepeatIcon />} />
           <BottomNavigationAction label="Goals" icon={<SavingsIcon />} />
+          <BottomNavigationAction label="Reports" icon={<AssessmentIcon />} />
           <BottomNavigationAction label="Settings" icon={<SettingsIcon />} />
         </BottomNavigation>
       </Box>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -40,6 +40,7 @@ import SavingsIcon from '@mui/icons-material/Savings';
 import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../types';
 import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult } from '../services/api';
+import { useTags } from '../hooks/useTags';
 import SummaryCards from './dashboard/SummaryCards';
 import DateRangeControl, { DatePreset } from './dashboard/DateRangeControl';
 import MobileHero from './dashboard/MobileHero';
@@ -87,6 +88,7 @@ const MainLayout: React.FC = () => {
   const { currency, setCurrency, convert, symbol } = useFxRates();
   const { items: recurringItems, markApplied } = useRecurring();
   const { budgets } = useBudgets();
+  const { tags, addTag } = useTags();
   const [activeTab, setActiveTab] = useState<0 | 1 | 2 | 3 | 4 | 5 | 6 | 7>(0);
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
 
@@ -109,6 +111,7 @@ const MainLayout: React.FC = () => {
   const [typeFilter, setTypeFilter] = useState<TransactionType | 'all'>('all');
   const [paymentMethodFilter, setPaymentMethodFilter] = useState<PaymentMethod | 'all'>('all');
   const [categoryFilter, setCategoryFilter] = useState<string | 'all'>('all');
+  const [tagFilter, setTagFilter] = useState<string | 'all'>('all');
   const [sortBy, setSortBy] = useState<'date' | 'amount'>('date');
   const [exportMenuAnchor, setExportMenuAnchor] = useState<null | HTMLElement>(null);
   const [addOpen, setAddOpen] = useState(false);
@@ -430,17 +433,19 @@ const MainLayout: React.FC = () => {
         (t.item || '').toLowerCase().includes(searchLow) ||
         (t.category || '').toLowerCase().includes(searchLow) ||
         (t.participants || []).some((p) => p.toLowerCase().includes(searchLow)) ||
-        (t.notes || '').toLowerCase().includes(searchLow);
+        (t.notes || '').toLowerCase().includes(searchLow) ||
+        (t.tags || []).some((tag) => tag.name.toLowerCase().includes(searchLow));
       const matchesType = typeFilter === 'all' || t.type === typeFilter;
       const matchesPayment = paymentMethodFilter === 'all' || t.paymentMethod === paymentMethodFilter;
       const matchesCategory = categoryFilter === 'all' || t.category === categoryFilter;
-      return matchesSearch && matchesType && matchesPayment && matchesCategory;
+      const matchesTag = tagFilter === 'all' || (t.tags || []).some((tag) => tag._id === tagFilter);
+      return matchesSearch && matchesType && matchesPayment && matchesCategory && matchesTag;
     });
     if (sortBy === 'amount') {
       return [...filtered].sort((a, b) => b.amount - a.amount);
     }
     return filtered;
-  }, [transactions, monthFiltered, search, typeFilter, paymentMethodFilter, categoryFilter, sortBy]);
+  }, [transactions, monthFiltered, search, typeFilter, paymentMethodFilter, categoryFilter, tagFilter, sortBy]);
 
   const handleExport = () => {
     const header = ['Date', 'Item', 'Description', 'Type', 'Category', 'Amount', 'Payment Method', 'Participants'];
@@ -884,7 +889,9 @@ const MainLayout: React.FC = () => {
                 typeFilter={typeFilter}
                 paymentMethodFilter={paymentMethodFilter}
                 categoryFilter={categoryFilter}
+                tagFilter={tagFilter}
                 categories={existingCategories}
+                availableTags={tags}
                 sortBy={sortBy}
                 total={search !== '' ? transactions.length : monthFiltered.length}
                 filtered={filteredTransactions.length}
@@ -893,6 +900,7 @@ const MainLayout: React.FC = () => {
                 onTypeFilterChange={setTypeFilter}
                 onPaymentMethodFilterChange={setPaymentMethodFilter}
                 onCategoryFilterChange={setCategoryFilter}
+                onTagFilterChange={setTagFilter}
                 onSortChange={setSortBy}
                 onExport={handleExport}
                 onExportJson={handleExportJson}
@@ -928,7 +936,7 @@ const MainLayout: React.FC = () => {
                 convert={convert}
                 symbol={symbol}
                 recurringLabels={recurringLabels}
-                filtersActive={search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all' || categoryFilter !== 'all'}
+                filtersActive={search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all' || categoryFilter !== 'all' || tagFilter !== 'all'}
                 onAddClick={() => setAddOpen(true)}
                 onRefresh={fetchTransactions}
               />
@@ -1062,6 +1070,8 @@ const MainLayout: React.FC = () => {
         amountsByDescription={amountsByDescription}
         categoriesByDescription={categoriesByDescription}
         receiptPrefill={receiptPrefill}
+        availableTags={tags}
+        onCreateTag={(name) => addTag(name)}
         participantsForItem={smartSuggestions.participantsForItem}
         timeRelevantItems={smartSuggestions.timeRelevantItems}
       />
@@ -1092,6 +1102,8 @@ const MainLayout: React.FC = () => {
         descriptionsByItem={descriptionsByItem}
         knownParticipants={knownParticipants}
         recentItems={recentItems}
+        availableTags={tags}
+        onCreateTag={(name) => addTag(name)}
       />
 
       <Snackbar

--- a/src/components/expenses/AddExpenseModal.tsx
+++ b/src/components/expenses/AddExpenseModal.tsx
@@ -29,8 +29,9 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
-import { TransactionRequest, TransactionType, PaymentMethod } from '../../types';
+import { TransactionRequest, TransactionType, PaymentMethod, Tag } from '../../types';
 import { ReceiptConfidence } from '../../services/api';
+import TagPicker from './TagPicker';
 import NumPad from './NumPad';
 import ItemPicker, { ItemPreset, ITEM_SUGGESTIONS } from './ItemPicker';
 import DescriptionPicker from './DescriptionPicker';
@@ -68,6 +69,8 @@ interface Props {
   amountsByDescription?: Record<string, number>;
   categoriesByDescription?: Record<string, string>;
   receiptPrefill?: ReceiptPrefill;
+  availableTags?: Tag[];
+  onCreateTag?: (name: string) => Promise<Tag>;
   /** Smart suggestions: participants ranked for current item */
   participantsForItem?: (item: string) => string[];
   /** Smart suggestions: time-relevant items for current hour */
@@ -83,7 +86,7 @@ const yesterday = () => {
 
 type QuickDate = 'today' | 'yesterday' | 'custom';
 
-const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, descriptionsByItem = {}, knownParticipants = [], recentItems = [], amountsByDescription = {}, categoriesByDescription = {}, receiptPrefill, participantsForItem, timeRelevantItems = [] }) => {
+const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, descriptionsByItem = {}, knownParticipants = [], recentItems = [], amountsByDescription = {}, categoriesByDescription = {}, receiptPrefill, availableTags = [], onCreateTag, participantsForItem, timeRelevantItems = [] }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { templates, addTemplate, deleteTemplate } = useTemplates();
@@ -106,6 +109,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState<RecurringFrequency>('monthly');
   const [notes, setNotes] = useState('');
+  const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
@@ -172,6 +176,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
     setIsRecurring(false);
     setFrequency('monthly');
     setNotes('');
+    setSelectedTags([]);
     setError('');
     onClose();
   };
@@ -195,6 +200,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
       splitBill: participants.length > 0 ? splitBillMode : undefined,
       paymentMethod: paymentMethod || undefined,
       notes: notes.trim() || undefined,
+      tags: selectedTags.length > 0 ? selectedTags.map((t) => t._id) : undefined,
       date: resolvedDate,
       ...(isForeign ? {
         currency: txCurrency,
@@ -224,6 +230,7 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
         setAmount('');
         setDescription('');
         setNotes('');
+        setSelectedTags([]);
         setError('');
       } else {
         handleClose();
@@ -505,6 +512,21 @@ const AddExpenseModal: React.FC<Props> = ({ open, onClose, onSubmit, description
             />
           )}
         </Box>
+
+        {/* Tags */}
+        {onCreateTag && (
+          <Box sx={{ mt: 1.5 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75, fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+              Tags
+            </Typography>
+            <TagPicker
+              selectedTags={selectedTags}
+              availableTags={availableTags}
+              onChange={setSelectedTags}
+              onCreateTag={onCreateTag}
+            />
+          </Box>
+        )}
 
         {/* Collapsible secondary fields */}
         <Box

--- a/src/components/expenses/EditExpenseModal.tsx
+++ b/src/components/expenses/EditExpenseModal.tsx
@@ -30,8 +30,9 @@ import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
 import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../../types';
+import { Transaction, TransactionRequest, TransactionType, PaymentMethod, Tag } from '../../types';
 import { updateExpense } from '../../services/api';
+import TagPicker from './TagPicker';
 import NumPad from './NumPad';
 import ItemPicker, { ItemPreset, ITEM_PRESETS, ITEM_SUGGESTIONS } from './ItemPicker';
 import DescriptionPicker from './DescriptionPicker';
@@ -52,6 +53,8 @@ interface Props {
   descriptionsByItem?: Record<string, string[]>;
   knownParticipants?: string[];
   recentItems?: string[];
+  availableTags?: Tag[];
+  onCreateTag?: (name: string) => Promise<Tag>;
 }
 
 type QuickDate = 'today' | 'yesterday' | 'custom';
@@ -70,7 +73,7 @@ function classifyDate(dateStr: string): QuickDate {
   return 'custom';
 }
 
-const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved, onDelete, onDuplicate, descriptionsByItem = {}, knownParticipants = [], recentItems = [] }) => {
+const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved, onDelete, onDuplicate, descriptionsByItem = {}, knownParticipants = [], recentItems = [], availableTags = [], onCreateTag }) => {
   const { presets: itemPresets } = useItemPresets();
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
@@ -89,6 +92,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
   const [splitBillMode, setSplitBillMode] = useState<'treat' | 'split' | 'participate'>('treat');
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null);
   const [notes, setNotes] = useState('');
+  const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [deleteConfirm, setDeleteConfirm] = useState(false);
@@ -116,6 +120,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
       setPaymentMethod((transaction.paymentMethod as PaymentMethod) || null);
       setTxCurrency((transaction.currency as Currency) || 'HKD');
       setNotes(transaction.notes || '');
+      setSelectedTags(transaction.tags ?? []);
       const raw = transaction.date ? transaction.date.split('T')[0] : todayStr();
       setQuickDate(classifyDate(raw));
       setCustomDate(raw);
@@ -158,6 +163,7 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
         splitBill: participants.length > 0 ? splitBillMode : undefined,
         paymentMethod: paymentMethod || undefined,
         notes: notes.trim() || undefined,
+        tags: selectedTags.map((t) => t._id),
         date: resolvedDate,
         owner: transaction.owner,
         ...(isForeign ? {
@@ -373,6 +379,21 @@ const EditExpenseModal: React.FC<Props> = ({ open, transaction, onClose, onSaved
             />
           )}
         </Box>
+
+        {/* Tags */}
+        {onCreateTag && (
+          <Box sx={{ mt: 1.5 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75, fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+              Tags
+            </Typography>
+            <TagPicker
+              selectedTags={selectedTags}
+              availableTags={availableTags}
+              onChange={setSelectedTags}
+              onCreateTag={onCreateTag}
+            />
+          </Box>
+        )}
 
         {/* Collapsible secondary fields */}
         <Box

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -27,7 +27,8 @@ import GroupIcon from '@mui/icons-material/Group';
 import EmptyState from '../EmptyState';
 import PaymentIcon from '@mui/icons-material/Payment';
 import NoteIcon from '@mui/icons-material/Notes';
-import { Transaction, PAYMENT_METHOD_LABELS, PaymentMethod } from '../../types';
+import { Transaction, PAYMENT_METHOD_LABELS, PaymentMethod, Tag } from '../../types';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import { CURRENCY_SYMBOLS, Currency } from '../../constants/currencies';
 
 interface Props {
@@ -79,6 +80,33 @@ function formatDateShort(dateStr: string | undefined, fallback?: string): string
     return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
   }
   return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function TagChips({ tags }: { tags: Tag[] }) {
+  if (!tags || tags.length === 0) return null;
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.375, mt: 0.375 }}>
+      {tags.map((tag) => (
+        <Chip
+          key={tag._id}
+          label={tag.name}
+          size="small"
+          icon={<LocalOfferIcon sx={{ fontSize: '10px !important', color: tag.color ? `${tag.color} !important` : undefined }} />}
+          sx={{
+            fontSize: '0.62rem',
+            height: 18,
+            px: 0,
+            bgcolor: tag.color ? `${tag.color}22` : 'rgba(148,163,184,0.08)',
+            color: tag.color ?? 'text.secondary',
+            border: '1px solid',
+            borderColor: tag.color ? `${tag.color}55` : 'rgba(148,163,184,0.15)',
+            fontWeight: 500,
+            '& .MuiChip-label': { px: 0.75 },
+          }}
+        />
+      ))}
+    </Box>
+  );
 }
 
 function fmtAmt(amount: number, convert: (n: number) => number, symbol: string) {
@@ -388,6 +416,7 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                                 {t.description}
                               </Typography>
                             )}
+                            {t.tags && t.tags.length > 0 && <TagChips tags={t.tags} />}
                             {t.participants && t.participants.length > 0 && (() => {
                               const mode = typeof t.splitBill === 'string' ? t.splitBill : t.splitBill === true ? 'split' : 'treat';
                               return (
@@ -520,6 +549,7 @@ const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert,
                       </Tooltip>
                     )}
                   </Box>
+                  {t.tags && t.tags.length > 0 && <TagChips tags={t.tags} />}
                 </TableCell>
                 <TableCell sx={{ maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'text.secondary', fontSize: '0.8rem' }}>
                   {t.participants && t.participants.length > 0 ? (() => {

--- a/src/components/expenses/FilterBar.tsx
+++ b/src/components/expenses/FilterBar.tsx
@@ -24,14 +24,17 @@ import DataObjectIcon from '@mui/icons-material/DataObject';
 import SortIcon from '@mui/icons-material/Sort';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import LabelIcon from '@mui/icons-material/Label';
-import { TransactionType, PAYMENT_METHODS, PaymentMethod } from '../../types';
+import { TransactionType, PAYMENT_METHODS, PaymentMethod, Tag } from '../../types';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 
 interface Props {
   search: string;
   typeFilter: TransactionType | 'all';
   paymentMethodFilter: PaymentMethod | 'all';
   categoryFilter: string | 'all';
+  tagFilter?: string | 'all';
   categories: string[];
+  availableTags?: Tag[];
   sortBy: 'date' | 'amount';
   total: number;
   filtered: number;
@@ -40,6 +43,7 @@ interface Props {
   onTypeFilterChange: (v: TransactionType | 'all') => void;
   onPaymentMethodFilterChange: (v: PaymentMethod | 'all') => void;
   onCategoryFilterChange: (v: string | 'all') => void;
+  onTagFilterChange?: (v: string | 'all') => void;
   onSortChange: (v: 'date' | 'amount') => void;
   onExport: () => void;
   onExportJson: () => void;
@@ -50,7 +54,9 @@ const FilterBar: React.FC<Props> = ({
   typeFilter,
   paymentMethodFilter,
   categoryFilter,
+  tagFilter = 'all',
   categories,
+  availableTags = [],
   sortBy,
   total,
   filtered,
@@ -59,6 +65,7 @@ const FilterBar: React.FC<Props> = ({
   onTypeFilterChange,
   onPaymentMethodFilterChange,
   onCategoryFilterChange,
+  onTagFilterChange = () => {},
   onSortChange,
   onExport,
   onExportJson,
@@ -67,8 +74,9 @@ const FilterBar: React.FC<Props> = ({
   const isDark = theme.palette.mode === 'dark';
   const [showPaymentFilter, setShowPaymentFilter] = useState(paymentMethodFilter !== 'all');
   const [showCategoryFilter, setShowCategoryFilter] = useState(categoryFilter !== 'all');
+  const [showTagFilter, setShowTagFilter] = useState(tagFilter !== 'all');
   const [exportMenuAnchor, setExportMenuAnchor] = useState<null | HTMLElement>(null);
-  const isActive = search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all' || categoryFilter !== 'all';
+  const isActive = search !== '' || typeFilter !== 'all' || paymentMethodFilter !== 'all' || categoryFilter !== 'all' || tagFilter !== 'all';
 
   return (
     <Box sx={{ mb: 2 }}>
@@ -139,6 +147,25 @@ const FilterBar: React.FC<Props> = ({
               }}
             >
               <LabelIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
+        {availableTags.length > 0 && (
+          <Tooltip title="Filter by tag">
+            <IconButton
+              size="small"
+              aria-label="Filter by tag"
+              onClick={() => {
+                const next = !showTagFilter;
+                setShowTagFilter(next);
+                if (!next) onTagFilterChange('all');
+              }}
+              sx={{
+                color: tagFilter !== 'all' ? theme.palette.primary.main : 'text.secondary',
+                '&:hover': { color: 'text.primary' },
+              }}
+            >
+              <LocalOfferIcon fontSize="small" />
             </IconButton>
           </Tooltip>
         )}
@@ -268,6 +295,48 @@ const FilterBar: React.FC<Props> = ({
                 border: '1px solid',
                 borderColor: categoryFilter === cat ? (isDark ? 'rgba(129,140,248,0.4)' : 'rgba(99,102,241,0.5)') : 'rgba(148,163,184,0.12)',
                 fontWeight: categoryFilter === cat ? 700 : 400,
+              }}
+            />
+          ))}
+        </Box>
+      </Collapse>
+      <Collapse in={showTagFilter && availableTags.length > 0}>
+        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 1.5 }}>
+          <Chip
+            label="All tags"
+            size="small"
+            clickable
+            onClick={() => onTagFilterChange('all')}
+            sx={{
+              fontSize: '0.72rem',
+              height: 26,
+              bgcolor: tagFilter === 'all' ? (isDark ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.22)') : 'rgba(148,163,184,0.08)',
+              color: tagFilter === 'all' ? theme.palette.primary.main : 'text.secondary',
+              border: '1px solid',
+              borderColor: tagFilter === 'all' ? (isDark ? 'rgba(129,140,248,0.4)' : 'rgba(99,102,241,0.5)') : 'rgba(148,163,184,0.12)',
+              fontWeight: tagFilter === 'all' ? 700 : 400,
+            }}
+          />
+          {availableTags.map((tag) => (
+            <Chip
+              key={tag._id}
+              label={tag.name}
+              size="small"
+              clickable
+              icon={<LocalOfferIcon sx={{ fontSize: '11px !important', color: tag.color ? `${tag.color} !important` : undefined }} />}
+              onClick={() => onTagFilterChange(tagFilter === tag._id ? 'all' : tag._id)}
+              sx={{
+                fontSize: '0.72rem',
+                height: 26,
+                bgcolor: tagFilter === tag._id
+                  ? (tag.color ? `${tag.color}22` : (isDark ? 'rgba(129,140,248,0.18)' : 'rgba(99,102,241,0.22)'))
+                  : 'rgba(148,163,184,0.08)',
+                color: tagFilter === tag._id ? (tag.color ?? theme.palette.primary.main) : 'text.secondary',
+                border: '1px solid',
+                borderColor: tagFilter === tag._id
+                  ? (tag.color ? `${tag.color}55` : (isDark ? 'rgba(129,140,248,0.4)' : 'rgba(99,102,241,0.5)'))
+                  : 'rgba(148,163,184,0.12)',
+                fontWeight: tagFilter === tag._id ? 700 : 400,
               }}
             />
           ))}

--- a/src/components/expenses/TagPicker.tsx
+++ b/src/components/expenses/TagPicker.tsx
@@ -1,0 +1,176 @@
+import React, { useState, useRef } from 'react';
+import {
+  Box,
+  Chip,
+  TextField,
+  Autocomplete,
+  Typography,
+  createFilterOptions,
+} from '@mui/material';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import { Tag } from '../../types';
+
+const MAX_TAGS_PER_TRANSACTION = 10;
+
+interface Props {
+  selectedTags: Tag[];
+  availableTags: Tag[];
+  onChange: (tags: Tag[]) => void;
+  onCreateTag: (name: string) => Promise<Tag>;
+  disabled?: boolean;
+}
+
+interface TagOption {
+  _id: string;
+  name: string;
+  color?: string;
+  inputValue?: string;
+}
+
+const filter = createFilterOptions<TagOption>();
+
+const TagPicker: React.FC<Props> = ({ selectedTags, availableTags, onChange, onCreateTag, disabled }) => {
+  const [inputValue, setInputValue] = useState('');
+  const [creating, setCreating] = useState(false);
+  const creatingRef = useRef(false);
+
+  const options: TagOption[] = availableTags.map((t) => ({
+    _id: t._id,
+    name: t.name,
+    color: t.color,
+  }));
+
+  const handleChange = async (_: React.SyntheticEvent, newValue: TagOption | null) => {
+    if (!newValue) return;
+
+    if (newValue.inputValue) {
+      // User wants to create a new tag inline
+      if (creatingRef.current) return;
+      creatingRef.current = true;
+      setCreating(true);
+      try {
+        const created = await onCreateTag(newValue.inputValue.trim());
+        onChange([...selectedTags, created]);
+      } finally {
+        setCreating(false);
+        creatingRef.current = false;
+      }
+      setInputValue('');
+      return;
+    }
+
+    // Existing tag selected
+    const alreadySelected = selectedTags.some((t) => t._id === newValue._id);
+    if (!alreadySelected && selectedTags.length < MAX_TAGS_PER_TRANSACTION) {
+      const original = availableTags.find((t) => t._id === newValue._id);
+      if (original) {
+        onChange([...selectedTags, original]);
+      }
+    }
+    setInputValue('');
+  };
+
+  const handleRemove = (id: string) => {
+    onChange(selectedTags.filter((t) => t._id !== id));
+  };
+
+  const atLimit = selectedTags.length >= MAX_TAGS_PER_TRANSACTION;
+
+  return (
+    <Box>
+      {selectedTags.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1 }}>
+          {selectedTags.map((tag) => (
+            <Chip
+              key={tag._id}
+              label={tag.name}
+              size="small"
+              onDelete={disabled ? undefined : () => handleRemove(tag._id)}
+              sx={{
+                fontSize: '0.72rem',
+                height: 24,
+                bgcolor: tag.color ? `${tag.color}22` : undefined,
+                borderColor: tag.color ?? undefined,
+                color: tag.color ?? undefined,
+                border: '1px solid',
+                fontWeight: 500,
+              }}
+              icon={<LocalOfferIcon sx={{ fontSize: '12px !important', color: `${tag.color} !important` }} />}
+            />
+          ))}
+        </Box>
+      )}
+      {!disabled && (
+        <Autocomplete<TagOption, false, false, false>
+          options={options.filter((o) => !selectedTags.some((s) => s._id === o._id))}
+          getOptionLabel={(option) => option.inputValue ?? option.name}
+          inputValue={inputValue}
+          onInputChange={(_, val) => setInputValue(val)}
+          onChange={handleChange}
+          value={null}
+          disabled={atLimit || creating}
+          filterOptions={(opts, params) => {
+            const filtered = filter(opts, params);
+            const { inputValue: iv } = params;
+            const trimmed = iv.trim();
+            if (
+              trimmed &&
+              !opts.some((o) => o.name.toLowerCase() === trimmed.toLowerCase()) &&
+              !selectedTags.some((t) => t.name.toLowerCase() === trimmed.toLowerCase())
+            ) {
+              filtered.push({ _id: '__new__', name: `Create "${trimmed}"`, inputValue: trimmed });
+            }
+            return filtered;
+          }}
+          renderOption={(props, option) => (
+            <li {...props} key={option._id}>
+              {option._id === '__new__' ? (
+                <Typography variant="body2" color="primary">
+                  {option.name}
+                </Typography>
+              ) : (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  {option.color && (
+                    <Box
+                      sx={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: '50%',
+                        bgcolor: option.color,
+                        flexShrink: 0,
+                      }}
+                    />
+                  )}
+                  <Typography variant="body2">{option.name}</Typography>
+                </Box>
+              )}
+            </li>
+          )}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              size="small"
+              label={atLimit ? `Max ${MAX_TAGS_PER_TRANSACTION} tags` : 'Add tag'}
+              placeholder={atLimit ? '' : 'Type to search or create…'}
+              InputProps={{
+                ...params.InputProps,
+                startAdornment: (
+                  <>
+                    <LocalOfferIcon sx={{ fontSize: 16, color: 'text.disabled', mr: 0.5 }} />
+                    {params.InputProps.startAdornment}
+                  </>
+                ),
+              }}
+            />
+          )}
+          noOptionsText="No tags — type to create one"
+          clearOnBlur
+          handleHomeEndKeys
+          selectOnFocus
+        />
+      )}
+    </Box>
+  );
+};
+
+export default TagPicker;

--- a/src/components/reports/MonthlyReportPage.tsx
+++ b/src/components/reports/MonthlyReportPage.tsx
@@ -1,0 +1,648 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  LinearProgress,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Typography,
+} from '@mui/material';
+import { useTheme, alpha } from '@mui/material/styles';
+import {
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import DownloadIcon from '@mui/icons-material/Download';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingFlatIcon from '@mui/icons-material/TrendingFlat';
+import dayjs from 'dayjs';
+import { Transaction } from '../../types';
+import { getMonthlyReport, MonthlyReportEntry, getBudgets, Budget } from '../../services/api';
+
+interface Props {
+  transactions: Transaction[];
+  convert: (hkd: number) => number;
+  symbol: string;
+}
+
+const CATEGORY_COLORS = [
+  '#6366f1',
+  '#f59e0b',
+  '#10b981',
+  '#ef4444',
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+  '#06b6d4',
+  '#84cc16',
+];
+
+function buildMonthOptions(): Array<{ value: string; label: string }> {
+  const options: Array<{ value: string; label: string }> = [];
+  for (let i = 0; i < 12; i++) {
+    const d = dayjs().subtract(i, 'month');
+    options.push({ value: d.format('YYYY-MM'), label: d.format('MMMM YYYY') });
+  }
+  return options;
+}
+
+const MonthlyReportPage: React.FC<Props> = ({ transactions, convert, symbol }) => {
+  const theme = useTheme();
+  const printRef = useRef<HTMLDivElement>(null);
+
+  const monthOptions = useMemo(() => buildMonthOptions(), []);
+  const [selectedMonth, setSelectedMonth] = useState<string>(monthOptions[0].value);
+  const [report, setReport] = useState<MonthlyReportEntry[]>([]);
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(false);
+    Promise.all([getMonthlyReport(13), getBudgets()])
+      .then(([reportData, budgetData]) => {
+        setReport(reportData);
+        setBudgets(budgetData);
+      })
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleMonthChange = useCallback((e: SelectChangeEvent) => {
+    setSelectedMonth(e.target.value);
+  }, []);
+
+  const selectedEntry = useMemo(
+    () => report.find((r) => r.month === selectedMonth) ?? null,
+    [report, selectedMonth]
+  );
+
+  const prevMonthKey = useMemo(
+    () => dayjs(selectedMonth + '-01').subtract(1, 'month').format('YYYY-MM'),
+    [selectedMonth]
+  );
+
+  const prevEntry = useMemo(
+    () => report.find((r) => r.month === prevMonthKey) ?? null,
+    [report, prevMonthKey]
+  );
+
+  const monthTxns = useMemo(
+    () => transactions.filter((t) => dayjs(t.date || t.createdAt).format('YYYY-MM') === selectedMonth),
+    [transactions, selectedMonth]
+  );
+
+  const prevMonthTxns = useMemo(
+    () => transactions.filter((t) => dayjs(t.date || t.createdAt).format('YYYY-MM') === prevMonthKey),
+    [transactions, prevMonthKey]
+  );
+
+  // Category breakdown for selected month
+  const categoryBreakdown = useMemo(() => {
+    const map: Record<string, number> = {};
+    monthTxns
+      .filter((t) => t.type === 'expense')
+      .forEach((t) => {
+        const cat = t.category || 'Other';
+        map[cat] = (map[cat] || 0) + t.amount;
+      });
+    const total = Object.values(map).reduce((s, v) => s + v, 0);
+    return Object.entries(map)
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, value], idx) => ({
+        name,
+        value,
+        pct: total > 0 ? Math.round((value / total) * 100) : 0,
+        color: CATEGORY_COLORS[idx % CATEGORY_COLORS.length],
+      }));
+  }, [monthTxns]);
+
+  // Top 5 categories
+  const top5 = useMemo(() => categoryBreakdown.slice(0, 5), [categoryBreakdown]);
+
+  // Previous month category breakdown for MoM comparison
+  const prevCategoryMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    prevMonthTxns
+      .filter((t) => t.type === 'expense')
+      .forEach((t) => {
+        const cat = t.category || 'Other';
+        map[cat] = (map[cat] || 0) + t.amount;
+      });
+    return map;
+  }, [prevMonthTxns]);
+
+  // Budget map
+  const budgetMap = useMemo(
+    () => Object.fromEntries(budgets.map((b) => [b.category, b.limit])),
+    [budgets]
+  );
+
+  // Summary totals — prefer API data, fall back to client-side
+  const totalIncome = selectedEntry?.income ?? monthTxns.filter((t) => t.type === 'income').reduce((s, t) => s + t.amount, 0);
+  const totalExpenses = selectedEntry?.expenses ?? monthTxns.filter((t) => t.type === 'expense').reduce((s, t) => s + t.amount, 0);
+  const netSavings = selectedEntry?.net ?? (totalIncome - totalExpenses);
+
+  const prevTotalExpenses = prevEntry?.expenses ?? prevMonthTxns.filter((t) => t.type === 'expense').reduce((s, t) => s + t.amount, 0);
+  const expenseDelta = prevTotalExpenses > 0 ? ((totalExpenses - prevTotalExpenses) / prevTotalExpenses) * 100 : null;
+
+  const hasData = monthTxns.length > 0 || (selectedEntry && (selectedEntry.income > 0 || selectedEntry.expenses > 0));
+
+  const handleDownloadPdf = useCallback(() => {
+    const monthLabel = dayjs(selectedMonth + '-01').format('MMMM YYYY');
+    const printWindow = window.open('', '_blank');
+    if (!printWindow || !printRef.current) return;
+
+    const styles = `
+      <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 24px; color: #1e293b; background: #fff; }
+        h1 { font-size: 22px; font-weight: 700; margin-bottom: 4px; color: #1e293b; }
+        .subtitle { font-size: 13px; color: #64748b; margin-bottom: 24px; }
+        .summary-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-bottom: 24px; }
+        .summary-card { border: 1px solid #e2e8f0; border-radius: 10px; padding: 16px; }
+        .summary-card .label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: #94a3b8; font-weight: 700; margin-bottom: 6px; }
+        .summary-card .value { font-size: 22px; font-weight: 700; }
+        .income-val { color: #10b981; }
+        .expense-val { color: #ef4444; }
+        .net-pos { color: #6366f1; }
+        .net-neg { color: #ef4444; }
+        .section-title { font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: #94a3b8; margin: 24px 0 12px; }
+        .category-row { display: flex; align-items: center; margin-bottom: 10px; gap: 10px; }
+        .category-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+        .category-name { flex: 1; font-size: 14px; }
+        .category-bar-wrap { width: 100px; background: #f1f5f9; border-radius: 4px; height: 6px; }
+        .category-bar { background: #6366f1; height: 6px; border-radius: 4px; }
+        .category-amount { font-size: 14px; font-weight: 600; min-width: 80px; text-align: right; }
+        .category-pct { font-size: 12px; color: #94a3b8; min-width: 36px; text-align: right; }
+        .mom-banner { border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; font-size: 14px; font-weight: 600; }
+        .mom-up { background: #fef2f2; color: #ef4444; }
+        .mom-down { background: #f0fdf4; color: #10b981; }
+        .mom-flat { background: #f8fafc; color: #64748b; }
+        .budget-row { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+        .budget-label { flex: 1; font-size: 13px; }
+        .budget-progress { width: 120px; background: #f1f5f9; border-radius: 4px; height: 6px; }
+        .budget-fill-ok { background: #10b981; height: 6px; border-radius: 4px; }
+        .budget-fill-warn { background: #f59e0b; height: 6px; border-radius: 4px; }
+        .budget-fill-over { background: #ef4444; height: 6px; border-radius: 4px; }
+        .budget-amounts { font-size: 12px; color: #64748b; min-width: 120px; text-align: right; }
+        @media print { body { padding: 0; } }
+      </style>
+    `;
+
+    const summaryHtml = `
+      <div class="summary-grid">
+        <div class="summary-card">
+          <div class="label">Income</div>
+          <div class="value income-val">${symbol}${convert(totalIncome).toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
+        </div>
+        <div class="summary-card">
+          <div class="label">Expenses</div>
+          <div class="value expense-val">${symbol}${convert(totalExpenses).toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
+        </div>
+        <div class="summary-card">
+          <div class="label">Net Savings</div>
+          <div class="value ${netSavings >= 0 ? 'net-pos' : 'net-neg'}">${netSavings >= 0 ? '+' : ''}${symbol}${convert(netSavings).toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
+        </div>
+      </div>
+    `;
+
+    const momHtml = expenseDelta !== null ? `
+      <div class="mom-banner ${expenseDelta > 0 ? 'mom-up' : expenseDelta < 0 ? 'mom-down' : 'mom-flat'}">
+        ${expenseDelta > 0 ? '↑' : expenseDelta < 0 ? '↓' : '→'} Spending ${expenseDelta > 0 ? 'up' : expenseDelta < 0 ? 'down' : 'flat'} ${Math.abs(Math.round(expenseDelta))}% vs ${dayjs(prevMonthKey + '-01').format('MMMM')}
+      </div>
+    ` : '';
+
+    const categoryHtml = top5.length > 0 ? `
+      <div class="section-title">Top Categories</div>
+      ${top5.map((c) => `
+        <div class="category-row">
+          <div class="category-dot" style="background:${c.color}"></div>
+          <div class="category-name">${c.name}</div>
+          <div class="category-bar-wrap"><div class="category-bar" style="width:${c.pct}%;background:${c.color}"></div></div>
+          <div class="category-amount">${symbol}${convert(c.value).toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
+          <div class="category-pct">${c.pct}%</div>
+        </div>
+      `).join('')}
+    ` : '';
+
+    const budgetCategories = Object.entries(budgetMap).filter(([, limit]) => limit > 0);
+    const budgetHtml = budgetCategories.length > 0 ? `
+      <div class="section-title">Budget vs Actual</div>
+      ${budgetCategories.map(([cat, limit]) => {
+        const spent = categoryBreakdown.find((c) => c.name === cat)?.value ?? 0;
+        const pct = Math.min(Math.round((spent / limit) * 100), 100);
+        const overClass = spent > limit ? 'budget-fill-over' : pct >= 80 ? 'budget-fill-warn' : 'budget-fill-ok';
+        return `
+          <div class="budget-row">
+            <div class="budget-label">${cat}</div>
+            <div class="budget-progress"><div class="${overClass}" style="width:${pct}%"></div></div>
+            <div class="budget-amounts">${symbol}${convert(spent).toLocaleString(undefined, { maximumFractionDigits: 0 })} / ${symbol}${convert(limit).toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
+          </div>
+        `;
+      }).join('')}
+    ` : '';
+
+    printWindow.document.write(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Money Flow — ${monthLabel}</title>
+          ${styles}
+        </head>
+        <body>
+          <h1>Monthly Report</h1>
+          <div class="subtitle">${monthLabel} &nbsp;·&nbsp; Generated ${dayjs().format('D MMM YYYY')}</div>
+          ${summaryHtml}
+          ${momHtml}
+          ${categoryHtml}
+          ${budgetHtml}
+        </body>
+      </html>
+    `);
+    printWindow.document.close();
+    printWindow.focus();
+    setTimeout(() => {
+      printWindow.print();
+      printWindow.close();
+    }, 300);
+  }, [selectedMonth, totalIncome, totalExpenses, netSavings, expenseDelta, prevMonthKey, top5, categoryBreakdown, budgetMap, convert, symbol]);
+
+  const cardBg = theme.palette.background.paper;
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress size={32} />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography color="text.secondary">Could not load report data. Please try again later.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box ref={printRef} sx={{ pb: 4 }}>
+      {/* Header row */}
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3, flexWrap: 'wrap', gap: 2 }}>
+        <Typography variant="h6" fontWeight={700}>
+          Monthly Report
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'center', flexWrap: 'wrap' }}>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="month-select-label">Month</InputLabel>
+            <Select
+              labelId="month-select-label"
+              value={selectedMonth}
+              label="Month"
+              onChange={handleMonthChange}
+            >
+              {monthOptions.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<DownloadIcon />}
+            onClick={handleDownloadPdf}
+            disabled={!hasData}
+            aria-label="Download PDF report"
+          >
+            Download PDF
+          </Button>
+        </Box>
+      </Box>
+
+      {/* Empty state */}
+      {!hasData ? (
+        <Card
+          elevation={0}
+          sx={{ border: `1px solid ${theme.palette.divider}`, borderRadius: 2, bgcolor: cardBg, py: 6, textAlign: 'center' }}
+        >
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            No transactions for {dayjs(selectedMonth + '-01').format('MMMM YYYY')}.
+          </Typography>
+          <Typography variant="caption" color="text.disabled">
+            Add some transactions to see your monthly report.
+          </Typography>
+        </Card>
+      ) : (
+        <>
+          {/* MoM comparison banner */}
+          {expenseDelta !== null && (
+            <Box
+              sx={{
+                mb: 2.5,
+                py: 1.25,
+                px: 2,
+                borderRadius: 2,
+                bgcolor: alpha(
+                  expenseDelta > 0 ? theme.palette.error.main : expenseDelta < 0 ? theme.palette.success.main : theme.palette.text.secondary,
+                  0.1
+                ),
+                border: `1px solid ${alpha(
+                  expenseDelta > 0 ? theme.palette.error.main : expenseDelta < 0 ? theme.palette.success.main : theme.palette.text.secondary,
+                  0.25
+                )}`,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+              }}
+            >
+              {expenseDelta < 0 ? (
+                <TrendingDownIcon sx={{ color: theme.palette.success.main, fontSize: 20 }} />
+              ) : expenseDelta > 0 ? (
+                <TrendingUpIcon sx={{ color: theme.palette.error.main, fontSize: 20 }} />
+              ) : (
+                <TrendingFlatIcon sx={{ color: theme.palette.text.secondary, fontSize: 20 }} />
+              )}
+              <Typography
+                sx={{
+                  fontSize: '0.875rem',
+                  fontWeight: 600,
+                  color: expenseDelta > 0 ? theme.palette.error.main : expenseDelta < 0 ? theme.palette.success.main : theme.palette.text.secondary,
+                }}
+              >
+                Spending {expenseDelta > 0 ? 'up' : expenseDelta < 0 ? 'down' : 'flat'}{' '}
+                {Math.abs(Math.round(expenseDelta))}% vs{' '}
+                {dayjs(prevMonthKey + '-01').format('MMMM')}
+              </Typography>
+            </Box>
+          )}
+
+          {/* Summary cards */}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(3, 1fr)' },
+              gap: 1.5,
+              mb: 2.5,
+            }}
+          >
+            {[
+              { label: 'Income', value: totalIncome, color: theme.palette.success.main, prefix: '+' },
+              { label: 'Expenses', value: totalExpenses, color: theme.palette.error.main, prefix: '-' },
+              {
+                label: 'Net Savings',
+                value: netSavings,
+                color: netSavings >= 0 ? theme.palette.primary.main : theme.palette.error.main,
+                prefix: netSavings >= 0 ? '+' : '',
+              },
+            ].map(({ label, value, color, prefix }) => (
+              <Card
+                key={label}
+                elevation={0}
+                sx={{ border: `1px solid ${theme.palette.divider}`, borderRadius: 2, bgcolor: cardBg }}
+              >
+                <CardContent sx={{ p: '14px 16px !important' }}>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      display: 'block',
+                      color: 'text.disabled',
+                      fontSize: '0.65rem',
+                      fontWeight: 700,
+                      letterSpacing: '0.06em',
+                      textTransform: 'uppercase',
+                      mb: 0.5,
+                    }}
+                  >
+                    {label}
+                  </Typography>
+                  <Typography variant="h6" fontWeight={700} sx={{ color, fontSize: { xs: '1.1rem', sm: '1.25rem' } }}>
+                    {prefix}{symbol}{convert(Math.abs(value)).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  </Typography>
+                </CardContent>
+              </Card>
+            ))}
+          </Box>
+
+          {/* Category pie chart + top 5 */}
+          {categoryBreakdown.length > 0 && (
+            <Card
+              elevation={0}
+              sx={{ mb: 2.5, border: `1px solid ${theme.palette.divider}`, borderRadius: 2, bgcolor: cardBg }}
+            >
+              <CardContent>
+                <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 2 }}>
+                  Category Breakdown
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: { xs: 'column', sm: 'row' },
+                    alignItems: { xs: 'center', sm: 'flex-start' },
+                    gap: 3,
+                  }}
+                >
+                  {/* Pie chart */}
+                  <Box sx={{ width: { xs: 180, sm: 200 }, height: { xs: 180, sm: 200 }, flexShrink: 0 }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie
+                          data={categoryBreakdown}
+                          dataKey="value"
+                          nameKey="name"
+                          cx="50%"
+                          cy="50%"
+                          innerRadius="55%"
+                          outerRadius="80%"
+                          paddingAngle={2}
+                        >
+                          {categoryBreakdown.map((entry) => (
+                            <Cell key={entry.name} fill={entry.color} />
+                          ))}
+                        </Pie>
+                        <Tooltip
+                          formatter={(value) => {
+                            const num = typeof value === 'number' ? value : 0;
+                            return [`${symbol}${convert(num).toLocaleString(undefined, { maximumFractionDigits: 0 })}`, ''] as [string, string];
+                          }}
+                          contentStyle={{
+                            background: theme.palette.background.paper,
+                            border: `1px solid ${theme.palette.divider}`,
+                            borderRadius: 8,
+                            fontSize: '0.78rem',
+                          }}
+                        />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </Box>
+
+                  {/* Top 5 legend */}
+                  <Box sx={{ flex: 1, width: '100%' }}>
+                    {top5.map((cat, idx) => {
+                      const prevCatAmount = prevCategoryMap[cat.name] ?? 0;
+                      const catDelta =
+                        prevCatAmount > 0
+                          ? Math.round(((cat.value - prevCatAmount) / prevCatAmount) * 100)
+                          : null;
+                      return (
+                        <Box key={cat.name} sx={{ mb: idx < top5.length - 1 ? 1.5 : 0 }}>
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'space-between',
+                              mb: 0.5,
+                            }}
+                          >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                              <Box
+                                sx={{
+                                  width: 10,
+                                  height: 10,
+                                  borderRadius: '50%',
+                                  bgcolor: cat.color,
+                                  flexShrink: 0,
+                                }}
+                              />
+                              <Typography sx={{ fontSize: '0.82rem', fontWeight: 600 }}>
+                                {cat.name}
+                              </Typography>
+                            </Box>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                              {catDelta !== null && (
+                                <Chip
+                                  label={`${catDelta > 0 ? '+' : ''}${catDelta}%`}
+                                  size="small"
+                                  sx={{
+                                    height: 18,
+                                    fontSize: '0.65rem',
+                                    fontWeight: 700,
+                                    bgcolor: alpha(
+                                      catDelta > 0 ? theme.palette.error.main : theme.palette.success.main,
+                                      0.12
+                                    ),
+                                    color: catDelta > 0 ? theme.palette.error.main : theme.palette.success.main,
+                                    '& .MuiChip-label': { px: 0.75 },
+                                  }}
+                                />
+                              )}
+                              <Typography sx={{ fontSize: '0.82rem', fontWeight: 700 }}>
+                                {symbol}{convert(cat.value).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                              </Typography>
+                              <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', minWidth: 30 }}>
+                                {cat.pct}%
+                              </Typography>
+                            </Box>
+                          </Box>
+                          <LinearProgress
+                            variant="determinate"
+                            value={cat.pct}
+                            sx={{
+                              height: 4,
+                              borderRadius: 2,
+                              bgcolor: alpha(cat.color, 0.15),
+                              '& .MuiLinearProgress-bar': { bgcolor: cat.color, borderRadius: 2 },
+                            }}
+                          />
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                </Box>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Budget vs Actual */}
+          {Object.keys(budgetMap).length > 0 && (
+            <Card
+              elevation={0}
+              sx={{ border: `1px solid ${theme.palette.divider}`, borderRadius: 2, bgcolor: cardBg }}
+            >
+              <CardContent>
+                <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 2 }}>
+                  Budget vs Actual
+                </Typography>
+                {Object.entries(budgetMap)
+                  .filter(([, limit]) => limit > 0)
+                  .map(([cat, limit]) => {
+                    const spent = categoryBreakdown.find((c) => c.name === cat)?.value ?? 0;
+                    const pct = limit > 0 ? Math.min((spent / limit) * 100, 100) : 0;
+                    const isOver = spent > limit;
+                    const isNear = !isOver && pct >= 80;
+                    const barColor = isOver
+                      ? theme.palette.error.main
+                      : isNear
+                      ? theme.palette.warning.main
+                      : theme.palette.success.main;
+
+                    return (
+                      <Box key={cat} sx={{ mb: 2 }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            mb: 0.5,
+                          }}
+                        >
+                          <Typography sx={{ fontSize: '0.82rem', fontWeight: 600 }}>{cat}</Typography>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            {isOver && (
+                              <Chip
+                                label="Over budget"
+                                size="small"
+                                sx={{
+                                  height: 18,
+                                  fontSize: '0.62rem',
+                                  fontWeight: 700,
+                                  bgcolor: alpha(theme.palette.error.main, 0.12),
+                                  color: theme.palette.error.main,
+                                  '& .MuiChip-label': { px: 0.75 },
+                                }}
+                              />
+                            )}
+                            <Typography sx={{ fontSize: '0.78rem', color: 'text.secondary' }}>
+                              {symbol}{convert(spent).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                              {' / '}
+                              {symbol}{convert(limit).toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                            </Typography>
+                          </Box>
+                        </Box>
+                        <LinearProgress
+                          variant="determinate"
+                          value={Math.min(pct, 100)}
+                          sx={{
+                            height: 6,
+                            borderRadius: 3,
+                            bgcolor: alpha(barColor, 0.15),
+                            '& .MuiLinearProgress-bar': { bgcolor: barColor, borderRadius: 3 },
+                          }}
+                        />
+                      </Box>
+                    );
+                  })}
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default MonthlyReportPage;

--- a/src/components/reports/__tests__/MonthlyReportPage.test.tsx
+++ b/src/components/reports/__tests__/MonthlyReportPage.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { darkTheme } from '../../../theme';
+import MonthlyReportPage from '../MonthlyReportPage';
+import { Transaction } from '../../../types';
+import dayjs from 'dayjs';
+
+jest.mock('../../../services/api', () => ({
+  getMonthlyReport: jest.fn(),
+  getBudgets: jest.fn(),
+}));
+
+jest.mock('recharts', () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: () => null,
+  Cell: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const { getMonthlyReport, getBudgets } = require('../../../services/api') as {
+  getMonthlyReport: jest.Mock;
+  getBudgets: jest.Mock;
+};
+
+const makeTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
+  _id: '1',
+  owner: 'user1',
+  description: 'Coffee',
+  amount: 50,
+  type: 'expense',
+  category: 'Food',
+  date: dayjs().format('YYYY-MM-DD'),
+  createdAt: dayjs().format('YYYY-MM-DD'),
+  updatedAt: dayjs().format('YYYY-MM-DD'),
+  ...overrides,
+});
+
+const renderComponent = (transactions: Transaction[] = []) =>
+  render(
+    <ThemeProvider theme={darkTheme}>
+      <MonthlyReportPage transactions={transactions} convert={(n) => n} symbol="HK$" />
+    </ThemeProvider>
+  );
+
+describe('MonthlyReportPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    getMonthlyReport.mockReturnValue(new Promise(() => {}));
+    getBudgets.mockReturnValue(new Promise(() => {}));
+    renderComponent();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders page title after data loads', async () => {
+    getMonthlyReport.mockResolvedValue([]);
+    getBudgets.mockResolvedValue([]);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Monthly Report')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when API fails', async () => {
+    getMonthlyReport.mockRejectedValue(new Error('fail'));
+    getBudgets.mockRejectedValue(new Error('fail'));
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(/could not load report data/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no transactions for selected month', async () => {
+    getMonthlyReport.mockResolvedValue([]);
+    getBudgets.mockResolvedValue([]);
+    // Pass transactions from a different month so selected (current) month is empty
+    const oldTxn = makeTransaction({ date: '2020-01-15' });
+    renderComponent([oldTxn]);
+    await waitFor(() => {
+      expect(screen.getByText(/no transactions for/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders summary cards when transactions exist', async () => {
+    const currentMonth = dayjs().format('YYYY-MM');
+    getMonthlyReport.mockResolvedValue([
+      { month: currentMonth, income: 10000, expenses: 5000, net: 5000, transactionCount: 3 },
+    ]);
+    getBudgets.mockResolvedValue([]);
+    const txns = [
+      makeTransaction({ _id: '1', amount: 3000, type: 'expense', category: 'Food' }),
+      makeTransaction({ _id: '2', amount: 2000, type: 'expense', category: 'Transport' }),
+      makeTransaction({ _id: '3', amount: 10000, type: 'income' }),
+    ];
+    renderComponent(txns);
+    await waitFor(() => {
+      expect(screen.getByText('Income')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Expenses')).toBeInTheDocument();
+    expect(screen.getByText('Net Savings')).toBeInTheDocument();
+  });
+
+  it('renders pie chart when category data exists', async () => {
+    getMonthlyReport.mockResolvedValue([]);
+    getBudgets.mockResolvedValue([]);
+    const txns = [
+      makeTransaction({ _id: '1', amount: 3000, type: 'expense', category: 'Food' }),
+      makeTransaction({ _id: '2', amount: 2000, type: 'expense', category: 'Transport' }),
+    ];
+    renderComponent(txns);
+    await waitFor(() => {
+      expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Category Breakdown')).toBeInTheDocument();
+  });
+
+  it('renders budget vs actual section when budgets exist', async () => {
+    getMonthlyReport.mockResolvedValue([]);
+    getBudgets.mockResolvedValue([{ category: 'Food', limit: 5000 }]);
+    const txns = [makeTransaction({ _id: '1', amount: 3000, type: 'expense', category: 'Food' })];
+    renderComponent(txns);
+    await waitFor(() => {
+      expect(screen.getByText('Budget vs Actual')).toBeInTheDocument();
+    });
+  });
+
+  it('shows download PDF button', async () => {
+    getMonthlyReport.mockResolvedValue([]);
+    getBudgets.mockResolvedValue([]);
+    const txns = [makeTransaction()];
+    renderComponent(txns);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /download pdf/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows month selector dropdown', async () => {
+    getMonthlyReport.mockResolvedValue([]);
+    getBudgets.mockResolvedValue([]);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Month')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -35,6 +35,7 @@ import { useItemPresets } from '../../hooks/useItemPresets';
 import { ITEM_PRESETS } from '../expenses/ItemPicker';
 import { useThemePreference } from '../../ThemeContext';
 import { ThemePreference } from '../../theme';
+import { useTags } from '../../hooks/useTags';
 
 interface Props {
   currency: string;
@@ -91,11 +92,15 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const { enabledCurrencies, toggleCurrency, isEnabled } = useCurrencyPreferences();
   const { budgets, setBudget } = useBudgets();
   const { presets, setPreset, deletePreset } = useItemPresets();
+  const { tags, renameTag, recolorTag, removeTag } = useTags();
   const [drafts, setDrafts] = useState<Record<string, string>>(() =>
     Object.fromEntries(BUDGET_CATEGORIES.map((c) => [c, budgets[c] ? String(budgets[c]) : '']))
   );
   const [editingItem, setEditingItem] = useState<string | null>(null);
   const [itemDraft, setItemDraft] = useState('');
+  const [editingTag, setEditingTag] = useState<string | null>(null);
+  const [tagNameDraft, setTagNameDraft] = useState('');
+  const [tagDeleteConfirm, setTagDeleteConfirm] = useState<string | null>(null);
   const [signOutConfirm, setSignOutConfirm] = useState(false);
 
   const handleBudgetBlur = (category: string) => {
@@ -115,6 +120,20 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
       setEditingItem(null);
     }
   };
+
+  const startEditTag = (id: string, currentName: string) => {
+    setEditingTag(id);
+    setTagNameDraft(currentName);
+  };
+
+  const saveTagName = async () => {
+    if (editingTag && tagNameDraft.trim()) {
+      await renameTag(editingTag, tagNameDraft.trim());
+    }
+    setEditingTag(null);
+  };
+
+  const TAG_COLORS = ['#818cf8', '#f472b6', '#34d399', '#fb923c', '#60a5fa', '#a78bfa', '#f87171', '#facc15'];
 
   const handleLogout = () => {
     clearToken();
@@ -336,6 +355,98 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
       <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>
         <Box sx={{ px: 2, py: 1.5 }}>
           <FriendsSection />
+        </Box>
+      </Box>
+
+      {/* Tags */}
+      <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>
+        <Box sx={{ px: 2, py: 1.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', mb: 0.5 }}>
+            Tags
+          </Typography>
+          <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', mb: 1.5 }}>
+            Rename or delete tags. Create tags directly in the transaction form.
+          </Typography>
+          {tags.length === 0 && (
+            <Typography sx={{ fontSize: '0.8rem', color: 'text.disabled', fontStyle: 'italic' }}>No tags yet</Typography>
+          )}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            {tags.map((tag) => (
+              <Box key={tag._id} sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
+                {editingTag === tag._id ? (
+                  <>
+                    <TextField
+                      size="small"
+                      autoFocus
+                      value={tagNameDraft}
+                      onChange={(e) => setTagNameDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') saveTagName();
+                        if (e.key === 'Escape') setEditingTag(null);
+                      }}
+                      sx={{ flex: 1, '& .MuiInputBase-input': { fontSize: '0.82rem', py: 0.75 } }}
+                    />
+                    <Box sx={{ display: 'flex', gap: 0.375, flexWrap: 'wrap', maxWidth: 160 }}>
+                      {TAG_COLORS.map((c) => (
+                        <Box
+                          key={c}
+                          onClick={() => recolorTag(tag._id, c)}
+                          sx={{
+                            width: 16, height: 16, borderRadius: '50%', bgcolor: c, cursor: 'pointer', flexShrink: 0,
+                            border: tag.color === c ? '2px solid white' : '2px solid transparent',
+                            boxShadow: tag.color === c ? `0 0 0 1px ${c}` : 'none',
+                          }}
+                        />
+                      ))}
+                    </Box>
+                    <IconButton size="small" onClick={saveTagName} sx={{ color: theme.palette.success.light }}>
+                      <CheckIcon sx={{ fontSize: 16 }} />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => setEditingTag(null)} sx={{ color: 'text.disabled' }}>
+                      <CloseIcon sx={{ fontSize: 16 }} />
+                    </IconButton>
+                  </>
+                ) : (
+                  <>
+                    <Box
+                      sx={{
+                        width: 10, height: 10, borderRadius: '50%', flexShrink: 0,
+                        bgcolor: tag.color ?? 'rgba(148,163,184,0.4)',
+                        border: '1px solid rgba(148,163,184,0.2)',
+                      }}
+                    />
+                    <Typography sx={{ fontSize: '0.85rem', flex: 1 }}>{tag.name}</Typography>
+                    <IconButton
+                      size="small"
+                      onClick={() => startEditTag(tag._id, tag.name)}
+                      sx={{ color: 'text.disabled', '&:hover': { color: theme.palette.primary.main } }}
+                    >
+                      <EditIcon sx={{ fontSize: 15 }} />
+                    </IconButton>
+                    {tagDeleteConfirm === tag._id ? (
+                      <>
+                        <Typography variant="caption" color="error" sx={{ fontSize: '0.7rem' }}>Delete?</Typography>
+                        <IconButton size="small" onClick={() => { removeTag(tag._id); setTagDeleteConfirm(null); }} sx={{ color: theme.palette.error.light }}>
+                          <CheckIcon sx={{ fontSize: 15 }} />
+                        </IconButton>
+                        <IconButton size="small" onClick={() => setTagDeleteConfirm(null)} sx={{ color: 'text.disabled' }}>
+                          <CloseIcon sx={{ fontSize: 15 }} />
+                        </IconButton>
+                      </>
+                    ) : (
+                      <IconButton
+                        size="small"
+                        onClick={() => setTagDeleteConfirm(tag._id)}
+                        sx={{ color: theme.palette.mode === 'dark' ? 'rgba(251,113,133,0.4)' : 'rgba(244,63,94,0.5)', '&:hover': { color: theme.palette.error.light } }}
+                      >
+                        <DeleteIcon sx={{ fontSize: 15 }} />
+                      </IconButton>
+                    )}
+                  </>
+                )}
+              </Box>
+            ))}
+          </Box>
         </Box>
       </Box>
 

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Tag } from '../types';
+import { getTags, createTag, updateTag, deleteTag } from '../services/api';
+
+export function useTags() {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchTags = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getTags();
+      setTags(data);
+    } catch {
+      setError('Failed to load tags');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTags();
+  }, [fetchTags]);
+
+  const addTag = useCallback(async (name: string, color?: string): Promise<Tag> => {
+    const tag = await createTag({ name, color });
+    setTags((prev) => [...prev, tag]);
+    return tag;
+  }, []);
+
+  const renameTag = useCallback(async (id: string, name: string): Promise<void> => {
+    const updated = await updateTag(id, { name });
+    setTags((prev) => prev.map((t) => (t._id === id ? updated : t)));
+  }, []);
+
+  const recolorTag = useCallback(async (id: string, color: string): Promise<void> => {
+    const updated = await updateTag(id, { color });
+    setTags((prev) => prev.map((t) => (t._id === id ? updated : t)));
+  }, []);
+
+  const removeTag = useCallback(async (id: string): Promise<void> => {
+    await deleteTag(id);
+    setTags((prev) => prev.filter((t) => t._id !== id));
+  }, []);
+
+  return { tags, loading, error, fetchTags, addTag, renameTag, recolorTag, removeTag };
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '../axiosInstance';
-import { Transaction, TransactionRequest } from '../types';
+import { Transaction, TransactionRequest, Tag } from '../types';
 import { setToken } from './auth';
 import { ThemePreference } from '../theme';
 
@@ -425,4 +425,24 @@ export const scanStatement = async (file: File): Promise<StatementScanResult> =>
 export const applyStatementImport = async (transactions: StatementTxn[]): Promise<{ imported: number }> => {
   const res = await axiosInstance.post('/api/import/statement/apply', { transactions });
   return res.data;
+};
+
+// Tags
+export const getTags = async (): Promise<Tag[]> => {
+  const res = await axiosInstance.get('/api/tags');
+  return res.data.tags;
+};
+
+export const createTag = async (data: { name: string; color?: string }): Promise<Tag> => {
+  const res = await axiosInstance.post('/api/tags', data);
+  return res.data;
+};
+
+export const updateTag = async (id: string, data: { name?: string; color?: string }): Promise<Tag> => {
+  const res = await axiosInstance.put(`/api/tags/${id}`, data);
+  return res.data;
+};
+
+export const deleteTag = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/tags/${id}`);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,15 @@ export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
   other: 'Other',
 };
 
+export interface Tag {
+  _id: string;
+  owner: string;
+  name: string;
+  color?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Transaction {
   _id: string;
   owner: string;
@@ -45,6 +54,7 @@ export interface Transaction {
   originalAmount?: number;
   exchangeRate?: number;
   notes?: string;
+  tags?: Tag[];
   date: string;
   createdAt: string;
   updatedAt: string;
@@ -64,6 +74,7 @@ export interface TransactionRequest {
   originalAmount?: number;
   exchangeRate?: number;
   notes?: string;
+  tags?: string[];
   date?: string;
 }
 


### PR DESCRIPTION
## Summary
- Tag autocomplete input on Add/Edit Transaction form — fetches `GET /api/tags`, inline creation by typing + Enter
- Tags displayed as small colored chips on transaction cards (mobile) and description column (desktop)
- Filter transactions by tag in FilterBar — collapsible tag chip row with toggle button
- Tags included in main search bar (matches tag names)
- Tag management in Settings: rename, delete, set color from 8-color palette
- `useTags` hook wrapping all tag API calls
- Backend API live at `/api/tags` (BE #162, merged)

## Test plan
- [ ] Add Transaction → Tags field visible → type name → Enter creates new tag → chip appears
- [ ] Edit Transaction → existing tags pre-filled → can add/remove tags
- [ ] Transaction list → tags show as colored chips below description
- [ ] Transactions tab → tag icon in filter bar → click → filter by tag → transactions filtered
- [ ] Search bar → type a tag name → matching transactions appear
- [ ] Settings → Tags section → rename tag → delete with confirm → color swatch picker

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)