### PR TITLE
feat: UI component library (Button/Input/Card/Chip/EmptyState) (#291)

### DIFF
--- a/e2e/components-axe.spec.ts
+++ b/e2e/components-axe.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * UI component library accessibility check.
+ *
+ * Visits the public `/dev/components` showcase route and runs axe-core in
+ * both light and dark color schemes. The test fails on any wcag2a, wcag2aa
+ * or wcag21aa violation — these are the required accessibility levels per
+ * the design-system spec.
+ */
+test.describe('UI component library', () => {
+  for (const scheme of ['light', 'dark'] as const) {
+    test(`showcase page has zero axe-core violations (${scheme})`, async ({ page }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      await page.goto('/dev/components');
+      await page.waitForLoadState('networkidle');
+
+      // Sanity check: the showcase actually rendered.
+      await expect(
+        page.getByRole('heading', { level: 1, name: /UI primitives/i }),
+      ).toBeVisible();
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+        .analyze();
+
+      expect(results.violations).toEqual([]);
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     ]
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.28.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const LoginPage = lazy(() => import('./components/auth/LoginPage'));
 const RegisterPage = lazy(() => import('./components/auth/RegisterPage'));
 const PrivacyPolicy = lazy(() => import('./components/PrivacyPolicy'));
 const MainLayout = lazy(() => import('./components/MainLayout'));
+const ComponentsPage = lazy(() => import('./pages/dev/ComponentsPage'));
 
 const GOOGLE_CLIENT_ID = process.env.VITE_GOOGLE_CLIENT_ID ?? '';
 
@@ -28,6 +29,7 @@ const App: React.FC = () => {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/privacy" element={<PrivacyPolicy />} />
+          <Route path="/dev/components" element={<ComponentsPage />} />
           <Route
             path="/"
             element={

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,105 @@
+import React, { forwardRef, memo } from 'react';
+import MuiButton, { ButtonProps as MuiButtonProps } from '@mui/material/Button';
+import { alpha, useTheme } from '@mui/material/styles';
+import { buttonSize, motion, radius, ButtonSizeToken } from './tokens';
+
+export type UIButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
+export type UIButtonSize = ButtonSizeToken;
+
+export interface ButtonProps
+  extends Omit<MuiButtonProps, 'variant' | 'size' | 'color'> {
+  /** Visual variant. Default: `primary`. */
+  variant?: UIButtonVariant;
+  /** Size token. Default: `md` (40h, ≥44px touch target on mobile). */
+  size?: UIButtonSize;
+}
+
+/**
+ * Button — UI primitive matching the design-system spec.
+ *
+ * Wraps MUI Button with variant/size tokens. Use `primary` for the main CTA,
+ * `secondary` for alternate actions, `ghost` for tertiary/nav, and
+ * `destructive` for delete operations.
+ *
+ * Sizes: `sm` (32h) / `md` (40h) / `lg` (48h). Always use `md` or larger on
+ * mobile touch targets.
+ */
+const ButtonImpl = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', size = 'md', sx, children, ...rest },
+  ref,
+) {
+  const theme = useTheme();
+  const sizeToken = buttonSize[size];
+
+  const variantSx = (() => {
+    switch (variant) {
+      case 'primary':
+        return {
+          backgroundColor: theme.palette.primary.main,
+          color: theme.palette.primary.contrastText,
+          '&:hover': { backgroundColor: theme.palette.primary.dark },
+          '&:disabled': {
+            backgroundColor: alpha(theme.palette.primary.main, 0.4),
+            color: theme.palette.primary.contrastText,
+          },
+        };
+      case 'secondary':
+        return {
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
+          border: `1px solid ${theme.palette.divider}`,
+          '&:hover': {
+            backgroundColor: alpha(theme.palette.text.primary, 0.04),
+            borderColor: theme.palette.text.secondary,
+          },
+        };
+      case 'ghost':
+        return {
+          backgroundColor: 'transparent',
+          color: theme.palette.text.primary,
+          '&:hover': { backgroundColor: alpha(theme.palette.text.primary, 0.06) },
+        };
+      case 'destructive':
+        return {
+          backgroundColor: theme.palette.error.main,
+          color: theme.palette.error.contrastText ?? '#ffffff',
+          '&:hover': {
+            backgroundColor: theme.palette.error.dark ?? theme.palette.error.main,
+          },
+        };
+      default:
+        return {};
+    }
+  })();
+
+  return (
+    <MuiButton
+      ref={ref}
+      disableElevation
+      variant="contained"
+      sx={{
+        minHeight: sizeToken.height,
+        height: sizeToken.height,
+        fontSize: sizeToken.fontSize,
+        paddingInline: `${sizeToken.paddingX}px`,
+        borderRadius: `${radius.md}px`,
+        textTransform: 'none',
+        fontWeight: 600,
+        boxShadow: 'none',
+        transition: `background-color ${motion.base} ${motion.easeStandard}, border-color ${motion.base} ${motion.easeStandard}`,
+        '&:focus-visible': {
+          outline: `2px solid ${theme.palette.primary.main}`,
+          outlineOffset: '2px',
+        },
+        ...variantSx,
+        ...sx,
+      }}
+      {...rest}
+    >
+      {children}
+    </MuiButton>
+  );
+});
+
+export const Button = memo(ButtonImpl);
+export default Button;

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,69 @@
+import React, { forwardRef, memo } from 'react';
+import Box, { BoxProps } from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import { motion, radius, spacing } from './tokens';
+
+export interface CardProps extends BoxProps {
+  /** When true, the card responds to hover with a stronger shadow. */
+  interactive?: boolean;
+  /** Render as a `button` semantically. Sets role + interactive shadow. */
+  asButton?: boolean;
+}
+
+/**
+ * Card — surface container matching the design-system spec.
+ *
+ * bg.surface, radius `lg`, padding `lg`, shadow `sm`. Hover (clickable):
+ * shadow `md`. Use `interactive` or `asButton` for clickable cards.
+ */
+const CardImpl = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { interactive = false, asButton = false, sx, children, ...rest },
+  ref,
+) {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+  const shadowSm = isDark
+    ? '0 1px 2px rgba(0, 0, 0, 0.4)'
+    : '0 1px 2px rgba(15, 23, 42, 0.06)';
+  const shadowMd = isDark
+    ? '0 4px 12px rgba(0, 0, 0, 0.5)'
+    : '0 4px 12px rgba(15, 23, 42, 0.08)';
+  const hoverable = interactive || asButton;
+
+  return (
+    <Box
+      ref={ref}
+      component={asButton ? 'button' : 'div'}
+      {...(asButton ? { type: 'button' } : {})}
+      sx={{
+        backgroundColor: theme.palette.background.paper,
+        borderRadius: `${radius.lg}px`,
+        padding: `${spacing.lg}px`,
+        border: `1px solid ${theme.palette.divider}`,
+        boxShadow: shadowSm,
+        transition: `box-shadow ${motion.base} ${motion.easeStandard}, transform ${motion.fast} ${motion.easeStandard}`,
+        textAlign: 'left',
+        ...(asButton && {
+          font: 'inherit',
+          color: 'inherit',
+          cursor: 'pointer',
+          width: '100%',
+        }),
+        ...(hoverable && {
+          '&:hover': { boxShadow: shadowMd },
+          '&:focus-visible': {
+            outline: `2px solid ${theme.palette.primary.main}`,
+            outlineOffset: '2px',
+          },
+        }),
+        ...sx,
+      }}
+      {...rest}
+    >
+      {children}
+    </Box>
+  );
+});
+
+export const Card = memo(CardImpl);
+export default Card;

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,0 +1,107 @@
+import React, { forwardRef, memo } from 'react';
+import Box from '@mui/material/Box';
+import { alpha, useTheme } from '@mui/material/styles';
+import { motion, radius } from './tokens';
+
+export interface ChipProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'> {
+  /** Visible label. */
+  label: string;
+  /** Whether the chip is currently selected. */
+  selected?: boolean;
+  /** Click handler. When provided the chip is rendered as a button. */
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Disable interaction. */
+  disabled?: boolean;
+}
+
+/**
+ * Chip — tag / category indicator matching the design-system spec.
+ *
+ * 24h, padding 4/10, radius `pill`, body-sm. Unselected: bg.subtle / fg.secondary.
+ * Selected: primary-100 / primary-600. Renders as a button when `onClick` is
+ * provided (toggle/filter chips), otherwise a static `span`.
+ */
+const ChipImpl = forwardRef<HTMLElement, ChipProps>(function Chip(
+  { label, selected = false, onClick, disabled = false, ...rest },
+  ref,
+) {
+  const theme = useTheme();
+  const isInteractive = typeof onClick === 'function';
+
+  const isDark = theme.palette.mode === 'dark';
+  // Use the darker primary shade for selected fg on light bg, and the lighter
+  // shade on dark bg, so the chip clears WCAG AA contrast against its tinted
+  // background.
+  const selectedBg = alpha(theme.palette.primary.main, isDark ? 0.22 : 0.18);
+  const selectedFg = isDark
+    ? theme.palette.primary.light ?? theme.palette.primary.main
+    : theme.palette.primary.dark ?? theme.palette.primary.main;
+  // Base chip uses a stronger surface and the primary text color so the
+  // foreground clears WCAG AA contrast.
+  const baseBg = isDark
+    ? alpha(theme.palette.common.white, 0.12)
+    : alpha(theme.palette.text.primary, 0.12);
+  const baseFg = theme.palette.text.primary;
+
+  const sharedSx = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 24,
+    paddingInline: '10px',
+    paddingBlock: '4px',
+    borderRadius: `${radius.pill}px`,
+    fontSize: 14,
+    lineHeight: '20px',
+    fontWeight: 500,
+    backgroundColor: selected ? selectedBg : baseBg,
+    color: selected ? selectedFg : baseFg,
+    border: 'none',
+    transition: `background-color ${motion.fast} ${motion.easeStandard}, color ${motion.fast} ${motion.easeStandard}`,
+    cursor: isInteractive ? 'pointer' : 'default',
+    opacity: disabled ? 0.5 : 1,
+    pointerEvents: disabled ? ('none' as const) : ('auto' as const),
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: '2px',
+    },
+    ...(isInteractive && {
+      '&:hover': {
+        backgroundColor: selected
+          ? alpha(theme.palette.primary.main, isDark ? 0.32 : 0.26)
+          : alpha(theme.palette.text.primary, isDark ? 0.18 : 0.18),
+      },
+    }),
+  };
+
+  if (isInteractive) {
+    return (
+      <Box
+        ref={ref as React.Ref<HTMLButtonElement>}
+        component="button"
+        type="button"
+        aria-pressed={selected}
+        onClick={onClick}
+        disabled={disabled}
+        sx={sharedSx}
+        {...rest}
+      >
+        {label}
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      ref={ref as React.Ref<HTMLSpanElement>}
+      component="span"
+      sx={sharedSx}
+    >
+      {label}
+    </Box>
+  );
+});
+
+export const Chip = memo(ChipImpl);
+export default Chip;

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,121 @@
+import React, { memo } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { spacing } from './tokens';
+import Button from './Button';
+
+export interface EmptyStateAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface EmptyStateProps {
+  /** Custom icon node. Rendered at 48px, color `fg.muted`. */
+  icon?: React.ReactNode;
+  /** Headline — `h2`, max-width 280. */
+  title: string;
+  /** Supporting copy — `body`, max-width 320, centered. */
+  body?: string;
+  /** Primary CTA (single action). */
+  cta?: EmptyStateAction;
+  /** Optional ghost-style secondary CTA. */
+  secondaryCta?: EmptyStateAction;
+  /** Override container test id (useful for showcase). */
+  'data-testid'?: string;
+}
+
+/**
+ * EmptyState — pattern matching patterns.md spec.
+ *
+ * Centered: 48px icon (fg.muted) → h2 headline → body fg.secondary → primary CTA.
+ * Min vertical padding `3xl`. Use for: dashboard empty, transactions list,
+ * reports no-data, tags empty.
+ */
+const EmptyStateImpl: React.FC<EmptyStateProps> = ({
+  icon,
+  title,
+  body,
+  cta,
+  secondaryCta,
+  'data-testid': dataTestId,
+}) => {
+  const theme = useTheme();
+  return (
+    <Box
+      data-testid={dataTestId}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        paddingBlock: `${spacing['3xl']}px`,
+        paddingInline: `${spacing.lg}px`,
+        gap: `${spacing.md}px`,
+      }}
+    >
+      {icon ? (
+        <Box
+          aria-hidden="true"
+          sx={{
+            color: theme.palette.text.disabled,
+            display: 'inline-flex',
+            fontSize: 48,
+            '& > svg': { fontSize: 48 },
+          }}
+        >
+          {icon}
+        </Box>
+      ) : null}
+      <Typography
+        component="h2"
+        sx={{
+          fontSize: 20,
+          fontWeight: 600,
+          lineHeight: '28px',
+          color: theme.palette.text.primary,
+          maxWidth: 280,
+        }}
+      >
+        {title}
+      </Typography>
+      {body ? (
+        <Typography
+          sx={{
+            fontSize: 16,
+            lineHeight: '24px',
+            color: theme.palette.text.secondary,
+            maxWidth: 320,
+          }}
+        >
+          {body}
+        </Typography>
+      ) : null}
+      {(cta || secondaryCta) && (
+        <Box
+          sx={{
+            display: 'flex',
+            gap: `${spacing.sm}px`,
+            marginTop: `${spacing.sm}px`,
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+          }}
+        >
+          {cta ? (
+            <Button variant="primary" size="md" onClick={cta.onClick}>
+              {cta.label}
+            </Button>
+          ) : null}
+          {secondaryCta ? (
+            <Button variant="ghost" size="md" onClick={secondaryCta.onClick}>
+              {secondaryCta.label}
+            </Button>
+          ) : null}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export const EmptyState = memo(EmptyStateImpl);
+export default EmptyState;

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,83 @@
+import React, { forwardRef, memo } from 'react';
+import MuiTextField, { TextFieldProps } from '@mui/material/TextField';
+import { useTheme } from '@mui/material/styles';
+import { radius } from './tokens';
+
+export interface InputProps
+  extends Omit<TextFieldProps, 'variant' | 'size'> {
+  /** Always render label above the field — placeholder-only is forbidden. */
+  label: string;
+  /** Helper text rendered below the field. Replaced by `error` when set. */
+  helperText?: React.ReactNode;
+  /** Error message. When provided, switches the field to error state. */
+  error?: boolean;
+  errorText?: string;
+}
+
+/**
+ * Input — UI primitive matching the design-system spec.
+ *
+ * Wraps MUI TextField with the canonical 40h size, md radius, and a strict
+ * label-above contract. Errors are shown as caption text below the field.
+ */
+const InputImpl = forwardRef<HTMLDivElement, InputProps>(function Input(
+  { label, helperText, error, errorText, sx, InputLabelProps, ...rest },
+  ref,
+) {
+  const theme = useTheme();
+  const showError = Boolean(error);
+  const helper = showError && errorText ? errorText : helperText;
+  // The theme's error.dark (#e11d48) sits just below WCAG AA on the
+  // bg.app surface. Apply a darker rose for caption text to clear 4.5:1.
+  const errorTextColor =
+    theme.palette.mode === 'dark' ? '#fda4af' : '#be123c';
+
+  return (
+    <MuiTextField
+      ref={ref}
+      label={label}
+      variant="outlined"
+      size="small"
+      fullWidth
+      error={showError}
+      helperText={helper}
+      InputLabelProps={{ shrink: true, ...InputLabelProps }}
+      sx={{
+        '& .MuiOutlinedInput-root': {
+          minHeight: 40,
+          borderRadius: `${radius.md}px`,
+          '& fieldset': {
+            borderColor: theme.palette.divider,
+            transition: 'border-color 200ms cubic-bezier(.2,.8,.2,1)',
+          },
+          '&:hover fieldset': {
+            borderColor: theme.palette.text.secondary,
+          },
+          '&.Mui-focused fieldset': {
+            borderWidth: 2,
+            borderColor: theme.palette.primary.main,
+          },
+          '&.Mui-error fieldset': {
+            borderColor: theme.palette.error.main,
+          },
+        },
+        '& .MuiFormHelperText-root': {
+          fontSize: 12,
+          marginLeft: 0,
+          '&.Mui-error': {
+            // Use a darker rose for caption text to clear WCAG AA contrast.
+            color: errorTextColor,
+          },
+        },
+        '& .MuiInputLabel-root.Mui-error': {
+          color: errorTextColor,
+        },
+        ...sx,
+      }}
+      {...rest}
+    />
+  );
+});
+
+export const Input = memo(InputImpl);
+export default Input;

--- a/src/components/ui/__tests__/ui.test.tsx
+++ b/src/components/ui/__tests__/ui.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { lightTheme } from '../../../theme';
+import { Button, Card, Chip, EmptyState, Input } from '../index';
+
+const wrap = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={lightTheme}>{ui}</ThemeProvider>);
+
+describe('UI primitives', () => {
+  describe('Button', () => {
+    it('renders all variants', () => {
+      wrap(
+        <>
+          <Button variant="primary">Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="destructive">Destructive</Button>
+        </>,
+      );
+      expect(screen.getByRole('button', { name: 'Primary' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Secondary' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Ghost' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Destructive' })).toBeInTheDocument();
+    });
+
+    it('fires onClick when not disabled', () => {
+      const onClick = jest.fn();
+      wrap(<Button onClick={onClick}>Click</Button>);
+      fireEvent.click(screen.getByRole('button', { name: 'Click' }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire onClick when disabled', () => {
+      const onClick = jest.fn();
+      wrap(
+        <Button onClick={onClick} disabled>
+          Click
+        </Button>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Click' }));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Input', () => {
+    it('renders the label and helper text', () => {
+      wrap(<Input label="Email" helperText="We'll never share" onChange={() => undefined} />);
+      expect(screen.getByLabelText('Email')).toBeInTheDocument();
+      expect(screen.getByText("We'll never share")).toBeInTheDocument();
+    });
+
+    it('shows error text in place of helper text when error is true', () => {
+      wrap(
+        <Input
+          label="Email"
+          helperText="hint"
+          error
+          errorText="Required"
+          onChange={() => undefined}
+        />,
+      );
+      expect(screen.getByText('Required')).toBeInTheDocument();
+      expect(screen.queryByText('hint')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Card', () => {
+    it('renders children', () => {
+      wrap(<Card>card body</Card>);
+      expect(screen.getByText('card body')).toBeInTheDocument();
+    });
+
+    it('renders as a button when asButton', () => {
+      const onClick = jest.fn();
+      wrap(
+        <Card asButton onClick={onClick}>
+          Tap me
+        </Card>,
+      );
+      const btn = screen.getByRole('button', { name: 'Tap me' });
+      fireEvent.click(btn);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Chip', () => {
+    it('renders as a static span by default', () => {
+      wrap(<Chip label="Static" />);
+      expect(screen.getByText('Static')).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('renders as a toggle button when onClick is provided', () => {
+      const onClick = jest.fn();
+      wrap(<Chip label="Food" selected onClick={onClick} />);
+      const btn = screen.getByRole('button', { name: 'Food' });
+      expect(btn).toHaveAttribute('aria-pressed', 'true');
+      fireEvent.click(btn);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('EmptyState', () => {
+    it('renders title, body and CTA', () => {
+      const cta = jest.fn();
+      wrap(
+        <EmptyState
+          title="Nothing here"
+          body="Start by adding one."
+          cta={{ label: 'Add', onClick: cta }}
+        />,
+      );
+      expect(screen.getByRole('heading', { name: 'Nothing here' })).toBeInTheDocument();
+      expect(screen.getByText('Start by adding one.')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(cta).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders without a CTA', () => {
+      wrap(<EmptyState title="Empty" />);
+      expect(screen.getByRole('heading', { name: 'Empty' })).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,11 @@
+export { Button } from './Button';
+export type { ButtonProps, UIButtonVariant, UIButtonSize } from './Button';
+export { Input } from './Input';
+export type { InputProps } from './Input';
+export { Card } from './Card';
+export type { CardProps } from './Card';
+export { Chip } from './Chip';
+export type { ChipProps } from './Chip';
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps, EmptyStateAction } from './EmptyState';
+export * from './tokens';

--- a/src/components/ui/tokens.ts
+++ b/src/components/ui/tokens.ts
@@ -1,0 +1,49 @@
+/**
+ * Design tokens for Money Flow UI primitives.
+ *
+ * Spec source: /tmp/mf-design-redesign/design-system.md
+ *
+ * These tokens are the canonical reference for the UI library. They mirror the
+ * semantic tokens documented in the design system and are consumed by the
+ * Button/Input/Card/Chip/EmptyState components below.
+ *
+ * When `src/theme.ts` is updated (issue #279) to expose these as theme tokens,
+ * components should switch to `theme.palette.*` / `theme.spacing(...)` and this
+ * file becomes redundant. Until then, components use these constants so the
+ * library is decoupled from the current ad-hoc theme.
+ */
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  '2xl': 32,
+  '3xl': 48,
+  '4xl': 64,
+} as const;
+
+export const radius = {
+  sm: 6,
+  md: 10,
+  lg: 14,
+  xl: 20,
+  pill: 9999,
+} as const;
+
+export const motion = {
+  fast: '120ms',
+  base: '200ms',
+  slow: '320ms',
+  easeStandard: 'cubic-bezier(.2,.8,.2,1)',
+  easeInOut: 'cubic-bezier(.4,0,.6,1)',
+} as const;
+
+export const buttonSize = {
+  sm: { height: 32, fontSize: 12, paddingX: 12 },
+  md: { height: 40, fontSize: 14, paddingX: 16 },
+  lg: { height: 48, fontSize: 16, paddingX: 20 },
+} as const;
+
+export type ButtonSizeToken = keyof typeof buttonSize;

--- a/src/pages/dev/ComponentsPage.tsx
+++ b/src/pages/dev/ComponentsPage.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import { Button, Card, Chip, EmptyState, Input } from 'src/components/ui';
+
+const Section: React.FC<{ id: string; title: string; children: React.ReactNode }> = ({
+  id,
+  title,
+  children,
+}) => (
+  <Box component="section" aria-labelledby={`${id}-heading`} sx={{ mb: 6 }}>
+    <Typography
+      id={`${id}-heading`}
+      component="h2"
+      sx={{ fontSize: 20, fontWeight: 600, mb: 2 }}
+    >
+      {title}
+    </Typography>
+    {children}
+  </Box>
+);
+
+const ComponentsPage: React.FC = () => {
+  const [inputValue, setInputValue] = useState('');
+  const [errorValue, setErrorValue] = useState('not-an-email');
+  const [selectedChips, setSelectedChips] = useState<Set<string>>(new Set(['Food']));
+
+  const toggleChip = (label: string) => {
+    setSelectedChips((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
+  };
+
+  return (
+    <Box
+      component="main"
+      sx={{
+        maxWidth: 960,
+        marginInline: 'auto',
+        paddingBlock: 6,
+        paddingInline: 3,
+      }}
+    >
+      <Box component="header" sx={{ mb: 5 }}>
+        <Typography component="h1" sx={{ fontSize: 32, fontWeight: 700, mb: 1 }}>
+          Money Flow — UI primitives
+        </Typography>
+        <Typography sx={{ fontSize: 16, color: 'text.secondary' }}>
+          Showcase of Button, Input, Card, Chip and EmptyState matching the design-system spec.
+        </Typography>
+      </Box>
+
+      <Section id="button" title="Button">
+        <Stack spacing={2}>
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            <Button variant="primary">Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="destructive">Destructive</Button>
+          </Stack>
+          <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+            <Button variant="primary" size="sm">Small</Button>
+            <Button variant="primary" size="md">Medium</Button>
+            <Button variant="primary" size="lg">Large</Button>
+          </Stack>
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            <Button variant="primary" disabled>Disabled primary</Button>
+            <Button variant="secondary" disabled>Disabled secondary</Button>
+            <Button variant="destructive" disabled>Disabled destructive</Button>
+          </Stack>
+        </Stack>
+      </Section>
+
+      <Section id="input" title="Input">
+        <Stack spacing={3} sx={{ maxWidth: 420 }}>
+          <Input
+            label="Email"
+            placeholder="you@example.com"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            helperText="We'll never share this."
+          />
+          <Input
+            label="Password"
+            type="password"
+            value=""
+            onChange={() => undefined}
+          />
+          <Input
+            label="Invalid email"
+            value={errorValue}
+            onChange={(e) => setErrorValue(e.target.value)}
+            error
+            errorText="Enter a valid email address."
+          />
+          <Input label="Disabled" value="read only" disabled onChange={() => undefined} />
+        </Stack>
+      </Section>
+
+      <Section id="card" title="Card">
+        <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+          <Card sx={{ minWidth: 240 }}>
+            <Typography sx={{ fontSize: 14, color: 'text.secondary', mb: 1 }}>
+              This month
+            </Typography>
+            <Typography sx={{ fontSize: 24, fontWeight: 700 }}>$1,248.50</Typography>
+          </Card>
+          <Card interactive sx={{ minWidth: 240 }} tabIndex={0}>
+            <Typography sx={{ fontSize: 14, color: 'text.secondary', mb: 1 }}>
+              Interactive (hover/focus)
+            </Typography>
+            <Typography sx={{ fontSize: 24, fontWeight: 700 }}>$420.00</Typography>
+          </Card>
+          <Card asButton onClick={() => undefined} sx={{ minWidth: 240 }}>
+            <Typography sx={{ fontSize: 14, color: 'text.secondary', mb: 1 }}>
+              Clickable card
+            </Typography>
+            <Typography sx={{ fontSize: 24, fontWeight: 700 }}>View report</Typography>
+          </Card>
+        </Stack>
+      </Section>
+
+      <Section id="chip" title="Chip">
+        <Stack spacing={2}>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Chip label="Static" />
+            <Chip label="Selected static" selected />
+          </Stack>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            {['Food', 'Transport', 'Bills', 'Fun'].map((label) => (
+              <Chip
+                key={label}
+                label={label}
+                selected={selectedChips.has(label)}
+                onClick={() => toggleChip(label)}
+              />
+            ))}
+          </Stack>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Chip label="Disabled" disabled onClick={() => undefined} />
+            <Chip label="Disabled selected" disabled selected onClick={() => undefined} />
+          </Stack>
+        </Stack>
+      </Section>
+
+      <Section id="empty-state" title="EmptyState">
+        <Card>
+          <EmptyState
+            data-testid="empty-state-showcase"
+            icon={<ReceiptLongIcon />}
+            title="No transactions yet"
+            body="Track your first expense to see your spending here."
+            cta={{ label: 'Add transaction', onClick: () => undefined }}
+            secondaryCta={{ label: 'Import CSV', onClick: () => undefined }}
+          />
+        </Card>
+      </Section>
+    </Box>
+  );
+};
+
+export default ComponentsPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
+"@axe-core/playwright@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.11.3.tgz#cefcb8e25c90598b20c09745982ae9db0d483fff"
+  integrity sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==
+  dependencies:
+    axe-core "~4.11.4"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.22.13"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz"
@@ -2867,6 +2874,11 @@ axe-core@^4.6.2:
   version "4.8.2"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz"
   integrity sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==
+
+axe-core@~4.11.4:
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.4.tgz#5b535e381ff1e61ffdd615e5483d16186d3b46a5"
+  integrity sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==
 
 axios@^1.13.5:
   version "1.13.6"


### PR DESCRIPTION
## What
Adds a reusable UI primitive library matching the v1 design-system spec:

- **Button** — variants `primary` / `secondary` / `ghost` / `destructive` × sizes `sm` / `md` / `lg`. Forwards refs, memoized, focus-visible outline, ≥44px touch target on `md`+.
- **Input** — 40h MUI TextField wrapper with strict label-above contract, helper / error text, WCAG-AA error caption color.
- **Card** — bg.surface + radius `lg` + padding `lg` + shadow `sm`; `interactive` variant with shadow `md` hover; `asButton` renders a semantic `<button>`.
- **Chip** — 24h pill with selected / unselected variants; renders as a toggle button (`aria-pressed`) when `onClick` is provided, else a static `<span>`.
- **EmptyState** — 48px icon + h2 + body + primary CTA + optional ghost secondary CTA per `patterns.md`.

Design tokens (`spacing` / `radius` / `motion` / `buttonSize`) live in `src/components/ui/tokens.ts`, so the components are decoupled from the current ad-hoc theme until `src/theme.ts` is upgraded in #279.

## Why
Closes #291.

Existing app screens still use ad-hoc MUI components. This PR ships the library + showcase only; replacing call-sites is intentionally a separate sweep so the diff stays focused and reviewable.

## Acceptance Criteria
- [x] Showcase at `/dev/components` shows every variant + size + state
- [x] axe-core passes on the showcase (contrast, focus) — zero `wcag2aa` violations in **both** light and dark color schemes
- [ ] All app screens use the new components — deferred to a follow-up sweep (out of scope here per task brief)

## Test Plan
1. `npx tsc --noEmit` — zero errors in `src/components/ui/**` and `src/pages/dev/**`.
2. `npx jest src/components/ui` — 11 unit tests pass (variants render, callbacks fire, disabled state, error swap, asButton, chip toggle).
3. `VITE_API_URL=... yarn build` — builds successfully; `ComponentsPage` chunk emitted.
4. Local UAT:
   - `yarn preview --port 4173`
   - Visit `http://localhost:4173/dev/components` → see all components rendered.
   - `PLAYWRIGHT_BASE_URL=http://localhost:4173 npx playwright test e2e/components-axe.spec.ts` → 2 tests pass (light + dark axe).
5. Prod UAT (post-merge):
   - Visit `https://money-flow-frontend.vercel.app/dev/components`
   - Verify visual parity with the design-system spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)