### PR TITLE
feat: global toast system + Undo on delete (#289)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { GoogleOAuthProvider } from '@react-oauth/google';
 import { AppThemeProvider } from './ThemeContext';
 import ProtectedRoute from './components/common/ProtectedRoute';
 import { CircularProgress, Box } from '@mui/material';
+import ToastProvider from './components/Toast/ToastProvider';
 
 const LoginPage = lazy(() => import('./components/auth/LoginPage'));
 const RegisterPage = lazy(() => import('./components/auth/RegisterPage'));
@@ -23,33 +24,35 @@ const App: React.FC = () => {
   return (
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
     <AppThemeProvider>
-      <BrowserRouter>
-        <Suspense fallback={<PageLoader />}>
-          <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/register" element={<RegisterPage />} />
-          <Route path="/privacy" element={<PrivacyPolicy />} />
-          <Route path="/dev/components" element={<ComponentsPage />} />
-          <Route
-            path="/"
-            element={
-              <ProtectedRoute>
-                <MainLayout />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/reports"
-            element={
-              <ProtectedRoute>
-                <MainLayout initialTab={6} />
-              </ProtectedRoute>
-            }
-          />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </Suspense>
-      </BrowserRouter>
+      <ToastProvider>
+        <BrowserRouter>
+          <Suspense fallback={<PageLoader />}>
+            <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<RegisterPage />} />
+            <Route path="/privacy" element={<PrivacyPolicy />} />
+            <Route path="/dev/components" element={<ComponentsPage />} />
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
+                  <MainLayout />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/reports"
+              element={
+                <ProtectedRoute>
+                  <MainLayout initialTab={6} />
+                </ProtectedRoute>
+              }
+            />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </Suspense>
+        </BrowserRouter>
+      </ToastProvider>
     </AppThemeProvider>
     </GoogleOAuthProvider>
   );

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -6,9 +6,6 @@ import {
   Typography,
   Box,
   Container,
-  Snackbar,
-  SnackbarContent,
-  Alert,
   CircularProgress,
   Button,
   Fab,
@@ -27,6 +24,7 @@ import {
   Menu,
   MenuItem,
 } from '@mui/material';
+import useToast from '../hooks/useToast';
 import AddIcon from '@mui/icons-material/Add';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
@@ -133,12 +131,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
   const [addReceiptOpen, setAddReceiptOpen] = useState(false);
   const [quickExpenseOpen, setQuickExpenseOpen] = useState(false);
   const [editTransaction, setEditTransaction] = useState<Transaction | null>(null);
-  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
-    open: false,
-    message: '',
-    severity: 'success',
-  });
-  const [undoSnackbar, setUndoSnackbar] = useState(false);
+  const toast = useToast();
   const pendingDelete = useRef<Transaction | null>(null);
   const [scanLoading, setScanLoading] = useState(false);
   const [receiptPrefill, setReceiptPrefill] = useState<ReceiptPrefill | undefined>(undefined);
@@ -157,9 +150,13 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
     setAddOpen(true);
   }, []);
 
-  const showSnackbar = (message: string, severity: 'success' | 'error' = 'success') => {
-    setSnackbar({ open: true, message, severity });
-  };
+  const showSnackbar = useCallback(
+    (message: string, severity: 'success' | 'error' = 'success') => {
+      if (severity === 'error') toast.error(message);
+      else toast.success(message);
+    },
+    [toast]
+  );
 
   const fetchTransactions = async () => {
     try {
@@ -313,35 +310,51 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
     }
   };
 
-  const handleDelete = useCallback((id: string) => {
-    setTransactions((prev) => {
-      const t = prev.find((tx) => tx._id === id);
-      if (!t) return prev;
-      pendingDelete.current = t;
-      return prev.filter((tx) => tx._id !== id);
-    });
-    setUndoSnackbar(true);
-  }, []);
+  const commitDelete = useCallback(
+    async (t: Transaction) => {
+      try {
+        await deleteExpense(t._id);
+      } catch {
+        setTransactions((prev) => [t, ...prev]);
+        toast.error('Failed to delete transaction');
+      }
+    },
+    [toast]
+  );
 
-  const commitDelete = useCallback(async () => {
-    const t = pendingDelete.current;
-    if (!t) return;
-    pendingDelete.current = null;
-    try {
-      await deleteExpense(t._id);
-    } catch {
-      setTransactions((prev) => [t, ...prev]);
-      showSnackbar('Failed to delete transaction', 'error');
-    }
-  }, []);
-
-  const handleUndo = useCallback(() => {
-    const t = pendingDelete.current;
-    if (!t) return;
-    pendingDelete.current = null;
-    setTransactions((prev) => [t, ...prev].sort((a, b) => new Date(b.date || b.createdAt).getTime() - new Date(a.date || a.createdAt).getTime()));
-    setUndoSnackbar(false);
-  }, []);
+  const handleDelete = useCallback(
+    (id: string) => {
+      const tx = transactions.find((t) => t._id === id);
+      if (!tx) return;
+      setTransactions((prev) => prev.filter((t) => t._id !== id));
+      pendingDelete.current = tx;
+      const label = tx.item || tx.description || 'Transaction';
+      const sign = tx.type === 'income' ? '+' : '-';
+      const amount = `${symbol}${convert(tx.amount).toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+      const message = `Deleted "${label}" (${sign}${amount})`;
+      toast.success(message, {
+        duration: 5000,
+        action: {
+          label: 'Undo',
+          onClick: () => {
+            if (pendingDelete.current?._id !== tx._id) return;
+            pendingDelete.current = null;
+            setTransactions((prev) =>
+              [tx, ...prev].sort(
+                (a, b) => new Date(b.date || b.createdAt).getTime() - new Date(a.date || a.createdAt).getTime()
+              )
+            );
+          },
+        },
+        onTimeout: () => {
+          if (pendingDelete.current?._id !== tx._id) return;
+          pendingDelete.current = null;
+          commitDelete(tx);
+        },
+      });
+    },
+    [toast, commitDelete, symbol, convert, transactions]
+  );
 
   const handleSaved = async (updated: Transaction) => {
     // Optimistic update for immediate UI feedback
@@ -1208,46 +1221,11 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
         onCreateTag={(name) => addTag(name)}
       />
 
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={3000}
-        onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        sx={{ bottom: { xs: 'calc(56px + env(safe-area-inset-bottom) + 8px) !important', sm: 24 } }}
-      >
-        <Alert severity={snackbar.severity} onClose={() => setSnackbar((s) => ({ ...s, open: false }))}>
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
-
       <OnboardingFlow
         open={onboardingOpen}
         onDismiss={handleOnboardingDismiss}
         onFabClick={handleOnboardingFab}
       />
-
-      <Snackbar
-        open={undoSnackbar}
-        autoHideDuration={5000}
-        onClose={(_, reason) => {
-          if (reason === 'timeout') {
-            setUndoSnackbar(false);
-            commitDelete();
-          }
-        }}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        sx={{ bottom: { xs: 'calc(56px + env(safe-area-inset-bottom) + 8px) !important', sm: 24 } }}
-      >
-        <SnackbarContent
-          sx={{ bgcolor: 'background.paper', border: `1px solid ${theme.palette.divider}`, borderRadius: 2, boxShadow: '0 8px 32px rgba(0,0,0,0.4)' }}
-          message={<Typography sx={{ fontSize: '0.85rem', color: 'text.primary' }}>Transaction deleted</Typography>}
-          action={
-            <Button size="small" onClick={handleUndo} sx={{ color: 'primary.main', fontWeight: 700, fontSize: '0.8rem' }}>
-              Undo
-            </Button>
-          }
-        />
-      </Snackbar>
     </Box>
   );
 };

--- a/src/components/Toast/ToastProvider.tsx
+++ b/src/components/Toast/ToastProvider.tsx
@@ -1,0 +1,191 @@
+import React, { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Snackbar,
+  Alert,
+  Button,
+  Box,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+
+export type ToastVariant = 'success' | 'error' | 'info' | 'warning';
+
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface ToastOptions {
+  duration?: number;
+  action?: ToastAction;
+  /** Called after the toast auto-dismisses (timeout). NOT called when the action button is clicked. */
+  onTimeout?: () => void;
+}
+
+export interface ToastItem {
+  id: string;
+  message: React.ReactNode;
+  variant: ToastVariant;
+  duration: number;
+  action?: ToastAction;
+  onTimeout?: () => void;
+}
+
+export interface ToastApi {
+  success: (message: React.ReactNode, options?: ToastOptions) => string;
+  error: (message: React.ReactNode, options?: ToastOptions) => string;
+  info: (message: React.ReactNode, options?: ToastOptions) => string;
+  warning: (message: React.ReactNode, options?: ToastOptions) => string;
+  dismiss: (id: string) => void;
+}
+
+const DEFAULT_DURATIONS: Record<ToastVariant, number> = {
+  success: 3000,
+  error: 6000,
+  info: 4000,
+  warning: 5000,
+};
+
+const MAX_VISIBLE = 3;
+
+export const ToastContext = createContext<ToastApi | null>(null);
+
+let toastCounter = 0;
+const nextId = (): string => {
+  toastCounter += 1;
+  return `toast-${Date.now()}-${toastCounter}`;
+};
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const ToastProvider: React.FC<Props> = ({ children }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const enqueue = useCallback(
+    (variant: ToastVariant, message: React.ReactNode, options?: ToastOptions): string => {
+      const id = nextId();
+      const item: ToastItem = {
+        id,
+        message,
+        variant,
+        duration: options?.duration ?? DEFAULT_DURATIONS[variant],
+        action: options?.action,
+        onTimeout: options?.onTimeout,
+      };
+      setToasts((prev) => {
+        const next = [...prev, item];
+        // FIFO eviction: drop the oldest if we exceed the max.
+        if (next.length > MAX_VISIBLE) {
+          return next.slice(next.length - MAX_VISIBLE);
+        }
+        return next;
+      });
+      return id;
+    },
+    []
+  );
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      success: (message, options) => enqueue('success', message, options),
+      error: (message, options) => enqueue('error', message, options),
+      info: (message, options) => enqueue('info', message, options),
+      warning: (message, options) => enqueue('warning', message, options),
+      dismiss,
+    }),
+    [enqueue, dismiss]
+  );
+
+  const anchorOrigin = isMobile
+    ? ({ vertical: 'bottom', horizontal: 'center' } as const)
+    : ({ vertical: 'bottom', horizontal: 'right' } as const);
+
+  // One Snackbar wraps a Stack so multiple toasts stack vertically with a single positioning system.
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <Snackbar
+        open={toasts.length > 0}
+        anchorOrigin={anchorOrigin}
+        sx={{
+          bottom: { xs: 'calc(56px + env(safe-area-inset-bottom) + 24px) !important', sm: '24px !important' },
+          right: { xs: 8, sm: 24 },
+          left: { xs: 8, sm: 'auto' },
+          maxWidth: { xs: 'calc(100% - 16px)', sm: 420 },
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%' }}>
+          {toasts.map((t) => (
+            <ToastEntry key={t.id} toast={t} onClose={dismiss} />
+          ))}
+        </Box>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+};
+
+interface EntryProps {
+  toast: ToastItem;
+  onClose: (id: string) => void;
+}
+
+const ToastEntry: React.FC<EntryProps> = ({ toast, onClose }) => {
+  const timeoutFiredRef = useRef(false);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      timeoutFiredRef.current = true;
+      if (toast.onTimeout) toast.onTimeout();
+      onClose(toast.id);
+    }, toast.duration);
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [toast.id, toast.duration, toast.onTimeout, onClose]);
+
+  const handleActionClick = useCallback(() => {
+    if (toast.action) toast.action.onClick();
+    onClose(toast.id);
+  }, [toast.action, toast.id, onClose]);
+
+  const handleAlertClose = useCallback(() => {
+    onClose(toast.id);
+  }, [toast.id, onClose]);
+
+  return (
+    <Alert
+      severity={toast.variant}
+      variant="filled"
+      onClose={handleAlertClose}
+      sx={{
+        width: '100%',
+        alignItems: 'center',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.24)',
+        '& .MuiAlert-message': { flex: 1 },
+      }}
+      action={
+        toast.action ? (
+          <Button
+            size="small"
+            onClick={handleActionClick}
+            sx={{ color: 'inherit', fontWeight: 700, ml: 1 }}
+          >
+            {toast.action.label}
+          </Button>
+        ) : undefined
+      }
+    >
+      {toast.message}
+    </Alert>
+  );
+};
+
+export default ToastProvider;

--- a/src/components/Toast/__tests__/ToastProvider.test.tsx
+++ b/src/components/Toast/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ToastProvider from '../ToastProvider';
+import useToast from '../../../hooks/useToast';
+
+const Consumer: React.FC<{ run: (toast: ReturnType<typeof useToast>) => void }> = ({ run }) => {
+  const toast = useToast();
+  return (
+    <button type="button" onClick={() => run(toast)}>
+      fire
+    </button>
+  );
+};
+
+describe('ToastProvider + useToast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('shows a success toast and auto-dismisses after 3s by default', () => {
+    render(
+      <ToastProvider>
+        <Consumer run={(t) => t.success('Saved')} />
+      </ToastProvider>
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('fire'));
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(2999);
+    });
+    expect(screen.queryByText('Saved')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(2);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('uses 6s for error variant', () => {
+    render(
+      <ToastProvider>
+        <Consumer run={(t) => t.error('Boom')} />
+      </ToastProvider>
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('fire'));
+    });
+    act(() => {
+      jest.advanceTimersByTime(5999);
+    });
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(2);
+    });
+    expect(screen.queryByText('Boom')).not.toBeInTheDocument();
+  });
+
+  it('renders an action button and invokes onClick when pressed (skipping onTimeout)', () => {
+    const action = jest.fn();
+    const onTimeout = jest.fn();
+    render(
+      <ToastProvider>
+        <Consumer
+          run={(t) =>
+            t.success('Deleted "Coffee" (-$5)', {
+              action: { label: 'Undo', onClick: action },
+              onTimeout,
+            })
+          }
+        />
+      </ToastProvider>
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('fire'));
+    });
+    act(() => {
+      fireEvent.click(screen.getByText('Undo'));
+    });
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Deleted "Coffee" (-$5)')).not.toBeInTheDocument();
+    // onTimeout must NOT fire even after the duration elapses
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('fires onTimeout when the toast auto-dismisses', () => {
+    const onTimeout = jest.fn();
+    render(
+      <ToastProvider>
+        <Consumer run={(t) => t.success('Bye', { duration: 1000, onTimeout })} />
+      </ToastProvider>
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('fire'));
+    });
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('stacks multiple toasts (max 3, FIFO eviction)', () => {
+    render(
+      <ToastProvider>
+        <Consumer
+          run={(t) => {
+            t.info('one');
+            t.info('two');
+            t.info('three');
+            t.info('four');
+          }}
+        />
+      </ToastProvider>
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('fire'));
+    });
+    expect(screen.queryByText('one')).not.toBeInTheDocument();
+    expect(screen.getByText('two')).toBeInTheDocument();
+    expect(screen.getByText('three')).toBeInTheDocument();
+    expect(screen.getByText('four')).toBeInTheDocument();
+  });
+
+  it('throws when useToast is used outside provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const Broken: React.FC = () => {
+      useToast();
+      return null;
+    };
+    expect(() => render(<Broken />)).toThrow(/useToast must be used inside/);
+    spy.mockRestore();
+  });
+});

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MainLayout from '../MainLayout';
+import ToastProvider from '../Toast/ToastProvider';
 import { Transaction } from '../../types';
 import dayjs from 'dayjs';
 
@@ -109,7 +110,9 @@ jest.mock('../../components/settings/FriendsSection', () => () => null);
 const renderMainLayout = () =>
   render(
     <MemoryRouter>
-      <MainLayout />
+      <ToastProvider>
+        <MainLayout />
+      </ToastProvider>
     </MemoryRouter>
   );
 

--- a/src/components/__tests__/MainLayout.datefilter.test.tsx
+++ b/src/components/__tests__/MainLayout.datefilter.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MainLayout from '../MainLayout';
+import ToastProvider from '../Toast/ToastProvider';
 import { Transaction } from '../../types';
 import dayjs from 'dayjs';
 
@@ -100,7 +101,7 @@ jest.mock('../../hooks/useTemplates', () => ({
 jest.mock('../../components/settings/FriendsSection', () => () => null);
 
 
-const renderMainLayout = () => render(<MemoryRouter><MainLayout /></MemoryRouter>);
+const renderMainLayout = () => render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);
 
 jest.setTimeout(30000);
 

--- a/src/components/__tests__/MainLayout.extended.test.tsx
+++ b/src/components/__tests__/MainLayout.extended.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MainLayout from '../MainLayout';
+import ToastProvider from '../Toast/ToastProvider';
 import { Transaction } from '../../types';
 import dayjs from 'dayjs';
 
@@ -93,7 +94,7 @@ jest.mock('../../hooks/useTemplates', () => ({
 jest.mock('../../components/settings/FriendsSection', () => () => null);
 
 
-const renderMainLayout = () => render(<MemoryRouter><MainLayout /></MemoryRouter>);
+const renderMainLayout = () => render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);
 
 jest.setTimeout(30000);
 

--- a/src/components/__tests__/MainLayout.monthurl.test.tsx
+++ b/src/components/__tests__/MainLayout.monthurl.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import MainLayout from '../MainLayout';
+import ToastProvider from '../Toast/ToastProvider';
 import { Transaction } from '../../types';
 import dayjs from 'dayjs';
 
@@ -105,7 +106,9 @@ const LocationProbe: React.FC = () => {
 const renderAt = (initialEntry: string) =>
   render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <MainLayout />
+      <ToastProvider>
+        <MainLayout />
+      </ToastProvider>
       <LocationProbe />
     </MemoryRouter>
   );

--- a/src/components/__tests__/MainLayout.recurring.test.tsx
+++ b/src/components/__tests__/MainLayout.recurring.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MainLayout from '../MainLayout';
+import ToastProvider from '../Toast/ToastProvider';
 import { Transaction } from '../../types';
 import dayjs from 'dayjs';
 
@@ -130,7 +131,7 @@ describe('MainLayout — applyRecurring branch', () => {
   });
 
   it('renders pending recurring banner when items are pending', async () => {
-    render(<MemoryRouter><MainLayout /></MemoryRouter>);
+    render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);
     await waitFor(() => screen.getAllByText('Home').length > 0);
     await waitFor(() => {
       const pendingBanners = screen.queryAllByText(/recurring transaction/i);
@@ -139,7 +140,7 @@ describe('MainLayout — applyRecurring branch', () => {
   });
 
   it('clicking Apply in recurring banner triggers applyRecurring — calls createExpense', async () => {
-    render(<MemoryRouter><MainLayout /></MemoryRouter>);
+    render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);
     await waitFor(() => screen.getAllByText('Home').length > 0);
     const applyButtons = await screen.findAllByRole('button', { name: /apply/i });
     if (applyButtons.length > 0) {
@@ -156,7 +157,7 @@ describe('MainLayout — applyRecurring branch', () => {
   });
 
   it('applyRecurring calls markApplied after creating transactions', async () => {
-    render(<MemoryRouter><MainLayout /></MemoryRouter>);
+    render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);
     await waitFor(() => screen.getAllByText('Home').length > 0);
     const applyButtons = screen.queryAllByRole('button', { name: /apply/i });
     if (applyButtons.length > 0) {
@@ -169,7 +170,7 @@ describe('MainLayout — applyRecurring branch', () => {
   });
 
   it('applyRecurring with single item shows singular snackbar message', async () => {
-    render(<MemoryRouter><MainLayout /></MemoryRouter>);
+    render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);
     await waitFor(() => screen.getAllByText('Home').length > 0);
     const applyButtons = screen.queryAllByRole('button', { name: /apply/i });
     if (applyButtons.length > 0) {

--- a/src/components/__tests__/MainLayout.test.tsx
+++ b/src/components/__tests__/MainLayout.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MainLayout from '../MainLayout';
+import ToastProvider from '../Toast/ToastProvider';
 import { Transaction } from '../../types';
 import dayjs from 'dayjs';
 
@@ -121,7 +122,9 @@ jest.mock('../../hooks/useTemplates', () => ({
 const renderMainLayout = () =>
   render(
     <MemoryRouter>
-      <MainLayout />
+      <ToastProvider>
+        <MainLayout />
+      </ToastProvider>
     </MemoryRouter>
   );
 

--- a/src/components/__tests__/MainLayoutMobile.test.tsx
+++ b/src/components/__tests__/MainLayoutMobile.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MainLayout from '../MainLayout';
+import ToastProvider from '../Toast/ToastProvider';
 import { Transaction } from '../../types';
 import dayjs from 'dayjs';
 
@@ -118,7 +119,9 @@ jest.mock('../../components/settings/FriendsSection', () => () => null);
 const renderMainLayout = () =>
   render(
     <MemoryRouter>
-      <MainLayout />
+      <ToastProvider>
+        <MainLayout />
+      </ToastProvider>
     </MemoryRouter>
   );
 

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { ToastContext, ToastApi } from '../components/Toast/ToastProvider';
+
+export const useToast = (): ToastApi => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used inside <ToastProvider>');
+  }
+  return ctx;
+};
+
+export default useToast;


### PR DESCRIPTION
## What
Global `ToastProvider` + `useToast()` hook with four variants (success / error / info / warning) per the design system. Replaces the two inline `<Snackbar>` blocks in `MainLayout` and wires the **Undo** action into the delete-transaction flow.

## Why
Closes #289

## Acceptance Criteria
- [x] `useToast()` hook available app-wide (mounted at `App` level inside `AppThemeProvider`)
- [x] Variants with correct durations — success 3s, info 4s, warning 5s, error 6s
- [x] Bottom-center on mobile (above bottom tab via `bottom: calc(56px + env(safe-area-inset-bottom) + 24px)`), bottom-right on desktop
- [x] Stack max 3 with FIFO eviction
- [x] Undo wired into Delete-Transaction with optimistic remove → toast `Deleted "<label>" (-<amount>)` → Undo restores; timeout commits the API DELETE

## Test Plan
1. Open the app, add a transaction. Toast `Transaction added` shows for 3s.
2. Delete a transaction → toast `Deleted "<label>" (-<amount>)` with **Undo** button visible.
3. Click **Undo** within 5s → row reappears, no DELETE request fires.
4. Delete again, wait 5s → row stays removed, DELETE call is sent.
5. On mobile, confirm the toast sits above the bottom tab (no overlap).
6. On desktop, confirm the toast appears at the bottom-right.

## Implementation Notes
- `ToastProvider` renders a single `<Snackbar>` containing a stacked Box of `<Alert variant="filled">` entries — one Portal, multiple toasts.
- Each toast manages its own `setTimeout`; `onTimeout` fires only on auto-dismiss, never when the action is clicked, so Undo cannot race the commit.
- `pendingDelete` ref guards against stale Undo / timeout firing after a follow-up delete.
- Existing MainLayout test helpers updated to wrap in `<ToastProvider>` since `useToast` now throws outside the provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)