### PR TITLE
fix: CI pipefail — test failures must fail build (#305)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Test with coverage gate
         run: |
+          set -o pipefail
           yarn test:ci --coverageReporters=json-summary 2>&1 | tee /tmp/test-output.txt
           COVERAGE=$(python3 -c "
           import json, sys


### PR DESCRIPTION
## What
Add `set -o pipefail` to the test step in `.github/workflows/ci.yml` so jest's exit code propagates through the `tee` pipe.

## Why
Closes #305

The step runs:
```
yarn test:ci --coverageReporters=json-summary 2>&1 | tee /tmp/test-output.txt
```

In bash, the exit code of a pipeline is the exit code of the **last** command (`tee`), which is always 0 unless `tee` itself fails. So when jest fails, the step still reports success. That's how PR #298 and PR #301 landed on main with 6 failing tests.

With `set -o pipefail`, the pipeline returns the first non-zero exit code, so jest failures now fail the step → fail the `build` job → block PR merge.

## Acceptance Criteria
- [x] CI workflow uses `set -o pipefail` (line 24)
- [x] YAML syntax valid (`yaml.safe_load` parses successfully)
- [x] Minimal one-line change, no behaviour change for the passing case
- [ ] (Manually verified in this PR run: jest passes → build green; jest failure → build red)

## Test Plan
1. Watch this PR's `build` job — should pass green if current tests pass on `main`
2. To reproduce the bug fix: open a follow-up PR with a deliberately failing test and confirm the build job goes red (tracked separately in #305's DoD item 3)

## Notes
- Did not remove the pipe — `tee /tmp/test-output.txt` is preserved for future log inspection
- Fix is intentionally minimal (one line) so it's trivial to review and revert if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)