### PR TITLE
Restore the 85% coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,11 @@ jobs:
             print(0)
           ")
           echo "Line coverage: ${COVERAGE}%"
-          # Baseline temporarily reduced from 85 to 80 (#278) to unblock CI while
-          # follow-up tests are added for RecurringPage, TagPicker,
-          # MonthlyReportPage, NlpInput, StatementReconciler. Tracking: #280.
-          if [ "${COVERAGE}" -lt 80 ]; then
-            echo "Coverage ${COVERAGE}% is below the 80% baseline. Add tests before merging."
+          if [ "${COVERAGE}" -lt 85 ]; then
+            echo "Coverage ${COVERAGE}% is below the 85% baseline. Add tests before merging."
             exit 1
           fi
-          echo "Coverage ${COVERAGE}% meets 80% baseline."
+          echo "Coverage ${COVERAGE}% meets 85% baseline."
       - name: Build
         run: yarn build
         env:

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -162,7 +162,7 @@ describe('Empty state on Home tab', () => {
       fireEvent.click(ctaButtons[0]);
     });
     await waitFor(() => {
-      expect(screen.getByText('Add transaction')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Add transaction' })).toBeInTheDocument();
     });
   });
 
@@ -240,7 +240,7 @@ describe('Empty state on Transactions tab', () => {
       fireEvent.click(screen.getByRole('button', { name: /add expense/i }));
     });
     await waitFor(() => {
-      expect(screen.getByText('Add transaction')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Add transaction' })).toBeInTheDocument();
     });
   });
 

--- a/src/components/__tests__/MainLayout.extended.test.tsx
+++ b/src/components/__tests__/MainLayout.extended.test.tsx
@@ -126,9 +126,9 @@ describe('MainLayout — extended coverage', () => {
     await waitFor(() => document.querySelector('[data-testid="AddIcon"]'));
     const fabBtn = document.querySelector('[data-testid="AddIcon"]')?.closest('button');
     if (fabBtn) { await act(async () => { fireEvent.click(fabBtn); }); }
-    await waitFor(() => screen.getByText('Add transaction'));
+    await waitFor(() => screen.getByRole('heading', { name: 'Add transaction' }));
     await act(async () => { fireEvent.keyDown(window, { key: 'n' }); });
-    expect(screen.getAllByText('Add transaction').length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('heading', { name: 'Add transaction' }).length).toBeGreaterThan(0);
   });
 
   it('handles commitDelete error — restores transaction on failure', async () => {

--- a/src/components/__tests__/MainLayout.test.tsx
+++ b/src/components/__tests__/MainLayout.test.tsx
@@ -239,7 +239,9 @@ describe('MainLayout', () => {
       await act(async () => { fireEvent.click(fabBtn); });
     }
     await waitFor(() => {
-      expect(screen.getByText('Add transaction')).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'Add transaction' }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -306,7 +308,9 @@ describe('MainLayout', () => {
       fireEvent.keyDown(window, { key: 'n' });
     });
     await waitFor(() => {
-      expect(screen.getByText('Add transaction')).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'Add transaction' }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -325,9 +329,13 @@ describe('MainLayout', () => {
     if (fabBtn) {
       await act(async () => { fireEvent.click(fabBtn); });
     }
-    await waitFor(() => screen.getByText('Add transaction'));
+    await waitFor(() =>
+      screen.getByRole('heading', { name: 'Add transaction' }),
+    );
     // Verify sheet opens without crashing
-    expect(screen.getByText('Add transaction')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Add transaction' }),
+    ).toBeInTheDocument();
   });
 
   it('submitting AddTransactionSheet calls createExpense and updates transactions', async () => {
@@ -338,7 +346,9 @@ describe('MainLayout', () => {
     if (fabBtn) {
       await act(async () => { fireEvent.click(fabBtn); });
     }
-    await waitFor(() => screen.getByText('Add transaction'));
+    await waitFor(() =>
+      screen.getByRole('heading', { name: 'Add transaction' }),
+    );
     const amountInput = screen.getByLabelText('Amount') as HTMLInputElement;
     await act(async () => { fireEvent.change(amountInput, { target: { value: '12.5' } }); });
     const categorySelect = screen.getByLabelText('Category') as HTMLSelectElement;

--- a/src/components/dashboard/__tests__/SummaryCards.test.tsx
+++ b/src/components/dashboard/__tests__/SummaryCards.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import SummaryCards from '../SummaryCards';
 import { Transaction } from '../../../types';
-import dayjs from 'dayjs';
 
 const makeTransaction = (overrides: Partial<Transaction>): Transaction => ({
   _id: '1',
@@ -103,7 +102,7 @@ describe('SummaryCards', () => {
   });
 
   it('shows today expenses when transactions from today exist', () => {
-    const todayDate = dayjs().format('YYYY-MM-DD');
+    const todayDate = new Date().toISOString().split('T')[0];
     const transactions = [makeTransaction({ type: 'expense', amount: 100, date: todayDate })];
     render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText(/Today:/i)).toBeInTheDocument();

--- a/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
+++ b/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
@@ -43,13 +43,15 @@ describe('ExpenseList (mobile layout)', () => {
   });
 
   it('shows Today label for transactions dated today', () => {
-    const transactions = [makeTransaction({ date: dayjs().format('YYYY-MM-DD') })];
+    const transactions = [makeTransaction({ date: new Date().toISOString().split('T')[0] })];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
     expect(screen.getByText('Today')).toBeInTheDocument();
   });
 
   it('shows Yesterday label for transactions dated yesterday', () => {
-    const transactions = [makeTransaction({ date: dayjs().subtract(1, 'day').format('YYYY-MM-DD') })];
+    const transactions = [
+      makeTransaction({ date: new Date(Date.now() - 86400000).toISOString().split('T')[0] }),
+    ];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
     expect(screen.getByText('Yesterday')).toBeInTheDocument();
   });
@@ -107,8 +109,8 @@ describe('ExpenseList (mobile layout)', () => {
   });
 
   it('groups multiple transactions by date', () => {
-    const today = dayjs().format('YYYY-MM-DD');
-    const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
+    const today = new Date().toISOString().split('T')[0];
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
     const transactions = [
       makeTransaction({ _id: '1', date: today, description: 'Today item' }),
       makeTransaction({ _id: '2', date: yesterday, description: 'Yesterday item' }),
@@ -121,7 +123,7 @@ describe('ExpenseList (mobile layout)', () => {
   });
 
   it('shows formatted date label for past transactions (not today or yesterday)', () => {
-    const pastDate = dayjs().subtract(14, 'day').format('YYYY-MM-DD');
+    const pastDate = new Date(Date.now() - 14 * 86400000).toISOString().split('T')[0];
     const transactions = [makeTransaction({ _id: 'past1', date: pastDate, description: 'Old lunch' })];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
     expect(screen.getByText('Old lunch')).toBeInTheDocument();

--- a/src/components/expenses/__tests__/NlpInput.success.test.tsx
+++ b/src/components/expenses/__tests__/NlpInput.success.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import NlpInput from '../NlpInput';
+import { parseTransactionText } from '../../../services/api';
+
+jest.mock('../../../services/api', () => ({
+  parseTransactionText: jest.fn(),
+}));
+
+describe('NlpInput happy path', () => {
+  const mockedParseTransactionText = parseTransactionText as jest.MockedFunction<
+    typeof parseTransactionText
+  >;
+
+  beforeEach(() => {
+    mockedParseTransactionText.mockReset();
+  });
+
+  it('submits parsed text and clears the input', async () => {
+    const onParsed = jest.fn();
+    mockedParseTransactionText.mockResolvedValue({
+      merchant: 'McDonalds',
+      amount: 65,
+      currency: 'HKD',
+      category: 'Food',
+    });
+
+    render(<NlpInput onParsed={onParsed} />);
+
+    const input = screen.getByPlaceholderText(/麥當勞/i);
+    await act(async () => {
+      fireEvent.change(input, {
+        target: { value: '今日同Casey食咗麥當勞 $65' },
+      });
+    });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    await waitFor(() => {
+      expect(onParsed).toHaveBeenCalledWith({
+        merchant: 'McDonalds',
+        amount: 65,
+        currency: 'HKD',
+        category: 'Food',
+      });
+    });
+
+    await waitFor(() => {
+      expect(input).toHaveValue('');
+    });
+  });
+});

--- a/src/components/expenses/__tests__/TagPicker.test.tsx
+++ b/src/components/expenses/__tests__/TagPicker.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TagPicker from '../TagPicker';
+import type { Tag } from '../../../types';
+
+describe('TagPicker', () => {
+  it('creates a new tag from the autocomplete list', async () => {
+    const onChange = jest.fn();
+    const onCreateTag = jest.fn().mockResolvedValue({
+      _id: 'tag-2',
+      name: 'Travel',
+      color: '#123456',
+    } as Tag);
+
+    render(
+      <TagPicker
+        selectedTags={[]}
+        availableTags={[]}
+        onChange={onChange}
+        onCreateTag={onCreateTag}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, 'Travel');
+
+    const createOption = await screen.findByText('Create "Travel"');
+    await userEvent.click(createOption);
+
+    await waitFor(() => {
+      expect(onCreateTag).toHaveBeenCalledWith('Travel');
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([
+        {
+          _id: 'tag-2',
+          name: 'Travel',
+          color: '#123456',
+        },
+      ]);
+    });
+  });
+});

--- a/src/components/recurring/__tests__/RecurringPage.test.tsx
+++ b/src/components/recurring/__tests__/RecurringPage.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RecurringPage from '../RecurringPage';
+import { useRecurring } from '../../../hooks/useRecurring';
+import { useFxRates } from '../../../hooks/useFxRates';
+
+jest.mock('../../../hooks/useRecurring', () => ({
+  useRecurring: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useFxRates', () => ({
+  useFxRates: jest.fn(),
+}));
+
+describe('RecurringPage', () => {
+  const mockedUseRecurring = useRecurring as jest.MockedFunction<
+    typeof useRecurring
+  >;
+  const mockedUseFxRates = useFxRates as jest.MockedFunction<typeof useFxRates>;
+
+  beforeEach(() => {
+    mockedUseRecurring.mockReturnValue({
+      items: [],
+      addItem: jest.fn(),
+      deleteItem: jest.fn(),
+      markApplied: jest.fn(),
+    });
+    mockedUseFxRates.mockReturnValue({
+      symbol: '$',
+      convert: (value: number) => value,
+      currency: 'HKD',
+      setCurrency: jest.fn(),
+      loading: false,
+      rates: { HKD: 1 } as never,
+      rateForCurrency: jest.fn(),
+    } as ReturnType<typeof useFxRates>);
+  });
+
+  it('opens the add form and submits a recurring item', async () => {
+    const addItem = jest.fn();
+    mockedUseRecurring.mockReturnValue({
+      items: [],
+      addItem,
+      deleteItem: jest.fn(),
+      markApplied: jest.fn(),
+    });
+
+    render(<RecurringPage />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /add recurring transaction/i }),
+    );
+
+    await userEvent.type(screen.getByLabelText('Label'), 'Spotify');
+    await userEvent.type(screen.getByLabelText('Amount (HKD)'), '12');
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'Spotify',
+        amount: 12,
+        type: 'expense',
+      }),
+    );
+    expect(screen.queryByText(/new recurring/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/settings/__tests__/StatementReconciler.test.tsx
+++ b/src/components/settings/__tests__/StatementReconciler.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import StatementReconciler from '../StatementReconciler';
+import { scanStatement, applyStatementImport } from '../../../services/api';
+
+jest.mock('../../../services/api', () => ({
+  scanStatement: jest.fn(),
+  applyStatementImport: jest.fn(),
+}));
+
+describe('StatementReconciler', () => {
+  const mockedScanStatement = scanStatement as jest.MockedFunction<
+    typeof scanStatement
+  >;
+  const mockedApplyStatementImport = applyStatementImport as jest.MockedFunction<
+    typeof applyStatementImport
+  >;
+
+  beforeEach(() => {
+    mockedScanStatement.mockReset();
+    mockedApplyStatementImport.mockReset();
+  });
+
+  it('imports selected missing transactions after scanning a statement', async () => {
+    mockedScanStatement.mockResolvedValue({
+      extracted: [
+        {
+          date: '2026-05-01',
+          description: 'Coffee',
+          amount: 12,
+          type: 'expense',
+        },
+      ],
+      matched: [
+        {
+          extracted: {
+            date: '2026-05-01',
+            description: 'Coffee',
+            amount: 12,
+            type: 'expense',
+          },
+          existingId: 'txn-1',
+          existingDescription: 'Coffee',
+        },
+      ],
+      missing: [
+        {
+          date: '2026-05-02',
+          description: 'Lunch',
+          amount: 42,
+          type: 'expense',
+        },
+      ],
+      discrepancies: [],
+    });
+    mockedApplyStatementImport.mockResolvedValue({ imported: 1 });
+    const onImported = jest.fn();
+
+    render(<StatementReconciler onImported={onImported} />);
+
+    const file = new File(['statement'], 'statement.pdf', {
+      type: 'application/pdf',
+    });
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toBeInTheDocument();
+
+    fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+
+    await screen.findByText('1 matched');
+    await screen.findByText('1 missing');
+    await screen.findByRole('button', { name: 'Import 1 transaction' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import 1 transaction' }));
+
+    await waitFor(() => {
+      expect(mockedApplyStatementImport).toHaveBeenCalledWith([
+        {
+          date: '2026-05-02',
+          description: 'Lunch',
+          amount: 42,
+          type: 'expense',
+        },
+      ]);
+    });
+    expect(onImported).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Restores the CI line-coverage gate back to 85% and updates the stale tests that were blocking coverage from reaching the original threshold.

Changes:
- add coverage for TagPicker, NlpInput, RecurringPage, and StatementReconciler
- fix stale assertions in dashboard and empty-state tests
- raise .github/workflows/ci.yml from 80% back to 85%

Validation:
- ./node_modules/.bin/jest --coverage --watchAll=false --coverageReporters=json-summary --runInBand
- git diff --check

Coverage summary: 85.98% lines