### PR TITLE
Use display labels for payment method chips

### DIFF
--- a/src/components/expenses/FilterBar.tsx
+++ b/src/components/expenses/FilterBar.tsx
@@ -24,7 +24,7 @@ import DataObjectIcon from '@mui/icons-material/DataObject';
 import SortIcon from '@mui/icons-material/Sort';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import LabelIcon from '@mui/icons-material/Label';
-import { TransactionType, PAYMENT_METHODS, PaymentMethod, Tag } from '../../types';
+import { TransactionType, PAYMENT_METHODS, PAYMENT_METHOD_LABELS, PaymentMethod, Tag } from '../../types';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 
 interface Props {
@@ -246,7 +246,7 @@ const FilterBar: React.FC<Props> = ({
           {PAYMENT_METHODS.map((m) => (
             <Chip
               key={m}
-              label={m}
+              label={PAYMENT_METHOD_LABELS[m] || m}
               size="small"
               clickable
               onClick={() => onPaymentMethodFilterChange(paymentMethodFilter === m ? 'all' : m)}

--- a/src/components/expenses/__tests__/FilterBar.test.tsx
+++ b/src/components/expenses/__tests__/FilterBar.test.tsx
@@ -143,10 +143,9 @@ describe('FilterBar', () => {
     render(<FilterBar {...defaultProps} />);
     const filterBtn = document.querySelector('[data-testid="FilterListIcon"]')?.parentElement;
     if (filterBtn) fireEvent.click(filterBtn);
-    // FilterBar currently renders enum keys as labels (see #279 follow-up)
-    expect(screen.getByText('cash')).toBeInTheDocument();
-    expect(screen.getByText('octopus')).toBeInTheDocument();
-    expect(screen.getByText('payme')).toBeInTheDocument();
+    expect(screen.getByText('Cash')).toBeInTheDocument();
+    expect(screen.getByText('Octopus')).toBeInTheDocument();
+    expect(screen.getByText('PayMe')).toBeInTheDocument();
   });
 
   it('calls onPaymentMethodFilterChange when payment chip clicked', () => {
@@ -154,7 +153,7 @@ describe('FilterBar', () => {
     render(<FilterBar {...defaultProps} onPaymentMethodFilterChange={onPaymentMethodFilterChange} />);
     const filterBtn = document.querySelector('[data-testid="FilterListIcon"]')?.parentElement;
     if (filterBtn) fireEvent.click(filterBtn);
-    fireEvent.click(screen.getByText('octopus'));
+    fireEvent.click(screen.getByText('Octopus'));
     expect(onPaymentMethodFilterChange).toHaveBeenCalledWith('octopus');
   });
 


### PR DESCRIPTION
Fixes the payment-method filter chips to use the shared display labels from PAYMENT_METHOD_LABELS instead of raw enum keys.

Validation:
- ./node_modules/.bin/jest --runInBand src/components/expenses/__tests__/FilterBar.test.tsx
- git diff --check

This preserves the existing filter behavior: click handlers still pass the enum keys back to the parent.