### PR TITLE
Add empty states for goals and budgets

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -23,6 +23,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import SavingsIcon from '@mui/icons-material/Savings';
 import dayjs from 'dayjs';
 import { useGoals } from '../../hooks/useGoals';
+import EmptyState from '../ui/EmptyState';
 
 interface Props {
   convert: (hkd: number) => number;
@@ -86,16 +87,12 @@ const GoalsPage: React.FC<Props> = ({ convert, symbol }) => {
       </Box>
 
       {sortedGoals.length === 0 && (
-        <Box sx={{ textAlign: 'center', py: 8 }}>
-          <SavingsIcon sx={{ fontSize: 56, color: 'text.secondary', opacity: 0.4, mb: 2 }} />
-          <Typography variant="h6" sx={{ color: 'text.secondary', mb: 1 }}>No goals yet</Typography>
-          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
-            Add your first goal to start tracking your savings
-          </Typography>
-          <Button variant="outlined" startIcon={<AddIcon />} onClick={() => setAddOpen(true)}>
-            Add Goal
-          </Button>
-        </Box>
+        <EmptyState
+          icon={<SavingsIcon />}
+          title="No goals yet"
+          body="Add your first goal to start tracking your savings"
+          cta={{ label: 'Add Goal', onClick: () => setAddOpen(true) }}
+        />
       )}
 
       <Box sx={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(auto-fill, minmax(320px, 1fr))', gap: 2 }}>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -36,6 +36,7 @@ import { ITEM_PRESETS } from '../expenses/ItemPicker';
 import { useThemePreference } from '../../ThemeContext';
 import { ThemePreference } from '../../theme';
 import { useTags } from '../../hooks/useTags';
+import EmptyState from '../ui/EmptyState';
 
 interface Props {
   currency: string;
@@ -102,6 +103,8 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const [tagNameDraft, setTagNameDraft] = useState('');
   const [tagDeleteConfirm, setTagDeleteConfirm] = useState<string | null>(null);
   const [signOutConfirm, setSignOutConfirm] = useState(false);
+  const hasAnyBudget = Object.values(budgets).some((limit) => limit > 0);
+  const budgetInputId = (category: string) => `budget-input-${category.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
 
   const handleBudgetBlur = (category: string) => {
     const val = parseFloat(drafts[category]);
@@ -318,6 +321,21 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
           <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', mb: 1.5 }}>
             Set limits per category — progress bars appear on the Home breakdown.
           </Typography>
+          {!hasAnyBudget && (
+            <Box sx={{ mb: 2 }}>
+              <EmptyState
+                title="No budgets yet"
+                body="Set limits per category to track progress on the Home breakdown."
+                cta={{
+                  label: 'Create your first budget',
+                  onClick: () => {
+                    const firstInput = document.getElementById(budgetInputId(BUDGET_CATEGORIES[0])) as HTMLInputElement | null;
+                    firstInput?.focus();
+                  },
+                }}
+              />
+            </Box>
+          )}
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             {BUDGET_CATEGORIES.map((cat) => {
               const spent = categorySpend[cat] || 0;
@@ -337,12 +355,12 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
                   size="small"
                   type="number"
                   placeholder="No limit"
+                  inputProps={{ min: 0, id: budgetInputId(cat) }}
                   value={drafts[cat]}
                   onChange={(e) => setDrafts((d) => ({ ...d, [cat]: e.target.value }))}
                   onBlur={() => handleBudgetBlur(cat)}
                   InputProps={{ startAdornment: <InputAdornment position="start"><Typography sx={{ fontSize: '0.78rem', color: 'text.disabled' }}>HK$</Typography></InputAdornment> }}
                   sx={{ width: 140, '& .MuiInputBase-input': { fontSize: '0.82rem', py: 0.75 } }}
-                  inputProps={{ min: 0 }}
                 />
               </Box>
               );

--- a/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -65,6 +65,8 @@ describe('SettingsPage', () => {
   it('shows Monthly Budgets section', () => {
     renderWithTheme(<SettingsPage {...defaultProps} />);
     expect(screen.getByText('Monthly Budgets')).toBeInTheDocument();
+    expect(screen.getByText('No budgets yet')).toBeInTheDocument();
+    expect(screen.getByText('Create your first budget')).toBeInTheDocument();
   });
 
   it('shows currency chips', () => {


### PR DESCRIPTION
Adds the shared EmptyState primitive to:
- GoalsPage when there are no goals
- Monthly Budgets in Settings when no budgets are configured

Also adds a small helper so the budgets CTA can jump focus to the first budget field.

Validation:
- ./node_modules/.bin/jest --runInBand src/components/goals/__tests__/GoalsPage.test.tsx src/components/settings/__tests__/SettingsPage.test.tsx
- git diff --check

This matches the empty-state bounty in #306.