### PR TITLE
Fix CI pipefail in test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Test with coverage gate
         run: |
+          set -o pipefail
           yarn test:ci --coverageReporters=json-summary 2>&1 | tee /tmp/test-output.txt
           COVERAGE=$(python3 -c "
           import json, sys


### PR DESCRIPTION
Adds  to the CI test step so failing yarn test runs can no longer be masked by the tee pipeline.\n\nValidation: git diff --check