### PR TITLE
Add settings data actions

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -605,6 +605,19 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
     URL.revokeObjectURL(url);
   };
 
+  const handleDeleteAllTransactions = useCallback(async () => {
+    const toDelete = [...transactions];
+    if (toDelete.length === 0) return;
+
+    try {
+      await Promise.all(toDelete.map((t) => deleteExpense(t._id)));
+      setTransactions([]);
+      showSnackbar('All transactions deleted');
+    } catch {
+      showSnackbar('Failed to delete transactions', 'error');
+    }
+  }, [transactions, showSnackbar]);
+
   const navItems = [
     { label: 'Home', icon: <DashboardIcon /> },
     { label: 'Transactions', icon: <ReceiptLongIcon /> },
@@ -1078,6 +1091,8 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
                 onCurrencyChange={(c: Currency) => setCurrency(c)}
                 categorySpend={categorySpend}
                 onTransactionsImported={fetchTransactions}
+                onExportCsv={handleExport}
+                onDeleteAllTransactions={handleDeleteAllTransactions}
               />
             )}
           </Suspense>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -24,6 +24,7 @@ import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
 import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import { useTheme } from '@mui/material/styles';
 import { clearToken } from '../../services/auth';
 import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
@@ -42,6 +43,8 @@ interface Props {
   onCurrencyChange: (c: Currency) => void;
   categorySpend?: Record<string, number>;
   onTransactionsImported?: () => void;
+  onExportCsv?: () => void;
+  onDeleteAllTransactions?: () => void | Promise<void>;
 }
 
 function getUserId(): string {
@@ -85,7 +88,14 @@ const ThemeToggle: React.FC = () => {
   );
 };
 
-const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpend = {}, onTransactionsImported }) => {
+const SettingsPage: React.FC<Props> = ({
+  currency,
+  onCurrencyChange,
+  categorySpend = {},
+  onTransactionsImported,
+  onExportCsv,
+  onDeleteAllTransactions,
+}) => {
   const theme = useTheme();
   const userId = getUserId();
   const { symbol, convert } = useFxRates();
@@ -102,6 +112,7 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const [tagNameDraft, setTagNameDraft] = useState('');
   const [tagDeleteConfirm, setTagDeleteConfirm] = useState<string | null>(null);
   const [signOutConfirm, setSignOutConfirm] = useState(false);
+  const [deleteAllConfirm, setDeleteAllConfirm] = useState(false);
 
   const handleBudgetBlur = (category: string) => {
     const val = parseFloat(drafts[category]);
@@ -143,6 +154,13 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const confirmLogout = () => {
     setSignOutConfirm(false);
     handleLogout();
+  };
+
+  const confirmDeleteAll = async () => {
+    setDeleteAllConfirm(false);
+    if (onDeleteAllTransactions) {
+      await onDeleteAllTransactions();
+    }
   };
 
   const renderItemSection = (label: string, items: typeof ITEM_PRESETS) => (
@@ -469,6 +487,33 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
         </Box>
       </Box>
 
+      <Box sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', overflow: 'hidden', mb: 2 }}>
+        <Box sx={{ px: 2, py: 1.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.72rem', letterSpacing: '0.04em', textTransform: 'uppercase', display: 'block', mb: 1 }}>
+            Data Actions
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Button
+              variant="outlined"
+              startIcon={<FileDownloadIcon />}
+              onClick={() => onExportCsv?.()}
+              disabled={!onExportCsv}
+            >
+              Export CSV
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<DeleteIcon />}
+              onClick={() => setDeleteAllConfirm(true)}
+              disabled={!onDeleteAllTransactions}
+            >
+              Delete All
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+
       <Button
         variant="outlined"
         color="error"
@@ -488,6 +533,19 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
           <Button onClick={() => setSignOutConfirm(false)}>Cancel</Button>
           <Button color="error" variant="contained" onClick={confirmLogout}>
             Sign Out
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={deleteAllConfirm} onClose={() => setDeleteAllConfirm(false)}>
+        <DialogTitle>Delete All Transactions</DialogTitle>
+        <DialogContent>
+          <Typography>Delete every transaction in the account? This cannot be undone.</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteAllConfirm(false)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={confirmDeleteAll} disabled={!onDeleteAllTransactions}>
+            Delete All
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -45,6 +45,8 @@ describe('SettingsPage', () => {
   const defaultProps = {
     currency: 'HKD',
     onCurrencyChange: jest.fn(),
+    onExportCsv: jest.fn(),
+    onDeleteAllTransactions: jest.fn(),
   };
 
   beforeEach(() => {
@@ -76,6 +78,12 @@ describe('SettingsPage', () => {
   it('shows Sign Out button', () => {
     renderWithTheme(<SettingsPage {...defaultProps} />);
     expect(screen.getByText('Sign Out')).toBeInTheDocument();
+  });
+
+  it('shows data actions buttons', () => {
+    renderWithTheme(<SettingsPage {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete all/i })).toBeInTheDocument();
   });
 
   it('calls onCurrencyChange when currency chip is clicked', () => {
@@ -129,6 +137,22 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Are you sure you want to sign out?')).toBeInTheDocument();
     // Cancel dismisses the dialog without crashing.
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  });
+
+  it('calls onExportCsv when Export CSV is clicked', () => {
+    const onExportCsv = jest.fn();
+    renderWithTheme(<SettingsPage {...defaultProps} onExportCsv={onExportCsv} />);
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+    expect(onExportCsv).toHaveBeenCalled();
+  });
+
+  it('opens delete all dialog and confirms action', () => {
+    const onDeleteAllTransactions = jest.fn();
+    renderWithTheme(<SettingsPage {...defaultProps} onDeleteAllTransactions={onDeleteAllTransactions} />);
+    fireEvent.click(screen.getByRole('button', { name: /delete all/i }));
+    expect(screen.getByText('Delete every transaction in the account? This cannot be undone.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All' }));
+    expect(onDeleteAllTransactions).toHaveBeenCalled();
   });
 
   it('shows My Currencies section', () => {


### PR DESCRIPTION
Wires the remaining settings actions from issue #292: export CSV and delete-all transactions. The layout now passes handlers through to Settings, and Settings shows a dedicated data-actions block plus confirmation dialog for destructive delete-all.\n\nValidation: ./node_modules/.bin/jest --runInBand src/components/settings/__tests__/SettingsPage.test.tsx && npm run build