### PR TITLE
Add pre-push build hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+npm run build:check

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lint": "eslint --fix . && prettier --write .",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
-    "build:check": "VITE_API_URL=https://money-flow-backend-production.up.railway.app vite build"
+    "build:check": "VITE_API_URL=https://money-flow-backend-production.up.railway.app vite build",
+    "postinstall": "node scripts/install-hooks.mjs"
   },
   "browserslist": {
     "production": [

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,20 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const hookDir = join(process.cwd(), '.githooks');
+const hookPath = join(hookDir, 'pre-push');
+
+mkdirSync(hookDir, { recursive: true });
+writeFileSync(
+  hookPath,
+  '#!/usr/bin/env sh\nset -eu\nnpm run build:check\n',
+  { mode: 0o755 },
+);
+chmodSync(hookPath, 0o755);
+
+try {
+  execFileSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'ignore' });
+} catch {
+  // Ignore non-git environments and CI sandboxes that do not need local hooks.
+}


### PR DESCRIPTION
Adds a tracked pre-push hook under .githooks, installs it via postinstall, and points git to it so build failures block pushes locally. The repo already had build:check and .env.local.example, so this finishes the remaining guardrail piece from issue #239.\n\nValidation: node scripts/install-hooks.mjs && npm run build:check