### PR TITLE
Replace loading spinners with skeletons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,9 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import { AppThemeProvider } from './ThemeContext';
 import ProtectedRoute from './components/common/ProtectedRoute';
-import { CircularProgress, Box } from '@mui/material';
+import { Box } from '@mui/material';
 import ToastProvider from './components/Toast/ToastProvider';
+import DashboardSkeleton from './components/dashboard/DashboardSkeleton';
 
 const LoginPage = lazy(() => import('./components/auth/LoginPage'));
 const RegisterPage = lazy(() => import('./components/auth/RegisterPage'));
@@ -15,8 +16,8 @@ const ComponentsPage = lazy(() => import('./pages/dev/ComponentsPage'));
 const GOOGLE_CLIENT_ID = process.env.VITE_GOOGLE_CLIENT_ID ?? '';
 
 const PageLoader = () => (
-  <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
-    <CircularProgress />
+  <Box sx={{ minHeight: '100vh', py: 4 }}>
+    <DashboardSkeleton />
   </Box>
 );
 

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1045,7 +1045,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
             </>
           )}
 
-          <Suspense fallback={<Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}><CircularProgress /></Box>}>
+          <Suspense fallback={<Box sx={{ py: 4 }}><DashboardSkeleton /></Box>}>
             {activeTab === 2 && (
               <NetWorthPage convert={convert} symbol={symbol} />
             )}

--- a/src/components/insights/SpendingInsightsPage.tsx
+++ b/src/components/insights/SpendingInsightsPage.tsx
@@ -4,7 +4,7 @@ import {
   Typography,
   Card,
   CardContent,
-  CircularProgress,
+  Skeleton,
   Chip,
 } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
@@ -169,8 +169,10 @@ const SpendingInsightsPage: React.FC<Props> = ({ transactions, convert, symbol }
             Income vs Expenses — last 6 months
           </Typography>
           {loading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-              <CircularProgress size={28} />
+            <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 1.5, py: 1 }}>
+              {Array.from({ length: 6 }).map((_, idx) => (
+                <Skeleton key={idx} variant="rounded" height={200} />
+              ))}
             </Box>
           ) : error ? (
             <Typography variant="body2" color="text.secondary" sx={{ py: 2, textAlign: 'center' }}>

--- a/src/components/networth/NetWorthPage.tsx
+++ b/src/components/networth/NetWorthPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Box, Typography, TextField, Button, InputAdornment, CircularProgress } from '@mui/material';
+import { Box, Typography, TextField, Button, InputAdornment, Skeleton } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { getNetWorth, getLatestNetWorth, createNetWorth, NetWorthSnapshot } from '../../services/api';
@@ -67,7 +67,25 @@ const NetWorthPage: React.FC<Props> = ({ convert, symbol }) => {
   }));
 
   if (loading) {
-    return <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}><CircularProgress size={28} /></Box>;
+    return (
+      <Box sx={{ maxWidth: 600, mx: 'auto' }}>
+        <Skeleton variant="text" width={120} height={14} sx={{ mb: 1 }} />
+        <Box sx={{ p: 2.5, borderRadius: 2, bgcolor: 'rgba(148,163,184,0.04)', border: '1px solid rgba(148,163,184,0.08)', mb: 2, textAlign: 'center' }}>
+          <Skeleton variant="text" width="35%" height={18} sx={{ mx: 'auto', mb: 1 }} />
+          <Skeleton variant="text" width="55%" height={44} sx={{ mx: 'auto' }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', gap: 3, mt: 1 }}>
+            <Skeleton variant="text" width={72} height={28} />
+            <Skeleton variant="text" width={72} height={28} />
+          </Box>
+        </Box>
+        <Box sx={{ mb: 2, p: 2, borderRadius: 2, bgcolor: 'rgba(148,163,184,0.04)', border: '1px solid rgba(148,163,184,0.08)' }}>
+          <Skeleton variant="text" width={80} height={14} sx={{ mb: 1 }} />
+          <Skeleton variant="rounded" width="100%" height={180} />
+        </Box>
+        <Skeleton variant="rounded" width="100%" height={44} sx={{ mb: 2 }} />
+        <Skeleton variant="rounded" width="100%" height={240} />
+      </Box>
+    );
   }
 
   return (

--- a/src/components/reports/MonthlyReportPage.tsx
+++ b/src/components/reports/MonthlyReportPage.tsx
@@ -5,13 +5,13 @@ import {
   Card,
   CardContent,
   Chip,
-  CircularProgress,
   FormControl,
   InputLabel,
   LinearProgress,
   MenuItem,
   Select,
   SelectChangeEvent,
+  Skeleton,
   Typography,
 } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
@@ -284,8 +284,11 @@ const MonthlyReportPage: React.FC<Props> = ({ transactions, convert, symbol }) =
 
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
-        <CircularProgress size={32} />
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, py: 1 }}>
+        <Skeleton variant="text" width={160} height={20} />
+        <Skeleton variant="rounded" width="100%" height={64} />
+        <Skeleton variant="rounded" width="100%" height={240} />
+        <Skeleton variant="rounded" width="100%" height={180} />
       </Box>
     );
   }


### PR DESCRIPTION
Swaps the full-page loading spinners in App/MainLayout and the page-level loading states in NetWorth, Spending Insights, and Monthly Report for skeleton placeholders. This is the first visible slice of the loading-state pass in issue #290.\n\nValidation: npm run build