### PR TITLE
fix: Settings page crash — getTags returns raw array not .tags property

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -430,7 +430,7 @@ export const applyStatementImport = async (transactions: StatementTxn[]): Promis
 // Tags
 export const getTags = async (): Promise<Tag[]> => {
   const res = await axiosInstance.get('/api/tags');
-  return res.data.tags;
+  return res.data;
 };
 
 export const createTag = async (data: { name: string; color?: string }): Promise<Tag> => {


### PR DESCRIPTION
## Summary
- `GET /api/tags` returns a plain array, but `getTags()` was doing `return res.data.tags` (undefined)
- `useTags` called `setTags(undefined)`, making `tags` undefined instead of `[]`
- `SettingsPage` crashed on `tags.length` for any user navigating to Settings

One-line fix: `res.data.tags` → `res.data`

Closes #320

## Test plan
- [ ] Navigate to Settings as a new user (no tags) — page renders without crash
- [ ] Screenshot confirms full Settings page visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)