### PR TITLE
ux(filter): show payment-method display labels not enum keys (#304)

### DIFF
--- a/src/components/expenses/FilterBar.tsx
+++ b/src/components/expenses/FilterBar.tsx
@@ -24,7 +24,7 @@ import DataObjectIcon from '@mui/icons-material/DataObject';
 import SortIcon from '@mui/icons-material/Sort';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import LabelIcon from '@mui/icons-material/Label';
-import { TransactionType, PAYMENT_METHODS, PaymentMethod, Tag } from '../../types';
+import { TransactionType, PAYMENT_METHODS, PAYMENT_METHOD_LABELS, PaymentMethod, Tag } from '../../types';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 
 interface Props {
@@ -246,7 +246,7 @@ const FilterBar: React.FC<Props> = ({
           {PAYMENT_METHODS.map((m) => (
             <Chip
               key={m}
-              label={m}
+              label={PAYMENT_METHOD_LABELS[m]}
               size="small"
               clickable
               onClick={() => onPaymentMethodFilterChange(paymentMethodFilter === m ? 'all' : m)}

--- a/src/components/expenses/__tests__/FilterBar.test.tsx
+++ b/src/components/expenses/__tests__/FilterBar.test.tsx
@@ -139,22 +139,22 @@ describe('FilterBar', () => {
     expect(document.querySelector('[data-testid="FilterListIcon"]')).toBeTruthy();
   });
 
-  it('shows payment method chips when filter toggle is clicked', () => {
+  it('shows payment method chips with display labels when filter toggle is clicked', () => {
     render(<FilterBar {...defaultProps} />);
     const filterBtn = document.querySelector('[data-testid="FilterListIcon"]')?.parentElement;
     if (filterBtn) fireEvent.click(filterBtn);
-    // FilterBar currently renders enum keys as labels (see #279 follow-up)
-    expect(screen.getByText('cash')).toBeInTheDocument();
-    expect(screen.getByText('octopus')).toBeInTheDocument();
-    expect(screen.getByText('payme')).toBeInTheDocument();
+    expect(screen.getByText('Cash')).toBeInTheDocument();
+    expect(screen.getByText('Octopus')).toBeInTheDocument();
+    expect(screen.getByText('PayMe')).toBeInTheDocument();
   });
 
-  it('calls onPaymentMethodFilterChange when payment chip clicked', () => {
+  it('calls onPaymentMethodFilterChange with enum key when payment chip clicked', () => {
     const onPaymentMethodFilterChange = jest.fn();
     render(<FilterBar {...defaultProps} onPaymentMethodFilterChange={onPaymentMethodFilterChange} />);
     const filterBtn = document.querySelector('[data-testid="FilterListIcon"]')?.parentElement;
     if (filterBtn) fireEvent.click(filterBtn);
-    fireEvent.click(screen.getByText('octopus'));
+    fireEvent.click(screen.getByText('Octopus'));
+    // Click hands back the enum key for filtering, not the display label
     expect(onPaymentMethodFilterChange).toHaveBeenCalledWith('octopus');
   });
 


### PR DESCRIPTION
## Summary
\`FilterBar\` rendered raw enum strings (\`cash\`, \`octopus\`, \`payme\`, …) as chip labels. Now uses \`PAYMENT_METHOD_LABELS\` (\`Cash\`, \`Octopus\`, \`PayMe\`, …) — same source of truth that \`PaymentMethodPicker\` and \`ExpenseList\` already use.

Click handler still passes the enum key to \`onPaymentMethodFilterChange\`, so filter behavior is unchanged.

## Test plan
- [x] FilterBar.test.tsx asserts display labels (Cash/Octopus/PayMe) and that click still passes \`'octopus'\` (enum) — 30/30 passing
- [x] No other usage of FilterBar elsewhere expects the enum key as a label (grep verified)
- [ ] CI green

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)