### PR TITLE
feat(fx): locale-detect default display currency (#280)

### DIFF
--- a/src/hooks/__tests__/useFxRates.test.ts
+++ b/src/hooks/__tests__/useFxRates.test.ts
@@ -32,12 +32,12 @@ describe('useFxRates', () => {
     jest.restoreAllMocks();
   });
 
-  it('defaults to HKD currency', async () => {
+  it('defaults to locale-detected currency (USD in jsdom default en-US)', async () => {
     const { result } = renderHook(() => useFxRates());
-    expect(result.current.currency).toBe('HKD');
+    expect(result.current.currency).toBe('USD');
   });
 
-  it('loads currency from localStorage', () => {
+  it('loads currency from localStorage (overriding locale detection)', () => {
     localStorage.setItem('mf_currency', 'CAD');
     const { result } = renderHook(() => useFxRates());
     expect(result.current.currency).toBe('CAD');
@@ -90,6 +90,7 @@ describe('useFxRates', () => {
   });
 
   it('convert for HKD returns same amount', async () => {
+    localStorage.setItem('mf_currency', 'HKD');
     const { result } = renderHook(() => useFxRates());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.convert(500)).toBe(500);

--- a/src/hooks/useFxRates.ts
+++ b/src/hooks/useFxRates.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getExchangeRates } from '../services/api';
 import { Currency, CURRENCY_SYMBOLS } from '../constants/currencies';
+import { detectCurrencyFromLocale } from '../utils/localeCurrency';
 
 export type { Currency };
 export { CURRENCY_SYMBOLS };
@@ -67,7 +68,7 @@ function fetchRates(): Promise<Rates> {
 
 export function useFxRates() {
   const [currency, setCurrencyState] = useState<Currency>(
-    () => (localStorage.getItem(STORAGE_KEY) as Currency) || 'HKD'
+    () => (localStorage.getItem(STORAGE_KEY) as Currency) || detectCurrencyFromLocale()
   );
   const [rates, setRates] = useState<Rates>(cachedRates || DEFAULT_RATES);
   const [loading, setLoading] = useState(!cachedRates);

--- a/src/utils/__tests__/localeCurrency.test.ts
+++ b/src/utils/__tests__/localeCurrency.test.ts
@@ -1,0 +1,73 @@
+import { detectCurrencyFromLocale } from '../localeCurrency';
+
+describe('detectCurrencyFromLocale', () => {
+  it('returns HKD for zh-HK', () => {
+    expect(detectCurrencyFromLocale('zh-HK')).toBe('HKD');
+  });
+
+  it('returns CNY for zh-CN', () => {
+    expect(detectCurrencyFromLocale('zh-CN')).toBe('CNY');
+  });
+
+  it('returns TWD for zh-TW', () => {
+    expect(detectCurrencyFromLocale('zh-TW')).toBe('TWD');
+  });
+
+  it('returns USD for en-US', () => {
+    expect(detectCurrencyFromLocale('en-US')).toBe('USD');
+  });
+
+  it('returns CAD for en-CA', () => {
+    expect(detectCurrencyFromLocale('en-CA')).toBe('CAD');
+  });
+
+  it('returns GBP for en-GB', () => {
+    expect(detectCurrencyFromLocale('en-GB')).toBe('GBP');
+  });
+
+  it('returns EUR for de-DE', () => {
+    expect(detectCurrencyFromLocale('de-DE')).toBe('EUR');
+  });
+
+  it('returns EUR for fr-FR', () => {
+    expect(detectCurrencyFromLocale('fr-FR')).toBe('EUR');
+  });
+
+  it('returns JPY for ja (language only)', () => {
+    expect(detectCurrencyFromLocale('ja')).toBe('JPY');
+  });
+
+  it('returns JPY for ja-JP', () => {
+    expect(detectCurrencyFromLocale('ja-JP')).toBe('JPY');
+  });
+
+  it('returns KRW for ko-KR', () => {
+    expect(detectCurrencyFromLocale('ko-KR')).toBe('KRW');
+  });
+
+  it('returns THB for th-TH', () => {
+    expect(detectCurrencyFromLocale('th-TH')).toBe('THB');
+  });
+
+  it('falls back to USD for an unknown locale', () => {
+    expect(detectCurrencyFromLocale('xx-YY')).toBe('USD');
+  });
+
+  it('falls back to USD for an empty locale', () => {
+    expect(detectCurrencyFromLocale('')).toBe('USD');
+  });
+
+  it('handles underscore separators (en_US)', () => {
+    expect(detectCurrencyFromLocale('en_US')).toBe('USD');
+  });
+
+  it('uses navigator.language when no arg passed', () => {
+    const origLang = Object.getOwnPropertyDescriptor(navigator, 'language');
+    Object.defineProperty(navigator, 'language', { value: 'en-CA', configurable: true });
+    try {
+      expect(detectCurrencyFromLocale()).toBe('CAD');
+    } finally {
+      if (origLang) Object.defineProperty(navigator, 'language', origLang);
+    }
+  });
+});

--- a/src/utils/localeCurrency.ts
+++ b/src/utils/localeCurrency.ts
@@ -1,0 +1,48 @@
+import type { Currency } from '../constants/currencies';
+
+const REGION_TO_CURRENCY: Record<string, Currency> = {
+  HK: 'HKD',
+  CN: 'CNY',
+  TW: 'TWD',
+  JP: 'JPY',
+  KR: 'KRW',
+  TH: 'THB',
+  US: 'USD',
+  CA: 'CAD',
+  GB: 'GBP',
+  IE: 'EUR',
+  DE: 'EUR',
+  FR: 'EUR',
+  ES: 'EUR',
+  IT: 'EUR',
+  NL: 'EUR',
+  PT: 'EUR',
+  AT: 'EUR',
+  BE: 'EUR',
+  FI: 'EUR',
+  GR: 'EUR',
+  LU: 'EUR',
+};
+
+const LANG_TO_CURRENCY: Record<string, Currency> = {
+  ja: 'JPY',
+  ko: 'KRW',
+  th: 'THB',
+};
+
+export function detectCurrencyFromLocale(localeStr?: string): Currency {
+  const locale =
+    localeStr ||
+    (typeof navigator !== 'undefined' ? navigator.language : undefined) ||
+    '';
+  if (!locale) return 'USD';
+
+  const [lang, region] = locale.split(/[-_]/);
+  if (region && REGION_TO_CURRENCY[region.toUpperCase()]) {
+    return REGION_TO_CURRENCY[region.toUpperCase()];
+  }
+  if (lang && LANG_TO_CURRENCY[lang.toLowerCase()]) {
+    return LANG_TO_CURRENCY[lang.toLowerCase()];
+  }
+  return 'USD';
+}


### PR DESCRIPTION
## Summary
Display currency previously hardcoded to HKD if no localStorage. Now detected from \`navigator.language\` with USD fallback.

## Mapping
- en-US → USD, en-CA → CAD, en-GB → GBP
- zh-HK → HKD, zh-CN → CNY, zh-TW → TWD
- ja-* → JPY, ko-KR → KRW, th-TH → THB
- de/fr/es/it/nl/pt/ie/at/be/fi/gr/lu-* → EUR
- Anything else → USD (never XAF)

\`localStorage\` still wins over locale detection — user explicit choice is preserved.

## Other DoD items (already done before this PR)
- ✅ French copy: \`git grep -E "Gérez|Se connecter|S'inscrire|Aucune" src/\` → 0 matches (cleared by the #325 redesign)
- ✅ XAF default: 0 occurrences in code; backend User model defaults \`baseCurrency: 'USD'\`

## Test plan
- [x] New \`src/utils/__tests__/localeCurrency.test.ts\` — 16/16 passing covering all regions + language-only fallback + empty + unknown
- [x] Existing \`useFxRates.test.ts\` updated: "defaults to" test now asserts USD (jsdom default en-US locale); "convert for HKD" sets localStorage explicitly to HKD
- [x] \`yarn test:ci\` → 853 passing, 5 skipped, 0 failed
- [x] \`yarn build\` clean
- [ ] CI green

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)