### PR TITLE
ui(goals): use shared EmptyState primitive (#306 partial)

### DIFF
--- a/src/components/goals/GoalsPage.tsx
+++ b/src/components/goals/GoalsPage.tsx
@@ -23,6 +23,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import SavingsIcon from '@mui/icons-material/Savings';
 import dayjs from 'dayjs';
 import { useGoals } from '../../hooks/useGoals';
+import EmptyState from '../ui/EmptyState';
 
 interface Props {
   convert: (hkd: number) => number;
@@ -86,16 +87,13 @@ const GoalsPage: React.FC<Props> = ({ convert, symbol }) => {
       </Box>
 
       {sortedGoals.length === 0 && (
-        <Box sx={{ textAlign: 'center', py: 8 }}>
-          <SavingsIcon sx={{ fontSize: 56, color: 'text.secondary', opacity: 0.4, mb: 2 }} />
-          <Typography variant="h6" sx={{ color: 'text.secondary', mb: 1 }}>No goals yet</Typography>
-          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
-            Add your first goal to start tracking your savings
-          </Typography>
-          <Button variant="outlined" startIcon={<AddIcon />} onClick={() => setAddOpen(true)}>
-            Add Goal
-          </Button>
-        </Box>
+        <EmptyState
+          data-testid="goals-empty-state"
+          icon={<SavingsIcon />}
+          title="No goals yet"
+          body="Set your first goal to start tracking what you're saving for."
+          cta={{ label: 'Set your first goal', onClick: () => setAddOpen(true) }}
+        />
       )}
 
       <Box sx={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : 'repeat(auto-fill, minmax(320px, 1fr))', gap: 2 }}>

--- a/src/components/goals/__tests__/GoalsPage.test.tsx
+++ b/src/components/goals/__tests__/GoalsPage.test.tsx
@@ -27,11 +27,12 @@ describe('GoalsPage', () => {
     mockGoals = [];
   });
 
-  it('renders empty state when no goals', () => {
+  it('renders shared EmptyState when no goals', () => {
     render(<GoalsPage {...defaultProps} />);
+    expect(screen.getByTestId('goals-empty-state')).toBeInTheDocument();
     expect(screen.getByText('No goals yet')).toBeInTheDocument();
     expect(screen.getByText('Savings Goals')).toBeInTheDocument();
-    expect(screen.getByText('Add your first goal to start tracking your savings')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Set your first goal/i })).toBeInTheDocument();
   });
 
   it('renders header with Add Goal button', () => {


### PR DESCRIPTION
## Summary
Replaced the bespoke "no goals" panel in \`GoalsPage\` with the shared \`EmptyState\` primitive (shipped in #291). CTA wording updated to match the patterns.md spec ("Set your first goal").

## Why "partial"
The original DoD also asked for a Budgets empty state, but there is no Budgets page:
- Budgets are managed inline in the Settings page (always renders the full \`BUDGET_CATEGORIES\` list with input fields — there's no empty list to show an EmptyState in)
- \`BudgetProgress\` on the dashboard returns \`null\` when no budgets are configured

So "no budgets EmptyState" needs a product call on where it should live. Posted a comment on #306 spelling out 3 options.

## Test plan
- [x] \`yarn jest src/components/goals/__tests__/GoalsPage.test.tsx\` → 20/20 passing
- [x] \`yarn build\` clean
- [ ] CI green

Refs #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)