### PR TITLE
design(record): NlpInput hero AI-First entry per Hi-Fi spec (#332 phase 1)

### DIFF
--- a/src/components/expenses/NlpInput.tsx
+++ b/src/components/expenses/NlpInput.tsx
@@ -1,29 +1,31 @@
 import React, { useState } from 'react';
-import { Box, TextField, IconButton, CircularProgress, Typography, Chip } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import { Box, TextField, Typography, CircularProgress } from '@mui/material';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import CameraAltOutlinedIcon from '@mui/icons-material/CameraAltOutlined';
 import { parseTransactionText, ParsedTransaction } from '../../services/api';
 
 interface Props {
   onParsed: (result: ParsedTransaction) => void;
+  onScanClick?: () => void;
 }
 
-const NlpInput: React.FC<Props> = ({ onParsed }) => {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === 'dark';
+const NlpInput: React.FC<Props> = ({ onParsed, onScanClick }) => {
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [justParsed, setJustParsed] = useState(false);
 
   const handleParse = async () => {
     const trimmed = text.trim();
     if (!trimmed) return;
     setLoading(true);
     setError('');
+    setJustParsed(false);
     try {
       const result = await parseTransactionText(trimmed);
       onParsed(result);
       setText('');
+      setJustParsed(true);
     } catch (err: any) {
       const status = err?.response?.status;
       const serverMsg = err?.response?.data?.error;
@@ -44,62 +46,151 @@ const NlpInput: React.FC<Props> = ({ onParsed }) => {
   };
 
   return (
-    <Box sx={{ mb: 1.5 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
-        <AutoFixHighIcon sx={{ fontSize: 14, color: 'primary.main' }} />
-        <Typography variant="caption" sx={{ fontSize: '0.68rem', color: 'primary.main', fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-          Quick Entry
-        </Typography>
-        <Chip label="AI" size="small" sx={{ height: 16, fontSize: '0.6rem', bgcolor: isDark ? 'rgba(129,140,248,0.15)' : 'rgba(99,102,241,0.12)', color: 'primary.main', ml: 0.5 }} />
-      </Box>
-      <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'flex-start' }}>
-        <TextField
-          size="small"
-          fullWidth
-          multiline
-          maxRows={2}
-          placeholder="e.g. 今日同Casey食咗麥當勞 $65"
-          value={text}
-          onChange={(e) => { setText(e.target.value); setError(''); }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              handleParse();
-            }
-          }}
-          disabled={loading}
-          error={!!error}
-          helperText={error || undefined}
+    <Box
+      sx={{
+        mb: 2,
+        p: '14px 16px 12px',
+        borderRadius: '16px',
+        background: 'linear-gradient(135deg, #EEEDFC 0%, #F0EEFF 100%)',
+        border: '1.5px solid #D4D0F0',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.25 }}>
+        <Box
           sx={{
-            '& .MuiInputBase-root': {
-              fontSize: '0.88rem',
-              py: 0.5,
-              bgcolor: isDark ? 'rgba(129,140,248,0.04)' : 'rgba(99,102,241,0.04)',
-              borderRadius: 2,
-            },
-            '& .MuiOutlinedInput-notchedOutline': {
-              borderColor: isDark ? 'rgba(129,140,248,0.2)' : 'rgba(99,102,241,0.2)',
-            },
-            '& .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline': {
-              borderColor: 'primary.main',
-            },
-          }}
-        />
-        <IconButton
-          size="small"
-          onClick={handleParse}
-          disabled={loading || !text.trim()}
-          sx={{
-            mt: 0.25,
-            bgcolor: isDark ? 'rgba(129,140,248,0.12)' : 'rgba(99,102,241,0.12)',
-            border: `1px solid ${isDark ? 'rgba(129,140,248,0.25)' : 'rgba(99,102,241,0.25)'}`,
-            '&:hover': { bgcolor: isDark ? 'rgba(129,140,248,0.22)' : 'rgba(99,102,241,0.22)' },
-            '&.Mui-disabled': { opacity: 0.4 },
+            width: 24,
+            height: 24,
+            borderRadius: '8px',
+            bgcolor: 'primary.main',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
           }}
         >
-          {loading ? <CircularProgress size={18} /> : <AutoFixHighIcon sx={{ fontSize: 18, color: 'primary.main' }} />}
-        </IconButton>
+          <AutoAwesomeIcon sx={{ fontSize: 14, color: '#fff' }} />
+        </Box>
+        <Typography
+          sx={{
+            fontFamily: '"Plus Jakarta Sans", sans-serif',
+            fontSize: '0.72rem',
+            fontWeight: 600,
+            color: 'primary.main',
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+          }}
+        >
+          Quick Entry
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        {onScanClick && (
+          <Box
+            role="button"
+            tabIndex={0}
+            onClick={onScanClick}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onScanClick(); }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              padding: '4px 10px',
+              borderRadius: '8px',
+              bgcolor: '#fff',
+              border: '1px solid #D4D0F0',
+              cursor: 'pointer',
+              fontSize: '0.7rem',
+              fontWeight: 500,
+              color: 'primary.main',
+              fontFamily: '"Plus Jakarta Sans", sans-serif',
+              '&:hover': { bgcolor: '#FAFAFF' },
+            }}
+          >
+            <CameraAltOutlinedIcon sx={{ fontSize: 14 }} />
+            Scan
+          </Box>
+        )}
       </Box>
+      <TextField
+        size="small"
+        fullWidth
+        multiline
+        maxRows={3}
+        placeholder="e.g. 今日同Casey食咗麥當勞 $65"
+        value={text}
+        onChange={(e) => { setText(e.target.value); setError(''); setJustParsed(false); }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleParse();
+          }
+        }}
+        disabled={loading}
+        error={!!error}
+        helperText={error || undefined}
+        InputProps={{
+          sx: {
+            fontFamily: '"Plus Jakarta Sans", sans-serif',
+            fontSize: '1.0625rem',
+            fontWeight: 500,
+            lineHeight: 1.5,
+            color: '#1C1917',
+            padding: 0,
+            '& fieldset': { border: 'none' },
+            '&.Mui-focused fieldset': { border: 'none' },
+            '&:hover fieldset': { border: 'none' },
+          },
+        }}
+        sx={{
+          '& .MuiFormHelperText-root': {
+            mx: 0,
+            mt: 0.75,
+            fontSize: '0.72rem',
+          },
+        }}
+      />
+      {(loading || justParsed) && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 1 }}>
+          <Box
+            sx={{
+              flex: 1,
+              height: 3,
+              borderRadius: '2px',
+              bgcolor: 'primary.main',
+              opacity: loading ? 0.4 : 0.6,
+              position: 'relative',
+              overflow: 'hidden',
+              ...(loading && {
+                '&::after': {
+                  content: '""',
+                  position: 'absolute',
+                  inset: 0,
+                  background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.5), transparent)',
+                  animation: 'nlpShimmer 1.2s infinite',
+                },
+                '@keyframes nlpShimmer': {
+                  '0%': { transform: 'translateX(-100%)' },
+                  '100%': { transform: 'translateX(100%)' },
+                },
+              }),
+            }}
+          />
+          {loading ? (
+            <CircularProgress size={11} sx={{ color: 'primary.main' }} />
+          ) : (
+            <Typography
+              sx={{
+                fontFamily: '"Plus Jakarta Sans", sans-serif',
+                fontSize: '0.68rem',
+                fontWeight: 500,
+                color: 'primary.main',
+                letterSpacing: '0.02em',
+              }}
+            >
+              Parsed ✓
+            </Typography>
+          )}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/expenses/__tests__/NlpInput.test.tsx
+++ b/src/components/expenses/__tests__/NlpInput.test.tsx
@@ -71,3 +71,39 @@ describe('NlpInput error handling', () => {
     });
   });
 });
+
+describe('NlpInput hero visual', () => {
+  beforeEach(() => {
+    mockedParse.mockReset();
+  });
+
+  test('renders the Quick Entry hero label', () => {
+    render(<NlpInput onParsed={jest.fn()} />);
+    expect(screen.getByText('Quick Entry')).toBeInTheDocument();
+  });
+
+  test('does not render Scan button when onScanClick is not provided', () => {
+    render(<NlpInput onParsed={jest.fn()} />);
+    expect(screen.queryByRole('button', { name: /scan/i })).toBeNull();
+  });
+
+  test('renders Scan button and invokes onScanClick when provided', () => {
+    const onScanClick = jest.fn();
+    render(<NlpInput onParsed={jest.fn()} onScanClick={onScanClick} />);
+    const scan = screen.getByRole('button', { name: /scan/i });
+    expect(scan).toBeInTheDocument();
+    scan.click();
+    expect(onScanClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows "Parsed ✓" indicator after a successful parse', async () => {
+    mockedParse.mockResolvedValueOnce({ amount: 65, category: 'Food' } as any);
+    const onParsed = jest.fn();
+    render(<NlpInput onParsed={onParsed} />);
+    await typeAndSubmit('lunch 65');
+    await waitFor(() => {
+      expect(screen.getByText(/Parsed ✓/)).toBeInTheDocument();
+    });
+    expect(onParsed).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 of #332 — visually upgrades the Quick Entry input in the Record Transaction modal to match the chosen **Record Modal C · AI-First (Parsed Rows)** direction from the design handoff.

## Visual changes
- Gradient bg \`linear-gradient(135deg, #EEEDFC, #F0EEFF)\` per spec
- 1.5px \`primaryBorder\` (#D4D0F0), 16px radius
- 24×24 star icon (radius 8, primary bg) + uppercase "QUICK ENTRY" label
- Optional Scan pill button on right (opt-in via \`onScanClick\` — not wired in this PR)
- Input text Plus Jakarta Sans 17px/500, no border (flat over gradient)
- 3px progress bar with shimmer while loading; "Parsed ✓" indicator after success

## Behavior unchanged
- Existing \`parseTransactionText\` + \`onParsed\` callback contract preserved
- All error handling paths (429 / 401 / network / generic) untouched

## Screenshot
Playwright UAT confirmed visual match — gradient hero replaces the previous flat outline input. Modal still shows the structured form fields below (those move to a parsed-rows display in **Phase 2** of #332).

## Test plan
- [x] 9/9 NlpInput tests passing (5 existing error-handling + 4 new visual)
- [x] \`yarn test:ci\` → 866 passing, 5 skipped, 0 failed
- [x] \`yarn build\` clean
- [x] Local Playwright: register → open Record modal → hero gradient + star icon visible
- [ ] CI green

## Out of scope (tracked in #332)
- **Phase 2**: parsed-fields display after AI parse (replace form with read-only cards)
- **Phase 3**: templates row + collapsible Calculator
- **Phase 4**: Transactions Calendar Strip (mobile)
- **Phase 5**: Settings iOS grouped sections
- Scan button wire-up to existing scanReceipt flow

Refs #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)