### PR TITLE
feat(contacts): ContactsSection replaces FriendsSection (#339)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -26,7 +26,7 @@ import TableChartIcon from '@mui/icons-material/TableChart';
 import DataObjectIcon from '@mui/icons-material/DataObject';
 import dayjs, { Dayjs } from 'dayjs';
 import { Transaction, TransactionRequest, TransactionType, PaymentMethod } from '../types';
-import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult } from '../services/api';
+import { getExpenses, getExpense, createExpense, deleteExpense, scanReceipt, getLastAmounts, ReceiptScanResult, getContacts } from '../services/api';
 import { useTags } from '../hooks/useTags';
 import SummaryCards from './dashboard/SummaryCards';
 import DashboardSkeleton from './dashboard/DashboardSkeleton';
@@ -327,6 +327,11 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
     return () => { window.removeEventListener('offline', goOffline); window.removeEventListener('online', goOnline); };
   }, []);
 
+  const [contactNames, setContactNames] = useState<string[]>([]);
+  useEffect(() => {
+    getContacts().then((cs) => setContactNames(cs.map((c) => c.name))).catch(() => {});
+  }, []);
+
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
   const [datePreset, setDatePreset] = useState<DatePreset>(() => {
@@ -556,10 +561,10 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
   }, [transactions]);
 
   const knownParticipants = useMemo(() => {
-    const seen = new Set<string>();
+    const seen = new Set<string>(contactNames);
     transactions.forEach((t) => (t.participants ?? []).forEach((p) => seen.add(p)));
-    return Array.from(seen).slice(0, 10);
-  }, [transactions]);
+    return Array.from(seen).slice(0, 20);
+  }, [transactions, contactNames]);
 
   const descriptionsByItem = useMemo(() => {
     const map: Record<string, string[]> = {};

--- a/src/components/settings/ContactsSection.tsx
+++ b/src/components/settings/ContactsSection.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  IconButton,
+  List,
+  ListItem,
+  CircularProgress,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import PersonIcon from '@mui/icons-material/Person';
+import { getContacts, createContact, updateContact, deleteContact, Contact } from '../../services/api';
+
+const ContactsSection: React.FC = () => {
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [addName, setAddName] = useState('');
+  const [addEmail, setAddEmail] = useState('');
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editEmail, setEditEmail] = useState('');
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await getContacts();
+      setContacts(data);
+    } catch {
+      // silently fail
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const handleAdd = async () => {
+    if (!addName.trim()) return;
+    setLoading(true);
+    try {
+      await createContact({ name: addName.trim(), email: addEmail.trim() || undefined });
+      setAddName('');
+      setAddEmail('');
+      setShowAddForm(false);
+      refresh();
+    } catch {
+      // silently fail
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const startEdit = (c: Contact) => {
+    setEditingId(c._id);
+    setEditName(c.name);
+    setEditEmail(c.email ?? '');
+  };
+
+  const saveEdit = async () => {
+    if (!editingId || !editName.trim()) return;
+    try {
+      await updateContact(editingId, {
+        name: editName.trim(),
+        email: editEmail.trim() || null,
+      });
+      setEditingId(null);
+      refresh();
+    } catch {
+      // silently fail
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteContact(id);
+      refresh();
+    } catch {
+      // silently fail
+    }
+  };
+
+  return (
+    <Box>
+      <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled', mb: 1.5 }}>
+        People you split or share expenses with. No MoneyFlow account needed.
+      </Typography>
+
+      {contacts.length > 0 && (
+        <List disablePadding sx={{ mb: 1 }}>
+          {contacts.map((c) => (
+            <ListItem key={c._id} disableGutters sx={{ py: 0.5, gap: 0.5, alignItems: 'flex-start' }}>
+              <PersonIcon sx={{ fontSize: 16, color: 'text.disabled', mt: 0.5 }} />
+              {editingId === c._id ? (
+                <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                  <TextField
+                    size="small"
+                    autoFocus
+                    placeholder="Name"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') saveEdit(); if (e.key === 'Escape') setEditingId(null); }}
+                    sx={{ '& .MuiInputBase-input': { fontSize: '0.82rem', py: 0.6 } }}
+                  />
+                  <TextField
+                    size="small"
+                    placeholder="Email (optional)"
+                    value={editEmail}
+                    onChange={(e) => setEditEmail(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') saveEdit(); if (e.key === 'Escape') setEditingId(null); }}
+                    sx={{ '& .MuiInputBase-input': { fontSize: '0.82rem', py: 0.6 } }}
+                  />
+                </Box>
+              ) : (
+                <Box sx={{ flex: 1 }}>
+                  <Typography sx={{ fontSize: '0.85rem', fontWeight: 500 }}>{c.name}</Typography>
+                  {c.email && (
+                    <Typography sx={{ fontSize: '0.72rem', color: 'text.disabled' }}>{c.email}</Typography>
+                  )}
+                </Box>
+              )}
+              {editingId === c._id ? (
+                <Box sx={{ display: 'flex', gap: 0.25 }}>
+                  <IconButton size="small" onClick={saveEdit} sx={{ color: 'success.main' }}>
+                    <CheckIcon sx={{ fontSize: 15 }} />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => setEditingId(null)}>
+                    <CloseIcon sx={{ fontSize: 15 }} />
+                  </IconButton>
+                </Box>
+              ) : (
+                <Box sx={{ display: 'flex', gap: 0.25 }}>
+                  <IconButton size="small" onClick={() => startEdit(c)} sx={{ color: 'text.disabled' }}>
+                    <EditIcon sx={{ fontSize: 15 }} />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => handleDelete(c._id)} sx={{ color: 'text.disabled' }}>
+                    <DeleteIcon sx={{ fontSize: 15 }} />
+                  </IconButton>
+                </Box>
+              )}
+            </ListItem>
+          ))}
+        </List>
+      )}
+
+      {contacts.length === 0 && !showAddForm && (
+        <Typography sx={{ fontSize: '0.75rem', color: 'text.disabled', fontStyle: 'italic', mb: 1.5 }}>
+          No contacts yet.
+        </Typography>
+      )}
+
+      {showAddForm ? (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+          <TextField
+            size="small"
+            autoFocus
+            placeholder="Name *"
+            value={addName}
+            onChange={(e) => setAddName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); if (e.key === 'Escape') setShowAddForm(false); }}
+            sx={{ '& .MuiInputBase-input': { fontSize: '0.82rem', py: 0.75 } }}
+            disabled={loading}
+          />
+          <TextField
+            size="small"
+            placeholder="Email (optional)"
+            value={addEmail}
+            onChange={(e) => setAddEmail(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAdd(); if (e.key === 'Escape') setShowAddForm(false); }}
+            sx={{ '& .MuiInputBase-input': { fontSize: '0.82rem', py: 0.75 } }}
+            disabled={loading}
+          />
+          <Box sx={{ display: 'flex', gap: 0.75 }}>
+            <IconButton
+              size="small"
+              onClick={handleAdd}
+              disabled={loading || !addName.trim()}
+              sx={{ bgcolor: 'primary.main', color: 'white', borderRadius: 1, '&:hover': { bgcolor: 'primary.dark' }, '&:disabled': { bgcolor: 'action.disabledBackground' } }}
+            >
+              {loading ? <CircularProgress size={14} color="inherit" /> : <CheckIcon sx={{ fontSize: 16 }} />}
+            </IconButton>
+            <IconButton size="small" onClick={() => { setShowAddForm(false); setAddName(''); setAddEmail(''); }}>
+              <CloseIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+          </Box>
+        </Box>
+      ) : (
+        <IconButton
+          size="small"
+          onClick={() => setShowAddForm(true)}
+          sx={{ color: 'primary.main', border: '1px dashed', borderColor: 'primary.light', borderRadius: 1, px: 1.5, gap: 0.5, fontSize: '0.78rem' }}
+        >
+          <AddIcon sx={{ fontSize: 16 }} />
+          <Typography sx={{ fontSize: '0.78rem', color: 'primary.main' }}>Add contact</Typography>
+        </IconButton>
+      )}
+    </Box>
+  );
+};
+
+export default ContactsSection;

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -29,7 +29,7 @@ import { clearToken } from '../../services/auth';
 import { useFxRates, CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../hooks/useFxRates';
 import { useCurrencyPreferences } from '../../hooks/useCurrencyPreferences';
 import { useBudgets, BUDGET_CATEGORIES } from '../../hooks/useBudgets';
-import FriendsSection from './FriendsSection';
+import ContactsSection from './ContactsSection';
 import StatementReconciler from './StatementReconciler';
 import { useItemPresets } from '../../hooks/useItemPresets';
 import { ITEM_PRESETS } from '../expenses/ItemPicker';
@@ -355,9 +355,9 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
         </Box>
       </SettingsSection>
 
-      <SettingsSection title="Friends">
+      <SettingsSection title="Contacts">
         <Box sx={{ px: 2, py: 1.5 }}>
-          <FriendsSection />
+          <ContactsSection />
         </Box>
       </SettingsSection>
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -446,3 +446,31 @@ export const updateTag = async (id: string, data: { name?: string; color?: strin
 export const deleteTag = async (id: string): Promise<void> => {
   await axiosInstance.delete(`/api/tags/${id}`);
 };
+
+// Contacts
+export interface Contact {
+  _id: string;
+  name: string;
+  email?: string;
+  color?: string;
+  createdAt: string;
+}
+
+export const getContacts = async (): Promise<Contact[]> => {
+  const res = await axiosInstance.get('/api/contacts');
+  return res.data.contacts;
+};
+
+export const createContact = async (data: { name: string; email?: string; color?: string }): Promise<Contact> => {
+  const res = await axiosInstance.post('/api/contacts', data);
+  return res.data.contact;
+};
+
+export const updateContact = async (id: string, data: { name?: string; email?: string | null; color?: string | null }): Promise<Contact> => {
+  const res = await axiosInstance.patch(`/api/contacts/${id}`, data);
+  return res.data.contact;
+};
+
+export const deleteContact = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/api/contacts/${id}`);
+};


### PR DESCRIPTION
## Summary
- New `ContactsSection` component: add contacts by name (email optional), edit inline, delete with one tap
- Replaces `FriendsSection` (user-to-user friend requests) — contacts are now per-account, no MoneyFlow account needed
- `knownParticipants` in `MainLayout` seeded from `/api/contacts` names so AddExpenseModal autocomplete works
- Contacts CRUD API calls added to `api.ts`

## Test plan
- [ ] Settings → Contacts section renders (not Friends)
- [ ] Add "Casey" → appears in list
- [ ] Edit to "Casey Chan" → saved inline
- [ ] Delete → removed
- [ ] Add Expense → participant field suggests "Casey Chan"
- [ ] tsc clean, build passes

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)