### PR TITLE
test: fix MainLayout test mocks for ContactsSection (#339)

### DIFF
--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -55,6 +55,7 @@ jest.mock('../../services/api', () => ({
   login: jest.fn().mockResolvedValue(undefined),
   loginWithGoogle: jest.fn().mockResolvedValue(undefined),
   loginWithApple: jest.fn().mockResolvedValue(undefined),
+  getContacts: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('recharts', () => ({
@@ -104,7 +105,7 @@ jest.mock('../../hooks/useItemPresets', () => ({
 jest.mock('../../hooks/useTemplates', () => ({
   useTemplates: () => ({ templates: [], addTemplate: jest.fn(), deleteTemplate: jest.fn() }),
 }));
-jest.mock('../../components/settings/FriendsSection', () => () => null);
+jest.mock('../../components/settings/ContactsSection', () => () => null);
 
 
 const renderMainLayout = () =>

--- a/src/components/__tests__/MainLayout.datefilter.test.tsx
+++ b/src/components/__tests__/MainLayout.datefilter.test.tsx
@@ -60,6 +60,7 @@ jest.mock('../../services/api', () => ({
   login: jest.fn().mockResolvedValue(undefined),
   loginWithGoogle: jest.fn().mockResolvedValue(undefined),
   loginWithApple: jest.fn().mockResolvedValue(undefined),
+  getContacts: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('recharts', () => ({
@@ -98,7 +99,7 @@ jest.mock('../../hooks/useItemPresets', () => ({
 jest.mock('../../hooks/useTemplates', () => ({
   useTemplates: () => ({ templates: [], addTemplate: jest.fn(), deleteTemplate: jest.fn() }),
 }));
-jest.mock('../../components/settings/FriendsSection', () => () => null);
+jest.mock('../../components/settings/ContactsSection', () => () => null);
 
 
 const renderMainLayout = () => render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);

--- a/src/components/__tests__/MainLayout.extended.test.tsx
+++ b/src/components/__tests__/MainLayout.extended.test.tsx
@@ -58,6 +58,7 @@ jest.mock('../../services/api', () => ({
   login: jest.fn().mockResolvedValue(undefined),
   loginWithGoogle: jest.fn().mockResolvedValue(undefined),
   loginWithApple: jest.fn().mockResolvedValue(undefined),
+  getContacts: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('recharts', () => ({
@@ -91,7 +92,7 @@ jest.mock('../../hooks/useItemPresets', () => ({
 jest.mock('../../hooks/useTemplates', () => ({
   useTemplates: () => ({ templates: [], addTemplate: jest.fn(), deleteTemplate: jest.fn() }),
 }));
-jest.mock('../../components/settings/FriendsSection', () => () => null);
+jest.mock('../../components/settings/ContactsSection', () => () => null);
 
 
 const renderMainLayout = () => render(<MemoryRouter><ToastProvider><MainLayout /></ToastProvider></MemoryRouter>);

--- a/src/components/__tests__/MainLayout.monthurl.test.tsx
+++ b/src/components/__tests__/MainLayout.monthurl.test.tsx
@@ -60,6 +60,7 @@ jest.mock('../../services/api', () => ({
   login: jest.fn().mockResolvedValue(undefined),
   loginWithGoogle: jest.fn().mockResolvedValue(undefined),
   loginWithApple: jest.fn().mockResolvedValue(undefined),
+  getContacts: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('recharts', () => ({
@@ -94,7 +95,7 @@ jest.mock('../../hooks/useTemplates', () => ({
   useTemplates: () => ({ templates: [], addTemplate: jest.fn(), deleteTemplate: jest.fn() }),
 }));
 
-jest.mock('../../components/settings/FriendsSection', () => () => null);
+jest.mock('../../components/settings/ContactsSection', () => () => null);
 
 let lastSearch = '';
 const LocationProbe: React.FC = () => {

--- a/src/components/__tests__/MainLayout.recurring.test.tsx
+++ b/src/components/__tests__/MainLayout.recurring.test.tsx
@@ -59,6 +59,7 @@ jest.mock('../../services/api', () => ({
   login: jest.fn().mockResolvedValue(undefined),
   loginWithGoogle: jest.fn().mockResolvedValue(undefined),
   loginWithApple: jest.fn().mockResolvedValue(undefined),
+  getContacts: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('recharts', () => ({
@@ -110,7 +111,7 @@ jest.mock('../../hooks/useItemPresets', () => ({
 jest.mock('../../hooks/useTemplates', () => ({
   useTemplates: () => ({ templates: [], addTemplate: jest.fn(), deleteTemplate: jest.fn() }),
 }));
-jest.mock('../../components/settings/FriendsSection', () => () => null);
+jest.mock('../../components/settings/ContactsSection', () => () => null);
 
 
 jest.setTimeout(30000);

--- a/src/components/__tests__/MainLayout.test.tsx
+++ b/src/components/__tests__/MainLayout.test.tsx
@@ -64,11 +64,12 @@ jest.mock('../../services/api', () => {
     login: jest.fn(resolvedUndef),
     loginWithGoogle: jest.fn(resolvedUndef),
     loginWithApple: jest.fn(resolvedUndef),
+    getContacts: jest.fn(resolvedArray),
   };
 });
 
-// Mock FriendsSection to avoid API dependency
-jest.mock('../../components/settings/FriendsSection', () => () => <div data-testid="friends-section">Friends</div>);
+// Mock ContactsSection to avoid API dependency
+jest.mock('../../components/settings/ContactsSection', () => () => <div data-testid="contacts-section">Contacts</div>);
 
 // Mock recharts
 jest.mock('recharts', () => ({

--- a/src/components/__tests__/MainLayoutMobile.test.tsx
+++ b/src/components/__tests__/MainLayoutMobile.test.tsx
@@ -64,6 +64,7 @@ jest.mock('../../services/api', () => ({
   login: jest.fn().mockResolvedValue(undefined),
   loginWithGoogle: jest.fn().mockResolvedValue(undefined),
   loginWithApple: jest.fn().mockResolvedValue(undefined),
+  getContacts: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('recharts', () => ({
@@ -113,7 +114,7 @@ jest.mock('../../hooks/useItemPresets', () => ({
 jest.mock('../../hooks/useTemplates', () => ({
   useTemplates: () => ({ templates: [], addTemplate: jest.fn(), deleteTemplate: jest.fn() }),
 }));
-jest.mock('../../components/settings/FriendsSection', () => () => null);
+jest.mock('../../components/settings/ContactsSection', () => () => null);
 
 
 const renderMainLayout = () =>


### PR DESCRIPTION
## Summary
- Add `getContacts: jest.fn().mockResolvedValue([])` to all 7 MainLayout test files that mock the API
- Replace `FriendsSection` mock path with `ContactsSection` (follows PR #340 rename)
- All 82 suites / 898 tests green

Fixes test regression introduced by #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)