### PR TITLE
chore: add pre-push build hook (#316 resolved)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+npm run build:check

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lint": "eslint --fix . && prettier --write .",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
-    "build:check": "VITE_API_URL=https://money-flow-backend.fly.dev vite build"
+    "build:check": "VITE_API_URL=https://money-flow-backend.fly.dev vite build",
+    "postinstall": "node scripts/install-hooks.mjs"
   },
   "browserslist": {
     "production": [

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,20 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const hookDir = join(process.cwd(), '.githooks');
+const hookPath = join(hookDir, 'pre-push');
+
+mkdirSync(hookDir, { recursive: true });
+writeFileSync(
+  hookPath,
+  '#!/usr/bin/env sh\nset -eu\nnpm run build:check\n',
+  { mode: 0o755 },
+);
+chmodSync(hookPath, 0o755);
+
+try {
+  execFileSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'ignore' });
+} catch {
+  // Ignore non-git environments and CI sandboxes that do not need local hooks.
+}


### PR DESCRIPTION
## What
Applies bounty PR #316 manually resolved against current main. Adds `.githooks/pre-push` that runs `npm run build:check` before every push. A `postinstall` script auto-registers the hook via `git config core.hooksPath`.

## Why
Bounty PR #316 was CONFLICTING (branched off v1.0.21, main is now v1.0.32). The diff was all-additive (2 new files + 1 package.json line) so conflict resolution was straightforward.

Closes #316 (bounty)
Part of #343

## Acceptance Criteria
- [x] `.githooks/pre-push` runs `npm run build:check`
- [x] `scripts/install-hooks.mjs` auto-registers hook on `yarn install`
- [x] `package.json` has `postinstall` entry
- [x] `npx tsc --noEmit` passes
- [x] `yarn build` passes

## Test Plan
Run `yarn install` — verify `.git/config` contains `hooksPath = .githooks`. Attempt `git push` with a broken build to confirm hook fires.