### PR TITLE
feat: budget empty state in SettingsPage (#311 resolved)

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -38,6 +38,7 @@ import { ThemePreference } from '../../theme';
 import { useTags } from '../../hooks/useTags';
 import SettingsSection from './SettingsSection';
 import SettingsProfile from './SettingsProfile';
+import EmptyState from '../ui/EmptyState';
 
 interface Props {
   currency: string;
@@ -108,6 +109,8 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
   const [tagNameDraft, setTagNameDraft] = useState('');
   const [tagDeleteConfirm, setTagDeleteConfirm] = useState<string | null>(null);
   const [signOutConfirm, setSignOutConfirm] = useState(false);
+  const hasAnyBudget = Object.values(budgets).some((limit) => limit > 0);
+  const budgetInputId = (category: string) => `budget-input-${category.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
 
   const handleBudgetBlur = (category: string) => {
     const val = parseFloat(drafts[category]);
@@ -322,6 +325,21 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
           <Typography sx={{ display: 'none' }}>
             Set limits per category — progress bars appear on the Home breakdown.
           </Typography>
+          {!hasAnyBudget && (
+            <Box sx={{ mb: 2 }}>
+              <EmptyState
+                title="No budgets yet"
+                body="Set limits per category to track progress on the Home breakdown."
+                cta={{
+                  label: 'Create your first budget',
+                  onClick: () => {
+                    const firstInput = document.getElementById(budgetInputId(BUDGET_CATEGORIES[0])) as HTMLInputElement | null;
+                    firstInput?.focus();
+                  },
+                }}
+              />
+            </Box>
+          )}
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             {BUDGET_CATEGORIES.map((cat) => {
               const spent = categorySpend[cat] || 0;
@@ -341,12 +359,12 @@ const SettingsPage: React.FC<Props> = ({ currency, onCurrencyChange, categorySpe
                   size="small"
                   type="number"
                   placeholder="No limit"
+                  inputProps={{ min: 0, id: budgetInputId(cat) }}
                   value={drafts[cat]}
                   onChange={(e) => setDrafts((d) => ({ ...d, [cat]: e.target.value }))}
                   onBlur={() => handleBudgetBlur(cat)}
                   InputProps={{ startAdornment: <InputAdornment position="start"><Typography sx={{ fontSize: '0.78rem', color: 'text.disabled' }}>HK$</Typography></InputAdornment> }}
                   sx={{ width: 140, '& .MuiInputBase-input': { fontSize: '0.82rem', py: 0.75 } }}
-                  inputProps={{ min: 0 }}
                 />
               </Box>
               );

--- a/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -65,6 +65,8 @@ describe('SettingsPage', () => {
   it('shows Monthly Budgets section', () => {
     renderWithTheme(<SettingsPage {...defaultProps} />);
     expect(screen.getByText('Monthly Budgets')).toBeInTheDocument();
+    expect(screen.getByText('No budgets yet')).toBeInTheDocument();
+    expect(screen.getByText('Create your first budget')).toBeInTheDocument();
   });
 
   it('shows currency chips', () => {


### PR DESCRIPTION
## What
Applies bounty PR #311 (empty states for goals and budgets) against current main. The GoalsPage EmptyState was already shipped in #330 — only the SettingsPage budget empty state was missing.

Adds `EmptyState` when no budget limits are set, with a CTA that focuses the first budget input. TextFields now have accessible `id` attrs for focus targeting.

## Why
Bounty PR #311 was CONFLICTING. GoalsPage portion was already applied; only the SettingsPage changes remained.

Closes #311 (bounty)
Part of #343

## Acceptance Criteria
- [x] "No budgets yet" EmptyState appears in Monthly Budgets section when no limits are set
- [x] "Create your first budget" CTA focuses first input
- [x] SettingsPage tests updated and passing (18/18)
- [x] `npx tsc --noEmit` passes
- [x] `yarn build` passes

## Test Plan
Navigate to Settings → Monthly Budgets with no budgets set. Verify "No budgets yet" and CTA appear. Click CTA — first budget input should receive focus.