### PR TITLE
fix: widen responsive breakpoints sm→lg/md (#315 resolved)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -309,7 +309,7 @@ interface MainLayoutProps {
 
 const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
   const theme = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up('sm'));
+  const isDesktop = useMediaQuery(theme.breakpoints.up('lg'));
   const { currency, setCurrency, convert, symbol } = useFxRates();
   const { items: recurringItems, markApplied } = useRecurring();
   const { budgets } = useBudgets();
@@ -1021,7 +1021,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
                   <SpendingPulse />
 
                   {/* Mobile dashboard */}
-                  <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+                  <Box sx={{ display: { xs: 'block', lg: 'none' } }}>
                     <Box sx={{ mb: 1.5 }}>
                       <DateRangeControl
                         preset={datePreset}
@@ -1091,7 +1091,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
                   </Box>
 
                   {/* Desktop dashboard */}
-                  <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+                  <Box sx={{ display: { xs: 'none', lg: 'block' } }}>
                     <Box sx={{ mb: 2 }}>
                       <DateRangeControl
                         preset={datePreset}

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -129,7 +129,7 @@ const PULL_DEBOUNCE_MS = 2000;
 
 const ExpenseList: React.FC<Props> = ({ transactions, onEdit, onDelete, convert, symbol, recurringLabels, filtersActive, monthLabel, onAddClick, onRefresh }) => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isDark = theme.palette.mode === 'dark';
   const [expandedNote, setExpandedNote] = useState<string | null>(null);
   const [swipedId, setSwipedId] = useState<string | null>(null);


### PR DESCRIPTION
## What
Applies the valid portions of bounty PR #315 against current main. Changes the desktop/mobile threshold in MainLayout from \`sm\` (600px) to \`lg\` (1200px) so tablets (600–1200px) correctly get the mobile layout. ExpenseList mobile card view threshold updated from \`sm\` to \`md\`.

The PR's sidebar SX props (\`ml: { sm: '220px' }\`) no longer exist in current main (the sidebar uses boolean \`isDesktop\` conditional rendering), so only the three applicable changes were applied.

## Why
Bounty PR #315 was CONFLICTING. The original diff patched SX responsive objects that have since been replaced with JSX conditional rendering — but the breakpoint values themselves were still using \`sm\`.

Closes #315 (bounty)
Part of #343

## Acceptance Criteria
- [x] \`isDesktop\` uses \`breakpoints.up('lg')\` in MainLayout
- [x] Mobile/desktop dashboard sections use \`lg\` breakpoints in sx
- [x] ExpenseList \`isMobile\` uses \`breakpoints.down('md')\`
- [x] \`npx tsc --noEmit\` passes
- [x] \`yarn build\` passes

## Test Plan
Resize browser. At 900px width (tablet), verify mobile layout (bottom nav, no sidebar). At 1280px, verify desktop layout (sidebar visible, no bottom nav).