### PR TITLE
test: coverage tests + stale assertion fixes (#308 resolved)

### DIFF
--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -163,7 +163,7 @@ describe('Empty state on Home tab', () => {
       fireEvent.click(ctaButtons[0]);
     });
     await waitFor(() => {
-      expect(screen.getByText('Add transaction')).toBeInTheDocument();
+      expect(screen.getByText('Record Transaction')).toBeInTheDocument();
     });
   });
 

--- a/src/components/__tests__/MainLayout.test.tsx
+++ b/src/components/__tests__/MainLayout.test.tsx
@@ -240,7 +240,7 @@ describe('MainLayout', () => {
       await act(async () => { fireEvent.click(fabBtn); });
     }
     await waitFor(() => {
-      expect(screen.getByText('Add transaction')).toBeInTheDocument();
+      expect(screen.getByText('Record Transaction')).toBeInTheDocument();
     });
   });
 
@@ -307,7 +307,7 @@ describe('MainLayout', () => {
       fireEvent.keyDown(window, { key: 'n' });
     });
     await waitFor(() => {
-      expect(screen.getByText('Add transaction')).toBeInTheDocument();
+      expect(screen.getByText('Record Transaction')).toBeInTheDocument();
     });
   });
 
@@ -326,9 +326,9 @@ describe('MainLayout', () => {
     if (fabBtn) {
       await act(async () => { fireEvent.click(fabBtn); });
     }
-    await waitFor(() => screen.getByText('Add transaction'));
+    await waitFor(() => screen.getByText('Record Transaction'));
     // Verify sheet opens without crashing
-    expect(screen.getByText('Add transaction')).toBeInTheDocument();
+    expect(screen.getByText('Record Transaction')).toBeInTheDocument();
   });
 
   it.skip('submitting AddExpenseModal calls createExpense and updates transactions', async () => {

--- a/src/components/dashboard/__tests__/SummaryCards.test.tsx
+++ b/src/components/dashboard/__tests__/SummaryCards.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import SummaryCards from '../SummaryCards';
 import { Transaction } from '../../../types';
-import dayjs from 'dayjs';
 
 const makeTransaction = (overrides: Partial<Transaction>): Transaction => ({
   _id: '1',
@@ -103,7 +102,7 @@ describe('SummaryCards', () => {
   });
 
   it('shows today expenses when transactions from today exist', () => {
-    const todayDate = dayjs().format('YYYY-MM-DD');
+    const todayDate = new Date().toISOString().split('T')[0];
     const transactions = [makeTransaction({ type: 'expense', amount: 100, date: todayDate })];
     render(<SummaryCards transactions={transactions} convert={(n) => n} symbol="HK$" />);
     expect(screen.getByText(/Today:/i)).toBeInTheDocument();

--- a/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
+++ b/src/components/expenses/__tests__/ExpenseListMobile.test.tsx
@@ -43,13 +43,15 @@ describe('ExpenseList (mobile layout)', () => {
   });
 
   it('shows Today label for transactions dated today', () => {
-    const transactions = [makeTransaction({ date: dayjs().format('YYYY-MM-DD') })];
+    const transactions = [makeTransaction({ date: new Date().toISOString().split('T')[0] })];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
     expect(screen.getByText('Today')).toBeInTheDocument();
   });
 
   it('shows Yesterday label for transactions dated yesterday', () => {
-    const transactions = [makeTransaction({ date: dayjs().subtract(1, 'day').format('YYYY-MM-DD') })];
+    const transactions = [
+      makeTransaction({ date: new Date(Date.now() - 86400000).toISOString().split('T')[0] }),
+    ];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
     expect(screen.getByText('Yesterday')).toBeInTheDocument();
   });
@@ -107,8 +109,8 @@ describe('ExpenseList (mobile layout)', () => {
   });
 
   it('groups multiple transactions by date', () => {
-    const today = dayjs().format('YYYY-MM-DD');
-    const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
+    const today = new Date().toISOString().split('T')[0];
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
     const transactions = [
       makeTransaction({ _id: '1', date: today, description: 'Today item' }),
       makeTransaction({ _id: '2', date: yesterday, description: 'Yesterday item' }),
@@ -121,7 +123,7 @@ describe('ExpenseList (mobile layout)', () => {
   });
 
   it('shows formatted date label for past transactions (not today or yesterday)', () => {
-    const pastDate = dayjs().subtract(14, 'day').format('YYYY-MM-DD');
+    const pastDate = new Date(Date.now() - 14 * 86400000).toISOString().split('T')[0];
     const transactions = [makeTransaction({ _id: 'past1', date: pastDate, description: 'Old lunch' })];
     render(<ExpenseList {...defaultProps} transactions={transactions} />);
     expect(screen.getByText('Old lunch')).toBeInTheDocument();

--- a/src/components/expenses/__tests__/NlpInput.success.test.tsx
+++ b/src/components/expenses/__tests__/NlpInput.success.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import NlpInput from '../NlpInput';
+import { parseTransactionText } from '../../../services/api';
+
+jest.mock('../../../services/api', () => ({
+  parseTransactionText: jest.fn(),
+}));
+
+describe('NlpInput happy path', () => {
+  const mockedParseTransactionText = parseTransactionText as jest.MockedFunction<
+    typeof parseTransactionText
+  >;
+
+  beforeEach(() => {
+    mockedParseTransactionText.mockReset();
+  });
+
+  it('calls onParsed with result and clears input on success', async () => {
+    const onParsed = jest.fn();
+    mockedParseTransactionText.mockResolvedValue({
+      merchant: 'Coffee',
+      amount: 35,
+      category: 'Food & Drink',
+    });
+
+    render(<NlpInput onParsed={onParsed} />);
+
+    const input = screen.getByRole('textbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'coffee 35' } });
+    });
+
+    // NlpInput triggers parse on Enter key (no submit button)
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+    });
+
+    await waitFor(() => {
+      expect(mockedParseTransactionText).toHaveBeenCalledWith('coffee 35');
+    });
+
+    await waitFor(() => {
+      expect(onParsed).toHaveBeenCalledWith(
+        expect.objectContaining({ merchant: 'Coffee', amount: 35 }),
+      );
+    });
+
+    await waitFor(() => {
+      expect((input as HTMLInputElement).value).toBe('');
+    });
+  });
+});

--- a/src/components/recurring/__tests__/RecurringPage.test.tsx
+++ b/src/components/recurring/__tests__/RecurringPage.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RecurringPage from '../RecurringPage';
+import { useRecurring } from '../../../hooks/useRecurring';
+import { useFxRates } from '../../../hooks/useFxRates';
+
+jest.mock('../../../hooks/useRecurring', () => ({
+  useRecurring: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useFxRates', () => ({
+  useFxRates: jest.fn(),
+}));
+
+describe('RecurringPage', () => {
+  const mockedUseRecurring = useRecurring as jest.MockedFunction<
+    typeof useRecurring
+  >;
+  const mockedUseFxRates = useFxRates as jest.MockedFunction<typeof useFxRates>;
+
+  beforeEach(() => {
+    mockedUseRecurring.mockReturnValue({
+      items: [],
+      addItem: jest.fn(),
+      deleteItem: jest.fn(),
+      markApplied: jest.fn(),
+    });
+    mockedUseFxRates.mockReturnValue({
+      symbol: '$',
+      convert: (value: number) => value,
+      currency: 'HKD',
+      setCurrency: jest.fn(),
+      loading: false,
+      rates: { HKD: 1 } as never,
+      rateForCurrency: jest.fn(),
+    } as ReturnType<typeof useFxRates>);
+  });
+
+  it('opens the add form and submits a recurring item', async () => {
+    const addItem = jest.fn();
+    mockedUseRecurring.mockReturnValue({
+      items: [],
+      addItem,
+      deleteItem: jest.fn(),
+      markApplied: jest.fn(),
+    });
+
+    render(<RecurringPage />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /add recurring transaction/i }),
+    );
+
+    await userEvent.type(screen.getByLabelText('Label'), 'Spotify');
+    await userEvent.type(screen.getByLabelText('Amount (HKD)'), '12');
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'Spotify',
+        amount: 12,
+        type: 'expense',
+      }),
+    );
+    expect(screen.queryByText(/new recurring/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/settings/__tests__/StatementReconciler.test.tsx
+++ b/src/components/settings/__tests__/StatementReconciler.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import StatementReconciler from '../StatementReconciler';
+import { scanStatement, applyStatementImport } from '../../../services/api';
+
+jest.mock('../../../services/api', () => ({
+  scanStatement: jest.fn(),
+  applyStatementImport: jest.fn(),
+}));
+
+describe('StatementReconciler', () => {
+  const mockedScanStatement = scanStatement as jest.MockedFunction<
+    typeof scanStatement
+  >;
+  const mockedApplyStatementImport = applyStatementImport as jest.MockedFunction<
+    typeof applyStatementImport
+  >;
+
+  beforeEach(() => {
+    mockedScanStatement.mockReset();
+    mockedApplyStatementImport.mockReset();
+  });
+
+  it('imports selected missing transactions after scanning a statement', async () => {
+    mockedScanStatement.mockResolvedValue({
+      extracted: [
+        {
+          date: '2026-05-01',
+          description: 'Coffee',
+          amount: 12,
+          type: 'expense',
+        },
+      ],
+      matched: [
+        {
+          extracted: {
+            date: '2026-05-01',
+            description: 'Coffee',
+            amount: 12,
+            type: 'expense',
+          },
+          existingId: 'txn-1',
+          existingDescription: 'Coffee',
+        },
+      ],
+      missing: [
+        {
+          date: '2026-05-02',
+          description: 'Lunch',
+          amount: 42,
+          type: 'expense',
+        },
+      ],
+      discrepancies: [],
+    });
+    mockedApplyStatementImport.mockResolvedValue({ imported: 1 });
+    const onImported = jest.fn();
+
+    render(<StatementReconciler onImported={onImported} />);
+
+    const file = new File(['statement'], 'statement.pdf', {
+      type: 'application/pdf',
+    });
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toBeInTheDocument();
+
+    fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+
+    await screen.findByText('1 matched');
+    await screen.findByText('1 missing');
+    await screen.findByRole('button', { name: 'Import 1 transaction' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import 1 transaction' }));
+
+    await waitFor(() => {
+      expect(mockedApplyStatementImport).toHaveBeenCalledWith([
+        {
+          date: '2026-05-02',
+          description: 'Lunch',
+          amount: 42,
+          type: 'expense',
+        },
+      ]);
+    });
+    expect(onImported).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
Applies bounty PR #308 test improvements against current main. The CI coverage gate change (80→85%) was already done; this PR delivers the test additions and fixes.

**New test files:**
- `NlpInput.success.test.tsx` — Enter key triggers parse, clears input on success
- `RecurringPage.test.tsx` — add form opens, submits via addItem hook
- `StatementReconciler.test.tsx` — scan + import missing transactions flow

**Fixed existing tests:**
- `MainLayout.test.tsx` — 3 assertions updated from "Add transaction" → "Record Transaction" (modal title changed in a previous PR)
- `EmptyState.test.tsx` — same modal title fix
- `SummaryCards.test.tsx` — remove dayjs import, use native Date for today's date
- `ExpenseListMobile.test.tsx` — replace dayjs day-offset with native Date.now() - 86400000

## Why
Bounty PR #308 was CONFLICTING. The ci.yml change (80→85% gate) was superseded but the test additions are still valuable.

Closes #308 (bounty)
Part of #343

## Acceptance Criteria
- [x] 3 new test files added and passing
- [x] Stale "Add transaction" assertions updated to "Record Transaction"
- [x] dayjs removed from SummaryCards test
- [x] dayjs day-offset replaced with native Date arithmetic in ExpenseListMobile
- [x] All 88 affected tests pass (0 regressions)
- [x] `npx tsc --noEmit` passes
- [x] `yarn build` passes

## Test Plan
Run `npx jest --watchAll=false` and verify all suites pass.