### PR TITLE
fix: skip 401 redirect when already on login page (#341)

### DIFF
--- a/src/axiosInstance.ts
+++ b/src/axiosInstance.ts
@@ -22,7 +22,7 @@ axiosInstance.interceptors.request.use((config) => {
 axiosInstance.interceptors.response.use(
   (res) => res,
   (err) => {
-    if (err.response?.status === 401) {
+    if (err.response?.status === 401 && window.location.pathname !== '/login') {
       clearToken();
       window.location.href = '/login';
     }


### PR DESCRIPTION
## What
Changed the 401 response interceptor in `src/axiosInstance.ts` to skip the redirect-to-login when the user is already on `/login`. Previously, a failed login attempt (wrong credentials → 401) would trigger `clearToken()` + `window.location.href = '/login'`, which wiped any in-flight error state and prevented the LoginPage from showing its error alert.

## Why
Closes #341

## Acceptance Criteria
- [x] Entering wrong credentials on `/login` shows the error alert instead of silently redirecting
- [x] Expired session tokens on protected routes still redirect to `/login` as before
- [x] `tsc --noEmit` passes with zero errors
- [x] `VITE_API_URL=https://money-flow-backend.fly.dev yarn build` passes

## Test Plan
1. Navigate to `/login`
2. Enter an incorrect email/password combination
3. Confirm the red error alert appears ("Invalid credentials" or equivalent) — no redirect loop
4. Log in with valid credentials, let the session token expire, then navigate to a protected route — confirm redirect to `/login` still works