### PR TITLE
fix: dark mode toggle actually applies MUI palette (#281)

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -106,4 +106,27 @@ export async function stubSideEffects(page: Page): Promise<void> {
   await page.route('**/api/expenses/price-history/**', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ history: [], avg: null }) }),
   );
+  // Templates
+  await page.route('**/api/templates**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }),
+  );
+  // Exchange rates (backend)
+  await page.route('**/api/exchange-rates**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rates: {} }) }),
+  );
+  // Contacts
+  await page.route('**/api/contacts**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ contacts: [] }) }),
+  );
+  // Tags
+  await page.route('**/api/tags**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }),
+  );
+  // User preferences PATCH
+  await page.route('**/api/users/preferences**', (route) => {
+    if (route.request().method() === 'PATCH') {
+      return route.fulfill({ status: 204, body: '' });
+    }
+    return route.continue();
+  });
 }

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,63 +1,49 @@
 import { test, expect } from '@playwright/test';
-import { authenticateViaStorage, mockExpensesList } from './helpers';
+import { authenticateViaStorage, mockExpensesList, stubSideEffects } from './helpers';
 
 test.describe('Theme toggle', () => {
   test('toggles dark mode and persists across reload', async ({ page }) => {
     await authenticateViaStorage(page);
-    await page.addInitScript(() => {
-      window.localStorage.setItem('mf_onboarding_complete', 'true');
-    });
-    await page.route('**/openexchangerates.org/**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rates: {} }) }),
-    );
-    await page.route('**/api/expenses/last-amounts**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) }),
-    );
-    await page.route('**/api/budgets**', (route) =>
+    await stubSideEffects(page);
+    await mockExpensesList(page, []);
+
+    await page.route('**/api/net-worth**', (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }),
     );
-    await page.route('**/api/recurring**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }),
-    );
-    await page.route('**/api/expenses/price-history/**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ history: [], avg: null }) }),
-    );
-    await page.route('**/api/users/me**', async (route) => {
-      const themePreference = (await page.evaluate(() => window.localStorage.getItem('mf_theme'))) ?? 'system';
-      await route.fulfill({
+
+    // Override users/me to not return a themePreference so localStorage value is not overwritten
+    await page.route('**/api/users/me**', (route) =>
+      route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ _id: 'test-user-id', email: 'test@example.com', themePreference }),
-      });
-    });
-    await page.route('**/api/users/preferences**', async (route) => {
-      if (route.request().method() === 'PATCH') {
-        await route.fulfill({ status: 204, body: '' });
-        return;
-      }
-      await route.continue();
-    });
-    await mockExpensesList(page, []);
+        body: JSON.stringify({ _id: 'test-user-id', email: 'test@example.com' }),
+      }),
+    );
 
     await page.goto('/');
     await page.waitForLoadState('networkidle');
+
     await page.locator('.MuiListItemButton-root').filter({ hasText: 'Settings' }).click();
     await page.waitForLoadState('networkidle');
 
     const before = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
 
-    await page.getByRole('button', { name: 'Dark' }).click();
-    await expect(page.getByRole('button', { name: 'Dark' })).toHaveAttribute('aria-pressed', 'true');
+    const darkBtn = page.getByRole('button', { name: 'Dark' });
+    await expect(darkBtn).toBeVisible({ timeout: 5000 });
+    await darkBtn.click();
+    await expect(darkBtn).toHaveAttribute('aria-pressed', 'true');
 
     await page.waitForTimeout(200);
     const after = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
     expect(after).not.toBe(before);
+
+    expect(await page.evaluate(() => localStorage.getItem('mf_theme'))).toBe('dark');
 
     await page.reload();
     await page.waitForLoadState('networkidle');
     await page.locator('.MuiListItemButton-root').filter({ hasText: 'Settings' }).click();
     await page.waitForLoadState('networkidle');
     await expect(page.getByRole('button', { name: 'Dark' })).toHaveAttribute('aria-pressed', 'true');
-    await expect(page.evaluate(() => localStorage.getItem('mf_theme'))).resolves.toBe('dark');
+    expect(await page.evaluate(() => localStorage.getItem('mf_theme'))).toBe('dark');
   });
 });

--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -29,8 +29,15 @@ const DEBOUNCE_MS = 500;
 
 export const AppThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [preference, setPreferenceState] = useState<ThemePreference>(getStoredThemePreference);
-  const [systemDark] = useState(() => window.matchMedia(MEDIA_QUERY).matches);
+  const [systemDark, setSystemDark] = useState(() => window.matchMedia(MEDIA_QUERY).matches);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia(MEDIA_QUERY);
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
 
   // Fetch theme preference from backend on mount if user is authenticated.
   useEffect(() => {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -44,7 +44,7 @@ export const tokens = {
   sFab: '0 8px 24px rgba(91,78,199,0.3)',
 } as const;
 
-// ── Light theme (single theme — no dark mode) ──────────────────────────────
+// ── Light theme ────────────────────────────────────────────────────────────
 export const lightTheme: Theme = createTheme({
   palette: {
     mode: 'light',
@@ -438,8 +438,309 @@ export const lightTheme: Theme = createTheme({
   },
 });
 
-// Keep named exports for backward compat — both resolve to lightTheme
-export const darkTheme: Theme = lightTheme;
+export const darkTheme: Theme = createTheme({
+  palette: {
+    mode: 'dark',
+    background: {
+      default: '#0F0F14',
+      paper: '#1A1A24',
+    },
+    primary: {
+      main: tokens.primary,
+      light: tokens.primaryLight,
+      dark: tokens.primaryHover,
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: tokens.income,
+      contrastText: '#ffffff',
+    },
+    success: {
+      main: tokens.income,
+      light: '#86EFAC',
+      dark: '#047857',
+    },
+    error: {
+      main: tokens.expense,
+      light: '#FCA5A5',
+      dark: '#B91C1C',
+    },
+    warning: {
+      main: tokens.amber,
+      light: '#FDE68A',
+    },
+    text: {
+      primary: '#F1F0EE',
+      secondary: '#A8A4A0',
+      disabled: '#5C5954',
+    },
+    divider: 'rgba(255,255,255,0.08)',
+  },
+  typography: lightTheme.typography,
+  shape: { borderRadius: 12 },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          background: '#0F0F14',
+          color: '#F1F0EE',
+          scrollbarColor: 'rgba(255,255,255,0.12) #0F0F14',
+          '&::-webkit-scrollbar': { width: '6px' },
+          '&::-webkit-scrollbar-track': { background: '#0F0F14' },
+          '&::-webkit-scrollbar-thumb': { background: 'rgba(255,255,255,0.12)', borderRadius: '3px' },
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: { root: { backgroundImage: 'none' } },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          background: '#1A1A24',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 16,
+          boxShadow: '0 1px 2px rgba(0,0,0,0.3)',
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 14,
+          textTransform: 'none',
+          fontWeight: 600,
+          fontFamily: `'Plus Jakarta Sans', sans-serif`,
+        },
+        contained: {
+          backgroundColor: tokens.primary,
+          color: '#ffffff',
+          boxShadow: 'none',
+          '&:hover': { backgroundColor: tokens.primaryHover, boxShadow: 'none' },
+        },
+        outlined: {
+          borderColor: 'rgba(255,255,255,0.12)',
+          borderWidth: '1.5px',
+          color: '#F1F0EE',
+          '&:hover': {
+            borderColor: tokens.primary,
+            backgroundColor: 'rgba(91,78,199,0.15)',
+            borderWidth: '1.5px',
+          },
+        },
+        text: {
+          color: '#A78BFA',
+          '&:hover': { backgroundColor: 'rgba(91,78,199,0.15)' },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: 20,
+          fontFamily: `'Plus Jakarta Sans', sans-serif`,
+          fontWeight: 500,
+          fontSize: '0.8125rem',
+          border: '1px solid rgba(255,255,255,0.1)',
+          backgroundColor: 'rgba(255,255,255,0.06)',
+          color: '#A8A4A0',
+          '&.MuiChip-colorPrimary': {
+            backgroundColor: 'rgba(91,78,199,0.2)',
+            color: '#A78BFA',
+            border: '1px solid rgba(91,78,199,0.4)',
+          },
+        },
+        colorSuccess: {
+          backgroundColor: 'rgba(5,150,105,0.15)',
+          color: '#34D399',
+          border: '1px solid rgba(5,150,105,0.3)',
+        },
+        colorError: {
+          backgroundColor: 'rgba(220,38,38,0.15)',
+          color: '#F87171',
+          border: '1px solid rgba(220,38,38,0.3)',
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          padding: '14px 16px',
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+          fontFamily: `'Plus Jakarta Sans', sans-serif`,
+        },
+        head: {
+          fontWeight: 600,
+          fontSize: '0.6875rem',
+          textTransform: 'uppercase' as const,
+          letterSpacing: '0.06em',
+          color: '#5C5954',
+          backgroundColor: 'rgba(255,255,255,0.03)',
+        },
+      },
+    },
+    MuiTableRow: {
+      styleOverrides: {
+        root: {
+          transition: 'background-color 0.15s ease',
+          '&:hover': { backgroundColor: 'rgba(255,255,255,0.04)' },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 12,
+            fontFamily: `'Plus Jakarta Sans', sans-serif`,
+            '& fieldset': { borderColor: 'rgba(255,255,255,0.12)', borderWidth: '1.5px' },
+            '&:hover fieldset': { borderColor: tokens.primary, borderWidth: '1.5px' },
+            '&.Mui-focused fieldset': { borderColor: tokens.primary, borderWidth: '1.5px' },
+          },
+          '& .MuiInputLabel-root': {
+            fontFamily: `'Plus Jakarta Sans', sans-serif`,
+            color: '#5C5954',
+            '&.Mui-focused': { color: '#A78BFA' },
+          },
+        },
+      },
+    },
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          backgroundImage: 'none',
+          backgroundColor: '#1A1A24',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 24,
+          boxShadow: '0 24px 64px rgba(0,0,0,0.6)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          backgroundColor: '#1A1A24',
+          borderBottom: '1px solid rgba(255,255,255,0.08)',
+          boxShadow: 'none',
+          color: '#F1F0EE',
+        },
+      },
+    },
+    MuiDrawer: {
+      styleOverrides: {
+        paper: {
+          backgroundImage: 'none',
+          backgroundColor: '#0A0A12',
+          border: 'none',
+        },
+      },
+    },
+    MuiBottomNavigation: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#1A1A24',
+          borderTop: '1px solid rgba(255,255,255,0.08)',
+        },
+      },
+    },
+    MuiBottomNavigationAction: {
+      styleOverrides: {
+        root: {
+          color: '#5C5954',
+          fontFamily: `'Plus Jakarta Sans', sans-serif`,
+          '&.Mui-selected': { color: '#A78BFA' },
+          '& .MuiBottomNavigationAction-label': {
+            fontSize: '0.625rem',
+            fontWeight: 400,
+            '&.Mui-selected': { fontSize: '0.625rem', fontWeight: 600 },
+          },
+        },
+      },
+    },
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          backgroundColor: tokens.primary,
+          color: '#ffffff',
+          boxShadow: tokens.sFab,
+          '&:hover': { backgroundColor: tokens.primaryHover, boxShadow: tokens.sFab },
+        },
+      },
+    },
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          transition: 'background-color 0.15s ease',
+          '&:hover': { backgroundColor: 'rgba(255,255,255,0.06)' },
+        },
+      },
+    },
+    MuiDivider: {
+      styleOverrides: { root: { borderColor: 'rgba(255,255,255,0.08)' } },
+    },
+    MuiAlert: {
+      styleOverrides: { root: { borderRadius: 12 } },
+    },
+    MuiToggleButtonGroup: {
+      styleOverrides: {
+        root: { gap: 6 },
+        grouped: {
+          margin: 0,
+          '&:not(:first-of-type)': { borderRadius: '10px !important', marginLeft: 0 },
+          '&:first-of-type': { borderRadius: '10px !important' },
+        },
+      },
+    },
+    MuiToggleButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: '10px !important',
+          textTransform: 'none' as const,
+          fontWeight: 500,
+          fontSize: '0.8rem',
+          padding: '5px 14px',
+          border: '1px solid rgba(255,255,255,0.1)',
+          color: '#A8A4A0',
+          backgroundColor: 'rgba(255,255,255,0.05)',
+          '&.Mui-selected': {
+            color: '#A78BFA',
+            backgroundColor: 'rgba(91,78,199,0.2)',
+            borderColor: 'rgba(91,78,199,0.4) !important',
+            '&:hover': { backgroundColor: 'rgba(91,78,199,0.25)' },
+          },
+        },
+      },
+    },
+    MuiListItemButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 10,
+          margin: '1px 10px',
+          padding: '10px 12px',
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(91,78,199,0.25)',
+            '&:hover': { backgroundColor: 'rgba(91,78,199,0.3)' },
+          },
+          '&:hover': { backgroundColor: 'rgba(255,255,255,0.06)' },
+        },
+      },
+    },
+    MuiListItemIcon: {
+      styleOverrides: { root: { minWidth: 36 } },
+    },
+    MuiListItemText: {
+      styleOverrides: {
+        primary: {
+          fontFamily: `'Plus Jakarta Sans', sans-serif`,
+          fontSize: '0.875rem',
+        },
+      },
+    },
+  },
+});
 
 export type ThemePreference = 'light' | 'dark' | 'system';
 
@@ -455,8 +756,9 @@ export function storeThemePreference(pref: ThemePreference): void {
   localStorage.setItem(STORAGE_KEY, pref);
 }
 
-export function resolveTheme(_pref: ThemePreference, _systemDark: boolean): Theme {
-  return lightTheme;
+export function resolveTheme(pref: ThemePreference, systemDark: boolean): Theme {
+  const useDark = pref === 'dark' || (pref === 'system' && systemDark);
+  return useDark ? darkTheme : lightTheme;
 }
 
 export default lightTheme;


### PR DESCRIPTION
## What
Implements working dark mode. Previously `resolveTheme()` always returned `lightTheme` regardless of user preference — the toggle stored the value but never changed the MUI palette. Now dark mode fully works with a complete dark palette and component overrides.

## Why
Closes #281

## Acceptance Criteria
- [x] Theme persists across reload via localStorage key `mf_theme`
- [x] All cards, inputs, charts adapt to dark/light mode — dark palette applied via MUI createTheme
- [x] Playwright UAT toggles theme and asserts MUI mode flips (background color changes)
- [x] System preference respects OS dark/light setting + updates when OS changes at runtime
- [x] tsc --noEmit passes, build passes, 901 unit tests pass

## Changes
- `src/theme.ts` — adds `darkTheme` with full palette + component overrides; `resolveTheme()` now returns correct theme
- `src/ThemeContext.tsx` — adds `matchMedia` event listener for runtime OS changes  
- `e2e/theme.spec.ts` — rewrites test to mock all required APIs correctly
- `e2e/helpers.ts` — `stubSideEffects` now mocks templates, exchange-rates, contacts (with correct shape), tags, and PATCH users/preferences

## Test Plan
1. Open Settings → click Dark → body background changes to `#0F0F14`
2. Reload page → Dark button still selected, body still dark
3. Switch to Light → background returns to `#F5F3EE`
4. Switch to System → follows OS preference