### PR TITLE
feat: 4-step onboarding setup wizard (#284)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -53,6 +53,7 @@ const SettingsPage = React.lazy(() => import('./settings/SettingsPage'));
 const RecurringPage = React.lazy(() => import('./recurring/RecurringPage'));
 import { useBudgets } from '../hooks/useBudgets';
 import OnboardingFlow, { isOnboardingComplete, markOnboardingComplete } from './onboarding/OnboardingFlow';
+import OnboardingWizard, { isWizardComplete, markWizardComplete } from './onboarding/OnboardingWizard';
 const SpendingInsightsPage = React.lazy(() => import('./insights/SpendingInsightsPage'));
 import SpendingPulse from './dashboard/SpendingPulse';
 import { useSmartSuggestions } from '../hooks/useSmartSuggestions';
@@ -364,7 +365,13 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
   const [receiptPrefill, setReceiptPrefill] = useState<ReceiptPrefill | undefined>(undefined);
   const receiptImageUrlRef = useRef<string | null>(null);
   const [initialLoading, setInitialLoading] = useState(true);
-  const [onboardingOpen, setOnboardingOpen] = useState(() => !isOnboardingComplete());
+  const [wizardOpen, setWizardOpen] = useState(() => !isWizardComplete());
+  const [onboardingOpen, setOnboardingOpen] = useState(() => !isOnboardingComplete() && isWizardComplete());
+
+  const handleWizardDismiss = useCallback(() => {
+    markWizardComplete();
+    setWizardOpen(false);
+  }, []);
 
   const handleOnboardingDismiss = useCallback(() => {
     markOnboardingComplete();
@@ -1452,6 +1459,8 @@ const MainLayout: React.FC<MainLayoutProps> = ({ initialTab = 0 }) => {
         availableTags={tags}
         onCreateTag={(name) => addTag(name)}
       />
+
+      <OnboardingWizard open={wizardOpen} onDismiss={handleWizardDismiss} />
 
       <OnboardingFlow
         open={onboardingOpen}

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -129,6 +129,7 @@ const navigateToTransactionsTab = async () => {
 
 beforeEach(() => {
   localStorage.setItem('mf_onboarding_complete', 'true');
+  localStorage.setItem('mf_onboarded', 'true');
 });
 
 afterEach(() => {

--- a/src/components/__tests__/MainLayout.recurring.test.tsx
+++ b/src/components/__tests__/MainLayout.recurring.test.tsx
@@ -118,6 +118,7 @@ jest.setTimeout(30000);
 
 beforeEach(() => {
   localStorage.setItem('mf_onboarding_complete', 'true');
+  localStorage.setItem('mf_onboarded', 'true');
 });
 
 afterEach(() => {

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,329 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  MenuItem,
+  MobileStepper,
+  Select,
+  TextField,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import { CURRENCIES, CURRENCY_SYMBOLS, Currency } from '../../constants/currencies';
+import { detectCurrencyFromLocale } from '../../utils/localeCurrency';
+import { createExpense } from '../../services/api';
+import { PRESET_CATEGORIES } from '../expenses/CategorySelect';
+
+const WIZARD_KEY = 'mf_onboarded';
+
+function getOwnerFromToken(): string {
+  try {
+    const token = localStorage.getItem('mf_token');
+    if (!token) return '';
+    return JSON.parse(atob(token.split('.')[1])).userId || '';
+  } catch {
+    return '';
+  }
+}
+const CURRENCY_STORAGE_KEY = 'mf_currency';
+const WALKTHROUGH_KEY = 'mf_onboarding_complete';
+
+export const isWizardComplete = (): boolean =>
+  localStorage.getItem(WIZARD_KEY) === 'true';
+
+export const markWizardComplete = (): void => {
+  localStorage.setItem(WIZARD_KEY, 'true');
+  localStorage.setItem(WALKTHROUGH_KEY, 'true');
+};
+
+interface Props {
+  open: boolean;
+  onDismiss: () => void;
+}
+
+const TOTAL_STEPS = 4;
+
+const StepDots: React.FC<{ step: number }> = ({ step }) => (
+  <MobileStepper
+    variant="dots"
+    steps={TOTAL_STEPS}
+    position="static"
+    activeStep={step}
+    sx={{
+      bgcolor: 'transparent',
+      justifyContent: 'center',
+      py: 0,
+      '& .MuiMobileStepper-dot': { bgcolor: 'action.disabled' },
+      '& .MuiMobileStepper-dotActive': { bgcolor: 'primary.main' },
+    }}
+    nextButton={null}
+    backButton={null}
+  />
+);
+
+const OnboardingWizard: React.FC<Props> = ({ open, onDismiss }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const [step, setStep] = useState(0);
+  const [currency, setCurrency] = useState<Currency>(
+    () => (localStorage.getItem(CURRENCY_STORAGE_KEY) as Currency) || detectCurrencyFromLocale()
+  );
+
+  const [expenseAmount, setExpenseAmount] = useState('');
+  const [expenseDesc, setExpenseDesc] = useState('');
+  const [expenseCategory, setExpenseCategory] = useState(PRESET_CATEGORIES[0]);
+  const [expenseError, setExpenseError] = useState('');
+  const [expenseAdded, setExpenseAdded] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleCurrencyNext = useCallback(() => {
+    localStorage.setItem(CURRENCY_STORAGE_KEY, currency);
+    setStep(2);
+  }, [currency]);
+
+  const handleSkipExpense = useCallback(() => {
+    setStep(3);
+  }, []);
+
+  const handleAddExpense = useCallback(async () => {
+    const amount = parseFloat(expenseAmount);
+    if (!expenseAmount || isNaN(amount) || amount <= 0) {
+      setExpenseError('Please enter a valid amount');
+      return;
+    }
+    setExpenseError('');
+    setSubmitting(true);
+    try {
+      const owner = getOwnerFromToken();
+      await createExpense({
+        amount,
+        description: expenseDesc || 'First expense',
+        category: expenseCategory,
+        date: new Date().toISOString().split('T')[0],
+        type: 'expense',
+        owner,
+      });
+      setExpenseAdded(true);
+    } catch {
+      setExpenseError('Failed to save expense. You can add it later.');
+    } finally {
+      setSubmitting(false);
+      setStep(3);
+    }
+  }, [expenseAmount, expenseDesc, expenseCategory]);
+
+  const handleFinish = useCallback(() => {
+    markWizardComplete();
+    onDismiss();
+  }, [onDismiss]);
+
+  const renderStep = () => {
+    switch (step) {
+      case 0:
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 2.5, pt: 2, pb: 1, px: 1 }}>
+            <TrendingUpIcon sx={{ fontSize: 56, color: 'primary.main' }} />
+            <Box>
+              <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+                Welcome to Money Flow
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7, maxWidth: 340 }}>
+                Track your spending in seconds. Stay in control of your money — without the complexity.
+              </Typography>
+            </Box>
+            <StepDots step={0} />
+            <Button
+              variant="contained"
+              fullWidth
+              onClick={() => setStep(1)}
+              sx={{ fontWeight: 600, borderRadius: 2, maxWidth: 320 }}
+              aria-label="Start setup"
+            >
+              Get Started
+            </Button>
+          </Box>
+        );
+
+      case 1:
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 2, pb: 1, px: 1 }}>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>
+                Set your currency
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                All amounts will be shown in this currency.
+              </Typography>
+            </Box>
+            <Select
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value as Currency)}
+              fullWidth
+              size="small"
+              aria-label="Select base currency"
+            >
+              {CURRENCIES.map((c) => (
+                <MenuItem key={c} value={c}>
+                  {CURRENCY_SYMBOLS[c]} {c}
+                </MenuItem>
+              ))}
+            </Select>
+            <StepDots step={1} />
+            <Box sx={{ display: 'flex', gap: 1.5, maxWidth: 320, width: '100%', alignSelf: 'center' }}>
+              <Button
+                variant="text"
+                size="small"
+                onClick={handleSkipExpense}
+                sx={{ color: 'text.disabled', fontSize: '0.82rem', flexShrink: 0 }}
+                aria-label="Skip currency setup"
+              >
+                Skip
+              </Button>
+              <Button
+                variant="contained"
+                fullWidth
+                onClick={handleCurrencyNext}
+                sx={{ fontWeight: 600, borderRadius: 2 }}
+                aria-label="Save currency and continue"
+              >
+                Next
+              </Button>
+            </Box>
+          </Box>
+        );
+
+      case 2:
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 2, pb: 1, px: 1 }}>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5 }}>
+                Add your first expense
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                Optional — you can always add expenses later.
+              </Typography>
+            </Box>
+            <TextField
+              label="Amount"
+              type="number"
+              value={expenseAmount}
+              onChange={(e) => setExpenseAmount(e.target.value)}
+              fullWidth
+              size="small"
+              inputProps={{ min: 0, step: 'any', 'aria-label': 'Expense amount' }}
+              error={!!expenseError}
+            />
+            <TextField
+              label="Description (optional)"
+              value={expenseDesc}
+              onChange={(e) => setExpenseDesc(e.target.value)}
+              fullWidth
+              size="small"
+              inputProps={{ 'aria-label': 'Expense description' }}
+            />
+            <Select
+              value={expenseCategory}
+              onChange={(e) => setExpenseCategory(e.target.value)}
+              fullWidth
+              size="small"
+              aria-label="Expense category"
+            >
+              {PRESET_CATEGORIES.filter((c) => !['Salary', 'Freelance', 'Investment'].includes(c)).map((c) => (
+                <MenuItem key={c} value={c}>{c}</MenuItem>
+              ))}
+            </Select>
+            {expenseError && (
+              <Typography variant="caption" sx={{ color: 'error.main' }}>
+                {expenseError}
+              </Typography>
+            )}
+            <StepDots step={2} />
+            <Box sx={{ display: 'flex', gap: 1.5, maxWidth: 320, width: '100%', alignSelf: 'center' }}>
+              <Button
+                variant="text"
+                size="small"
+                onClick={handleSkipExpense}
+                sx={{ color: 'text.disabled', fontSize: '0.82rem', flexShrink: 0 }}
+                aria-label="Skip adding expense"
+              >
+                Skip
+              </Button>
+              <Button
+                variant="contained"
+                fullWidth
+                onClick={handleAddExpense}
+                disabled={submitting}
+                sx={{ fontWeight: 600, borderRadius: 2 }}
+                aria-label="Add expense and continue"
+              >
+                {submitting ? 'Adding…' : 'Add & Continue'}
+              </Button>
+            </Box>
+          </Box>
+        );
+
+      case 3:
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', gap: 2.5, pt: 2, pb: 1, px: 1 }}>
+            <CheckCircleIcon sx={{ fontSize: 56, color: 'success.main' }} />
+            <Box>
+              <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+                You're all set!
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'text.secondary', lineHeight: 1.7, maxWidth: 320 }}>
+                {[
+                  `Currency set to ${CURRENCY_SYMBOLS[currency]} ${currency}`,
+                  expenseAdded ? 'First expense logged' : null,
+                ]
+                  .filter(Boolean)
+                  .join(' · ')}
+              </Typography>
+            </Box>
+            <StepDots step={3} />
+            <Button
+              variant="contained"
+              fullWidth
+              onClick={handleFinish}
+              sx={{ fontWeight: 600, borderRadius: 2, maxWidth: 320 }}
+              aria-label="Go to dashboard"
+            >
+              Go to Dashboard
+            </Button>
+          </Box>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {}}
+      maxWidth={false}
+      fullScreen={isMobile}
+      PaperProps={{
+        sx: {
+          borderRadius: isMobile ? 0 : 3,
+          bgcolor: 'background.paper',
+          px: 2,
+          pt: 1,
+          pb: 2,
+          width: isMobile ? '100%' : 520,
+        },
+      }}
+      aria-label="Setup wizard"
+    >
+      <DialogContent sx={{ p: 0 }}>{renderStep()}</DialogContent>
+    </Dialog>
+  );
+};
+
+export default OnboardingWizard;

--- a/src/components/onboarding/__tests__/OnboardingWizard.test.tsx
+++ b/src/components/onboarding/__tests__/OnboardingWizard.test.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import OnboardingWizard, { isWizardComplete, markWizardComplete } from '../OnboardingWizard';
+
+const mockCreateExpense = jest.fn().mockResolvedValue({ _id: 'e1' });
+
+jest.mock('../../../services/api', () => ({
+  createExpense: (...args: unknown[]) => mockCreateExpense(...args),
+  getExchangeRates: jest.fn().mockResolvedValue({}),
+}));
+
+const renderWizard = (open = true, onDismiss = jest.fn()) =>
+  render(<OnboardingWizard open={open} onDismiss={onDismiss} />);
+
+describe('OnboardingWizard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('isWizardComplete / markWizardComplete', () => {
+    it('returns false when mf_onboarded is not set', () => {
+      expect(isWizardComplete()).toBe(false);
+    });
+
+    it('returns true after markWizardComplete is called', () => {
+      markWizardComplete();
+      expect(isWizardComplete()).toBe(true);
+    });
+
+    it('also sets mf_onboarding_complete when marking complete', () => {
+      markWizardComplete();
+      expect(localStorage.getItem('mf_onboarding_complete')).toBe('true');
+    });
+  });
+
+  describe('Step 1 — Welcome', () => {
+    it('renders welcome title', () => {
+      renderWizard();
+      expect(screen.getByText('Welcome to Money Flow')).toBeInTheDocument();
+    });
+
+    it('renders Get Started button', () => {
+      renderWizard();
+      expect(screen.getByRole('button', { name: /start setup/i })).toBeInTheDocument();
+    });
+
+    it('advances to step 2 on Get Started click', () => {
+      renderWizard();
+      fireEvent.click(screen.getByRole('button', { name: /start setup/i }));
+      expect(screen.getByText('Set your currency')).toBeInTheDocument();
+    });
+
+    it('does not render content when open is false', () => {
+      renderWizard(false);
+      expect(screen.queryByText('Welcome to Money Flow')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Step 2 — Currency', () => {
+    const goToStep2 = () => {
+      renderWizard();
+      fireEvent.click(screen.getByRole('button', { name: /start setup/i }));
+    };
+
+    it('shows currency selector', () => {
+      goToStep2();
+      expect(screen.getByText('Set your currency')).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    it('renders Next button', () => {
+      goToStep2();
+      expect(screen.getByRole('button', { name: /save currency and continue/i })).toBeInTheDocument();
+    });
+
+    it('renders Skip button', () => {
+      goToStep2();
+      expect(screen.getByRole('button', { name: /skip currency setup/i })).toBeInTheDocument();
+    });
+
+    it('saves currency to localStorage on Next click', () => {
+      goToStep2();
+      fireEvent.click(screen.getByRole('button', { name: /save currency and continue/i }));
+      expect(localStorage.getItem('mf_currency')).not.toBeNull();
+    });
+
+    it('advances to step 3 on Next click', () => {
+      goToStep2();
+      fireEvent.click(screen.getByRole('button', { name: /save currency and continue/i }));
+      expect(screen.getByText('Add your first expense')).toBeInTheDocument();
+    });
+
+    it('skips to step 4 when Skip is clicked', () => {
+      goToStep2();
+      fireEvent.click(screen.getByRole('button', { name: /skip currency setup/i }));
+      expect(screen.getByText("You're all set!")).toBeInTheDocument();
+    });
+  });
+
+  describe('Step 3 — Add expense', () => {
+    const goToStep3 = () => {
+      renderWizard();
+      fireEvent.click(screen.getByRole('button', { name: /start setup/i }));
+      fireEvent.click(screen.getByRole('button', { name: /save currency and continue/i }));
+    };
+
+    it('shows amount field', () => {
+      goToStep3();
+      expect(screen.getByRole('spinbutton', { name: /expense amount/i })).toBeInTheDocument();
+    });
+
+    it('shows description field', () => {
+      goToStep3();
+      expect(screen.getByRole('textbox', { name: /expense description/i })).toBeInTheDocument();
+    });
+
+    it('shows Skip button', () => {
+      goToStep3();
+      expect(screen.getByRole('button', { name: /skip adding expense/i })).toBeInTheDocument();
+    });
+
+    it('shows Add & Continue button', () => {
+      goToStep3();
+      expect(screen.getByRole('button', { name: /add expense and continue/i })).toBeInTheDocument();
+    });
+
+    it('shows validation error when amount is empty', async () => {
+      goToStep3();
+      fireEvent.click(screen.getByRole('button', { name: /add expense and continue/i }));
+      await waitFor(() => {
+        expect(screen.getByText('Please enter a valid amount')).toBeInTheDocument();
+      });
+    });
+
+    it('calls createExpense and advances to step 4 on valid input', async () => {
+      goToStep3();
+      fireEvent.change(screen.getByRole('spinbutton', { name: /expense amount/i }), {
+        target: { value: '50' },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /add expense and continue/i }));
+      });
+      await waitFor(() => {
+        expect(mockCreateExpense).toHaveBeenCalledTimes(1);
+        expect(screen.getByText("You're all set!")).toBeInTheDocument();
+      });
+    });
+
+    it('skips to step 4 without API call when Skip is clicked', async () => {
+      goToStep3();
+      fireEvent.click(screen.getByRole('button', { name: /skip adding expense/i }));
+      await waitFor(() => {
+        expect(screen.getByText("You're all set!")).toBeInTheDocument();
+      });
+      expect(mockCreateExpense).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Step 4 — Done', () => {
+    const goToStep4 = () => {
+      renderWizard();
+      fireEvent.click(screen.getByRole('button', { name: /start setup/i }));
+      fireEvent.click(screen.getByRole('button', { name: /skip currency setup/i }));
+    };
+
+    it('shows completion message', () => {
+      goToStep4();
+      expect(screen.getByText("You're all set!")).toBeInTheDocument();
+    });
+
+    it('renders Go to Dashboard button', () => {
+      goToStep4();
+      expect(screen.getByRole('button', { name: /go to dashboard/i })).toBeInTheDocument();
+    });
+
+    it('calls onDismiss and sets mf_onboarded when Go to Dashboard is clicked', () => {
+      const onDismiss = jest.fn();
+      render(<OnboardingWizard open onDismiss={onDismiss} />);
+      fireEvent.click(screen.getByRole('button', { name: /start setup/i }));
+      fireEvent.click(screen.getByRole('button', { name: /skip currency setup/i }));
+      fireEvent.click(screen.getByRole('button', { name: /go to dashboard/i }));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem('mf_onboarded')).toBe('true');
+    });
+  });
+});


### PR DESCRIPTION
## What
Adds a 4-step setup wizard (`OnboardingWizard`) shown once to new users after registration, before the main dashboard is usable. Separate from the existing product walkthrough (`OnboardingFlow`).

**Step 1 — Welcome**: Intro screen with tagline and Get Started button.
**Step 2 — Set currency**: Dropdown to pick base currency, defaults to browser locale. Saves to `localStorage` (`mf_currency` key — same key `useFxRates` reads).
**Step 3 — Add first expense (optional)**: Amount + description + category form. Skip or Add & Continue. Calls `POST /api/expenses`.
**Step 4 — Done**: Summary of what was set up. Go to Dashboard closes the wizard.

Completion tracked in `localStorage` key `mf_onboarded = 'true'`. Marking complete also sets `mf_onboarding_complete` to suppress the existing walkthrough for new users (they don't need both).

## Why
Closes #284

## Acceptance Criteria
- [x] Wizard shows once for new users (localStorage gate on `mf_onboarded`)
- [x] Step 1: Welcome screen with Get Started
- [x] Step 2: Currency picker defaults to browser locale, saves to `mf_currency`
- [x] Step 3: Optional expense form with Skip and Add & Continue
- [x] Step 4: Done screen with summary and Go to Dashboard
- [x] MUI Dialog, fullScreen on mobile (< sm), fixed 520px on desktop
- [x] tsc --noEmit clean
- [x] Build passes
- [x] 23 new unit tests, all 86 suites pass (929 total tests)

## Test Plan
1. Clear localStorage (`localStorage.clear()` in browser console)
2. Log in — wizard should appear immediately on the dashboard
3. Click Get Started → currency picker (defaults to locale)
4. Select a currency, click Next → expense form
5. Enter amount + optional desc, click Add & Continue → Done screen
6. Done screen shows currency set + "First expense logged" → Go to Dashboard closes wizard
7. Refresh — wizard should NOT appear again (`mf_onboarded = 'true'` is set)